### PR TITLE
Temporary removed py3k for travis

### DIFF
--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -6,31 +6,31 @@ ncpus=5
 #####################
 # build for python3 #
 #####################
-echo "Timestamp" && date
-echo "Configuring pythonocc for python3"
-mkdir cmake-build-py3
-cd cmake-build-py3
-cmake -DPYTHON_EXECUTABLE=/usr/bin/python3.4 \
-      -DPYTHON_INCLUDE_DIR=/usr/include/python3.4m \
-      -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so \
-      ..
-echo ""
-echo "Timestamp" && date
-# make for py3
-echo "Starting build for python3 with -j$ncpus ..."
-# travis-ci truncates when there are more than 10,000 lines of output.
-# trim them to see test results.
-sudo make -j$ncpus install | grep Built
-# Run tests
-echo "Timestamp" && date
-cd ../test
-sudo /usr/bin/python3.4 run_tests.py
-sudo /usr/bin/python3.4 core_webgl_unittest.py
+#echo "Timestamp" && date
+#echo "Configuring pythonocc for python3"
+#mkdir cmake-build-py3
+#cd cmake-build-py3
+#cmake -DPYTHON_EXECUTABLE=/usr/bin/python3.4 \
+#      -DPYTHON_INCLUDE_DIR=/usr/include/python3.4m \
+#      -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so \
+#      ..
+#echo ""
+#echo "Timestamp" && date
+## make for py3
+#echo "Starting build for python3 with -j$ncpus ..."
+## travis-ci truncates when there are more than 10,000 lines of output.
+## trim them to see test results.
+#sudo make -j$ncpus install | grep Built
+## Run tests
+#echo "Timestamp" && date
+#cd ../test
+#sudo /usr/bin/python3.4 run_tests.py
+#sudo /usr/bin/python3.4 core_webgl_unittest.py
 
 #####################
 # build for python2 #
 #####################
-cd ..
+#cd ..
 echo "Timestamp" && date
 echo "Configuring pythonocc for python2"
 mkdir cmake-build-py2


### PR DESCRIPTION
Since thee freecad team has upgraded oce to 0.17 on their ppa, we have to compile our own oce-0.16 on the travis server. So we drop py3k compilation so far, it will be re-enabled when oce ppa makes 0.16 available.