### PR TITLE
Fix travis build

### DIFF
--- a/.travis.build-oce.sh
+++ b/.travis.build-oce.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+set -e
+
+
+#  Default values
+: ${OCE_USE_PCH=OFF}
+: ${OCE_COPY_HEADERS_BUILD=OFF}
+
+echo "Timestamp" && date
+cmake -DOCE_ENABLE_DEB_FLAG:BOOL=OFF \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DOCE_USE_TCL_TEST_FRAMEWORK:BOOL=ON \
+      -DOCE_TESTING:BOOL=ON \
+      -DOCE_DRAW:BOOL=ON \
+      -DOCE_VISUALISATION:BOOL=ON \
+      -DOCE_OCAF:BOOL=ON \
+      -DOCE_DATAEXCHANGE:BOOL=ON \
+      -DOCE_USE_PCH:BOOL=${OCE_USE_PCH} \
+      -DOCE_COPY_HEADERS_BUILD:BOOL=${OCE_COPY_HEADERS_BUILD} \
+      -DOCE_WITH_GL2PS:BOOL=ON \
+      -DOCE_WITH_FREEIMAGE:BOOL=ON \
+      -DOCE_MULTITHREAD_LIBRARY:STRING=NONE \
+      ..
+echo ""
+echo "Timestamp" && date
+make -j16 | grep Built
+
+echo "Timestamp" && date

--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 set -e
 
-ncpus=6
+ncpus=5
 
 #####################
 # build for python3 #
@@ -10,9 +10,7 @@ echo "Timestamp" && date
 echo "Configuring pythonocc for python3"
 mkdir cmake-build-py3
 cd cmake-build-py3
-cmake -DOCE_INCLUDE_PATH=/usr/include/oce \
-      -DOCE_LIB_PATH=/usr/lib \
-      -DPYTHON_EXECUTABLE=/usr/bin/python3.4 \
+cmake -DPYTHON_EXECUTABLE=/usr/bin/python3.4 \
       -DPYTHON_INCLUDE_DIR=/usr/include/python3.4m \
       -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so \
       ..
@@ -37,9 +35,7 @@ echo "Timestamp" && date
 echo "Configuring pythonocc for python2"
 mkdir cmake-build-py2
 cd cmake-build-py2
-cmake -DOCE_INCLUDE_PATH=/usr/include/oce \
-      -DOCE_LIB_PATH=/usr/lib \
-      ..
+cmake ..
 echo ""
 echo "Timestamp" && date
 echo "Starting build for python2 with -j$ncpus ..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,33 @@
 language: cpp
 compiler:
-  - gcc
+ # - gcc
   - clang
 before_install:
-# following ppa contains oce-0.16.0
-   - sudo add-apt-repository "deb http://ppa.launchpad.net/freecad-maintainers/oce-release/ubuntu precise main" -y
-   - sudo apt-get update -q
-   - sudo apt-get install liboce-ocaf-dev oce-draw
-   - sudo apt-get install python-wxgtk2.8
-   - sudo python -c "import wx"
-   - sudo apt-get install python-qt4 python-qt4-gl
-   - sudo python -c "from PyQt4 import QtGui, QtCore, QtOpenGL"
-   - sudo apt-get install python-pyside
-   - sudo python -c "from PySide import QtGui, QtCore, QtOpenGL"
+# first downlod/install oce-0.16.1
+  - sudo apt-get update
+  - sudo apt-get install tcl8.5-dev tk8.5-dev libgl2ps-dev libfreeimage-dev
+  - wget https://github.com/tpaviot/oce/archive/OCE-0.16.1.tar.gz
+  - tar -xvf OCE-0.16.1.tar.gz > OCE-0.16.1-filelist.txt
+  - cd oce-OCE-0.16.1
+  - mkdir cmake-build
+  - cd cmake-build
+  - sh ../../.travis.build-oce.sh
+  - sudo make install > oce-installed-files.txt
+  - cd ../..
+#   - sudo add-apt-repository "deb http://ppa.launchpad.net/freecad-maintainers/oce-release/ubuntu precise main" -y
+#   - sudo apt-get update -q
+#   - sudo apt-get install liboce-ocaf-dev oce-draw
+  - sudo apt-get install python-wxgtk2.8
+  - sudo python -c "import wx"
+  - sudo apt-get install python-qt4 python-qt4-gl
+  - sudo python -c "from PyQt4 import QtGui, QtCore, QtOpenGL"
+  - sudo apt-get install python-pyside
+  - sudo python -c "from PySide import QtGui, QtCore, QtOpenGL"
 # and this one python3.4 for ubuntu precise
-   - sudo add-apt-repository "deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu precise main" -y
-   - sudo apt-get update
-   - sudo apt-get install python3.4
-   - sudo apt-get install python3.4-dev
+  - sudo add-apt-repository "deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu precise main" -y
+  - sudo apt-get update
+  - sudo apt-get install python3.4
+  - sudo apt-get install python3.4-dev
 before_script:
   - wget http://prdownloads.sourceforge.net/swig/swig-2.0.10.tar.gz
 # untar swig files generates thousands of lines. Redirect stdout stream
@@ -25,7 +35,8 @@ before_script:
   - tar -xvf swig-2.0.10.tar.gz > swig-2.0.10-filelist.txt
   - cd swig-2.0.10
   - ./configure
-  - make -j6 && sudo make install
+  - make -j6 > swig-build-log.txt
+  - sudo make install
   - cd ..
   - swig -version
 script: ./.travis.build.sh


### PR DESCRIPTION
Previous travis build was configured to use OCE binaries from the free-cad launchpad ppa. Unfortunately, after the upgrade of freecad up to oce-0.17, their ppa is not sync'ed anymore with pythonocc-core (which requires oce-0.16).

In ths new travis file, oce-0.16.1 is downloaded/compiled/installed before pythonocc compilation. This takes some precious time, leading to give up with gcc tests (only clang left).

This however should be enough to have travis-ci fixed.
