### PR TITLE
Fixes incorrect BUILD_DIR in CMakeLists.txt on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,9 @@ endif(${python_version_major} MATCHES "3")
 if(WIN32)
   if(MSVC) # The compiler used is MSVC
     message(STATUS "Found MSVC compiler: ${MSVC} ${MSVC_VERSION}")
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin/)
+    set(LIBRARY_OUTPUT_PATH bin/)
   elseif (BORLAND) # The compiler used is BORLAND
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/win${BIT}/bin/${CMAKE_BUILD_TYPE})
+    set(LIBRARY_OUTPUT_PATH win${BIT}/bin/${CMAKE_BUILD_TYPE})
   else()
     set(LIBRARY_OUTPUT_PATH win${BIT}/bin/${CMAKE_BUILD_TYPE})
   endif()


### PR DESCRIPTION
In line 277, the variable BUILD_DIR is prefixed with CMAKE_BINARY_DIR. Therefore, we should not prefix LIBRARY_OUTPUT_PATH as we would have a duplicate prefix otherwise.