### PR TITLE
fixes a number of issues with the Qt viewer

### DIFF
--- a/examples/core_visualization_overpaint_viewer.py
+++ b/examples/core_visualization_overpaint_viewer.py
@@ -1,0 +1,278 @@
+"""
+
+demonstrates overpainting of the OCC OpenGL viewer to share its OpenGL Context with Qt
+
+this allows for interesting interfaces, where elements are drawn as an overlay
+
+:ref:`Catia's structure browser` is a well known application of this idea
+
+the example is extends Qt's :ref:`OpenGL overpainting example`
+
+.. Catia's structure browser:: http://api.ning.com/files/baXVy107Waz1W6uzhBRSrhOaW6c2w8r-8560KbD2GBunh443xLrj2*jQWeecIWDpMtgaI2DeAVeJ2xKFYQyCH3DjdvxSfpWv/capture_061.jpg
+.. OpenGL overpainting example:: https://github.com/Werkov/PyQt4/blob/master/examples/opengl/overpainting.py
+
+
+"""
+
+
+
+import random
+import time
+import sys
+import traceback
+
+from OCC.Display.pyqt4Display import qtViewer3d
+from PyQt4 import QtCore, QtGui
+
+from OpenGL.GL import glViewport, glMatrixMode, glOrtho, glLoadIdentity, GL_PROJECTION, GL_MODELVIEW
+
+
+def log_uncaught_exceptions(ex_cls, ex, tb):
+    print "< start unhandeld exception >"
+    print ''.join(traceback.format_tb(tb))
+    print '{0}: {1}'.format(ex_cls, ex)
+    print "< end unhandeld exception >"
+    sys.__excepthook__(ex_cls, ex, tb)
+
+
+sys.excepthook = log_uncaught_exceptions
+
+
+class Bubble(object):
+    def __init__(self, position, radius, velocity):
+        self.position = position
+        self.vel = velocity
+        self.radius = radius
+
+        self.innerColor = self.randomColor()
+        self.outerColor = self.randomColor()
+        self.updateBrush()
+
+    def updateBrush(self):
+        gradient = QtGui.QRadialGradient(QtCore.QPointF(self.radius, self.radius),
+                                         self.radius, QtCore.QPointF(self.radius * 0.5, self.radius * 0.5))
+
+        gradient.setColorAt(0, QtGui.QColor(255, 255, 255, 0))
+        gradient.setColorAt(0.25, self.innerColor)
+        gradient.setColorAt(1, self.outerColor)
+        self.brush = QtGui.QBrush(gradient)
+
+    def drawBubble(self, painter):
+        painter.save()
+        painter.translate(self.position.x() - self.radius,
+                          self.position.y() - self.radius)
+        painter.setBrush(self.brush)
+        painter.drawEllipse(0, 0, int(2 * self.radius), int(2 * self.radius))
+        painter.restore()
+
+    def randomColor(self):
+        red = random.randrange(205, 256)
+        green = random.randrange(205, 256)
+        blue = random.randrange(205, 256)
+        alpha = random.randrange(91, 192)
+
+        return QtGui.QColor(red, green, blue, alpha)
+
+    def move(self, bbox):
+        self.position += self.vel
+        leftOverflow = self.position.x() - self.radius - bbox.left()
+        rightOverflow = self.position.x() + self.radius - bbox.right()
+        topOverflow = self.position.y() - self.radius - bbox.top()
+        bottomOverflow = self.position.y() + self.radius - bbox.bottom()
+
+        if leftOverflow < 0.0:
+            self.position.setX(self.position.x() - 2 * leftOverflow)
+            self.vel.setX(-self.vel.x())
+        elif rightOverflow > 0.0:
+            self.position.setX(self.position.x() - 2 * rightOverflow)
+            self.vel.setX(-self.vel.x())
+
+        if topOverflow < 0.0:
+            self.position.setY(self.position.y() - 2 * topOverflow)
+            self.vel.setY(-self.vel.y())
+        elif bottomOverflow > 0.0:
+            self.position.setY(self.position.y() - 2 * bottomOverflow)
+            self.vel.setY(-self.vel.y())
+
+    def rect(self):
+        return QtCore.QRectF(self.position.x() - self.radius,
+                             self.position.y() - self.radius, 2 * self.radius,
+                             2 * self.radius)
+
+
+class GLWidget(qtViewer3d):
+    def __init__(self, parent=None):
+        super(GLWidget, self).__init__(parent)
+
+        self._initialized = False
+
+        midnight = QtCore.QTime(0, 0, 0)
+        random.seed(midnight.secsTo(QtCore.QTime.currentTime()))
+
+        self.object = 0
+        self.xRot = 0
+        self.yRot = 0
+        self.zRot = 0
+        self.image = QtGui.QImage()
+        self.bubbles = []
+        self.lastPos = QtCore.QPoint()
+
+        self.trolltechGreen = QtGui.QColor.fromCmykF(0.40, 0.0, 1.0, 0.0)
+        self.trolltechPurple = QtGui.QColor.fromCmykF(0.39, 0.39, 0.0, 0.0)
+
+        self.animationTimer = QtCore.QTimer()
+        self.animationTimer.setSingleShot(False)
+        self.animationTimer.timeout.connect(self.animate)
+        self.animationTimer.start(25)
+
+        self.setAutoFillBackground(False)
+
+        self.setMinimumSize(200, 200)
+        self.setWindowTitle("Overpainting a Scene")
+
+        #/ Do some window stuff
+        #Avoid Qt background clears to improve resizing speed,
+        # along with a couple of other attributes
+        self.setAttribute(QtCore.Qt.WA_NoSystemBackground, 0)
+
+        # Clear buffer before start painting?:
+        self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
+
+    def setXRotation(self, angle):
+        if angle != self.xRot:
+            self.xRot = angle
+
+    def setYRotation(self, angle):
+        if angle != self.yRot:
+            self.yRot = angle
+
+    def setZRotation(self, angle):
+        if angle != self.zRot:
+            self.zRot = angle
+
+    def mousePressEvent(self, event):
+        self.lastPos = event.pos()
+        super(GLWidget, self).mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        dx = event.x() - self.lastPos.x()
+        dy = event.y() - self.lastPos.y()
+
+        if event.buttons() & QtCore.Qt.LeftButton:
+            self.setXRotation(self.xRot + 8 * dy)
+            self.setYRotation(self.yRot + 8 * dx)
+        elif event.buttons() & QtCore.Qt.RightButton:
+            self.setXRotation(self.xRot + 8 * dy)
+            self.setZRotation(self.zRot + 8 * dx)
+
+        self.lastPos = event.pos()
+        super(GLWidget, self).mouseMoveEvent(event)
+
+    def paintGL(self):
+        if self._inited:
+            self._display.Context.UpdateCurrentViewer()
+
+    def paintEvent(self, event):
+        print "paintEvent"
+
+        if self._inited:
+
+            self._display.Context.UpdateCurrentViewer()
+            self.makeCurrent()
+            painter = QtGui.QPainter(self)
+            painter.setRenderHint(QtGui.QPainter.Antialiasing)
+
+            if self.context().isValid():
+                self.swapBuffers()
+
+                if self._drawbox:
+                    painter.setPen(QtGui.QPen(QtGui.QColor(0, 0, 0), 1))
+                    rect = QtCore.QRect(*self._drawbox)
+                    painter.drawRect(rect)
+
+                for bubble in self.bubbles:
+                    if bubble.rect().intersects(QtCore.QRectF(event.rect())):
+                        bubble.drawBubble(painter)
+
+                self.drawInstructions(painter)
+                painter.end()
+                self.doneCurrent()
+                # nothing is dorawn if not disabled
+                # self._display.Context.UpdateCurrentViewer()
+            else:
+                print 'invalid context'
+
+    def showEvent(self, event):
+        self.createBubbles(20 - len(self.bubbles))
+
+    def sizeHint(self):
+        return QtCore.QSize(400, 400)
+
+    def createBubbles(self, number):
+        for i in range(number):
+            position = QtCore.QPointF(self.width() * (0.1 + 0.8 * random.random()),
+                                      self.height() * (0.1 + 0.8 * random.random()))
+            radius = min(self.width(), self.height()) * (0.0125 + 0.0875 * random.random())
+            velocity = QtCore.QPointF(self.width() * 0.0125 * (-0.5 + random.random()),
+                                      self.height() * 0.0125 * (-0.5 + random.random()))
+
+            self.bubbles.append(Bubble(position, radius, velocity))
+
+
+    def animate(self):
+        for bubble in self.bubbles:
+            bubble.move(self.rect())
+        self.update()
+        # self.updateOverlayGL()
+
+    def setupViewport(self, width, height):
+        side = min(width, height)
+        glViewport((width - side) // 2, (height - side) // 2, side, side)
+
+        glMatrixMode(GL_PROJECTION)
+        glLoadIdentity()
+        glOrtho(-0.5, +0.5, +0.5, -0.5, 4.0, 15.0)
+        glMatrixMode(GL_MODELVIEW)
+
+    def drawInstructions(self, painter):
+        text = "Click and drag with the left mouse button to rotate the Qt " \
+               "logo."
+        metrics = QtGui.QFontMetrics(self.font())
+        border = max(4, metrics.leading())
+
+        rect = metrics.boundingRect(0, 0, self.width() - 2 * border,
+                                    int(self.height() * 0.125),
+                                    QtCore.Qt.AlignCenter | QtCore.Qt.TextWordWrap, text)
+        painter.setRenderHint(QtGui.QPainter.TextAntialiasing)
+        painter.fillRect(QtCore.QRect(0, 0, self.width(), rect.height() + 2 * border), QtGui.QColor(0, 0, 0, 127))
+        painter.setPen(QtCore.Qt.white)
+        painter.fillRect(QtCore.QRect(0, 0, self.width(), rect.height() + 2 * border), QtGui.QColor(0, 0, 0, 127))
+        painter.drawText((self.width() - rect.width()) / 2, border, rect.width(),
+                         rect.height(), QtCore.Qt.AlignCenter | QtCore.Qt.TextWordWrap,
+                         text)
+
+
+if __name__ == '__main__':
+    def Test3d_bis():
+        class AppFrame(QtGui.QWidget):
+            def __init__(self, parent=None):
+                QtGui.QWidget.__init__(self, parent)
+                self.setWindowTitle(self.tr("qtDisplay3d sample"))
+                self.resize(640, 480)
+                self.canva = GLWidget(self)
+                mainLayout = QtGui.QHBoxLayout()
+                mainLayout.addWidget(self.canva)
+                mainLayout.setMargin(0)
+                self.setLayout(mainLayout)
+
+            def runTests(self):
+                self.canva._display.Test()
+
+        app = QtGui.QApplication(sys.argv)
+        frame = AppFrame()
+        frame.show()
+        frame.canva.InitDriver()
+        frame.runTests()
+        app.exec_()
+
+    Test3d_bis()

--- a/src/addons/Display/pyqt4Display.py
+++ b/src/addons/Display/pyqt4Display.py
@@ -165,6 +165,8 @@ class qtViewer3d(qtBaseViewer):
 
     def mouseReleaseEvent(self, event):
         pt = point(event.pos())
+        modifiers = event.modifiers()
+
         if event.button() == QtCore.Qt.LeftButton:
             pt = point(event.pos())
             if self._select_area:
@@ -173,7 +175,7 @@ class qtViewer3d(qtBaseViewer):
                 self._select_area = False
             else:
                 # multiple select if shift is pressed
-                if QtCore.Qt.ShiftModifier:
+                if modifiers == QtCore.Qt.ShiftModifier:
                     self._display.ShiftSelect(pt.x,pt.y)
                 else:
                 # single select otherwise

--- a/src/addons/Display/pyqt4Display.py
+++ b/src/addons/Display/pyqt4Display.py
@@ -23,7 +23,7 @@ import sys
 from OCC.Display import OCCViewer
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
-
+from OpenGL.GL import glEnable, GL_MULTISAMPLE
 
 class point(object):
     def __init__(self, obj=None):
@@ -44,12 +44,20 @@ class qtBaseViewer(QtOpenGL.QGLWidget):
         QtOpenGL.QGLWidget.__init__(self, parent)
         self._display = None
         self._inited = False
-        self.setMouseTracking(True)  # enable Mouse Tracking
-        self.setFocusPolicy(QtCore.Qt.WheelFocus)  # Strong focus
+        # enable Mouse Tracking
+        self.setMouseTracking(True)
+        # Strong focus
+        self.setFocusPolicy(QtCore.Qt.WheelFocus)
         # On X11, setting this attribute will disable all double buffering
         self.setAttribute(QtCore.Qt.WA_PaintOnScreen)
         # setting this flag implicitly disables double buffering for the widget
         self.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        # nessecary for correct handling of obtaining the OpenGL context
+        # for overdrawing, like drawing the rectangles for selection / zooming
+        self.setAutoFillBackground(False)
+
+    def initializeGL(self):
+        glEnable(GL_MULTISAMPLE)
 
     def GetHandle(self):
         return int(self.winId())
@@ -57,9 +65,6 @@ class qtBaseViewer(QtOpenGL.QGLWidget):
     def resizeEvent(self, event):
         if self._inited:
             self._display.OnResize()
-
-    def paintEngine(self):
-        return None
 
 
 class qtViewer3d(qtBaseViewer):
@@ -123,13 +128,21 @@ class qtViewer3d(qtBaseViewer):
 
     def paintEvent(self, event):
         if self._inited:
-            self._display.Repaint()
+            self._display.Context.UpdateCurrentViewer()
+            # important to allow overpainting of the OCC OpenGL context in Qt
+            self.swapBuffers()
+
         if self._drawbox:
+            self.makeCurrent()
             painter = QtGui.QPainter(self)
-            painter.setPen(QtGui.QPen(QtGui.QColor(0, 0, 0), 1))
+            painter.setPen(QtGui.QPen(QtGui.QColor(0,0,0), 1))
             rect = QtCore.QRect(*self._drawbox)
             painter.drawRect(rect)
             painter.end()
+            self.doneCurrent()
+
+    def resizeGL(self, width, height):
+        self.setupViewport(width, height)
 
     def ZoomAll(self, evt):
         self._display.Zoom_FitAll()
@@ -156,10 +169,15 @@ class qtViewer3d(qtBaseViewer):
             pt = point(event.pos())
             if self._select_area:
                 [Xmin, Ymin, dx, dy] = self._drawbox
-                selected_shapes = self._display.SelectArea(Xmin, Ymin, Xmin+dx, Ymin+dy)
+                selected_shapes = self._display.SelectArea(Xmin,Ymin,Xmin+dx,Ymin+dy)
                 self._select_area = False
             else:
-                self._display.Select(pt.x, pt.y)
+                # multiple select if shift is pressed
+                if QtCore.Qt.ShiftModifier:
+                    self._display.ShiftSelect(pt.x,pt.y)
+                else:
+                # single select otherwise
+                    self._display.Select(pt.x, pt.y)
         elif event.button() == QtCore.Qt.RightButton:
             if self._zoom_area:
                 [Xmin, Ymin, dx, dy] = self._drawbox
@@ -168,13 +186,13 @@ class qtViewer3d(qtBaseViewer):
 
     def DrawBox(self, event):
         tolerance = 2
-        pt = point(event.pos())
+        pt = point( event.pos() )
         dx = pt.x - self.dragStartPos.x
         dy = pt.y - self.dragStartPos.y
-        if abs(dx) <= tolerance and abs(dy) <= tolerance:
+        if abs( dx ) <= tolerance and abs( dy ) <= tolerance:
             return
-        self.repaint()
-        self._drawbox = [self.dragStartPos.x, self.dragStartPos.y, dx, dy]
+        self._drawbox = [self.dragStartPos.x, self.dragStartPos.y , dx, dy]
+        self.update()
 
     def mouseMoveEvent(self, evt):
         pt = point(evt.pos())


### PR DESCRIPTION
fixes a number of issues with the Qt viewer:

* when Shift-RMB dragging, no rectangle would be overpainted in the viewer. Shift-RMB dragging draws a frame that will be zoomed, so this is really important...
* Shift select was not implemented, which allows for multiple selection

These changes allow for overpainting of the OCC OpenGL viewer. This paves the way for really cool widget to be drawn on top of the OCC OpenGL viewer. OCC has a API for painting a layer on top of the viewer, but its horrible and does not allow for widgets / interactivity.

An example is contributed, "examples/core_visualization_overpaint_viewer.py"

This example is WIP -- when rotating the view, then there's an issue syncing the buffers.
Close to getting there though...

