### PR TITLE
import OCC.Display from py3k fails ( relative import, missing apply function )

### DIFF
--- a/src/addons/Display/SimpleGui.py
+++ b/src/addons/Display/SimpleGui.py
@@ -109,14 +109,14 @@ def init_display(backend_str=None):
     elif USED_BACKEND in ['pyqt4', 'pyside']:
         if USED_BACKEND == 'pyqt4':
             from PyQt4 import QtCore, QtGui, QtOpenGL
-            from pyqt4Display import qtViewer3d
+            from OCC.Display.pyqt4Display import qtViewer3d
         elif USED_BACKEND == 'pyside':
             from PySide import QtCore, QtGui, QtOpenGL
-            from pysideDisplay import qtViewer3d
+            from OCC.Display.pysideDisplay import qtViewer3d
 
         class MainWindow(QtGui.QMainWindow):
             def __init__(self, *args):
-                apply(QtGui.QMainWindow.__init__, (self,)+args)
+                super(QtGui.QMainWindow, self).__init__(*args)
                 self.canva = qtViewer3d(self)
                 self.setWindowTitle("pythonOCC-%s 3d viewer ('%s' backend)" % (VERSION, USED_BACKEND))
                 self.resize(1024, 768)

--- a/src/addons/Display/pyqt4Display.py
+++ b/src/addons/Display/pyqt4Display.py
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 import sys
-import OCCViewer
+from OCC.Display import OCCViewer
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
 

--- a/src/addons/Display/traitDisplay.py
+++ b/src/addons/Display/traitDisplay.py
@@ -24,8 +24,8 @@
 from itertools import izip
 import os
 
-import OCCViewer
-from qtDisplay import qtViewer3d
+from OCC.Display import OCCViewer
+from OCC.Display.pyqt4Display import qtViewer3d
 
 try:
     if os.environ["ETS_TOOLKIT"] == "wx":

--- a/src/addons/Display/wxDisplay.py
+++ b/src/addons/Display/wxDisplay.py
@@ -23,7 +23,7 @@ try:
     import wx
 except ImportError:
     raise ImportError('Please install wxPython.')
-import OCCViewer
+from OCC.Display import OCCViewer
 
 
 class wxBaseViewer(wx.Panel):


### PR DESCRIPTION
fixes #25

importing a module ( file ) from the same directory is only possible with the relative import syntax
however, I prefer the more consistent "from OCC.Display import X" syntax

finally, `apply` is no longer a keyword in py3k, so that's updated to unpacking the arguments form a tuple
