### PR TITLE
Conda recipe for CI builds

### DIFF
--- a/ci/conda/bld.bat
+++ b/ci/conda/bld.bat
@@ -1,0 +1,29 @@
+mkdir build
+cd build
+
+REM Remove dot from PY_VER for use in library name
+set MY_PY_VER=%PY_VER:.=%
+
+REM Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+ -DCMAKE_BUILD_TYPE=Release ^
+ -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DCMAKE_SYSTEM_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DPYTHON_EXECUTABLE:FILEPATH="%PYTHON%" ^
+ -DPYTHON_INCLUDE_DIR:PATH="%PREFIX%"/include ^
+ -DPYTHON_LIBRARY:FILEPATH="%PREFIX%"/libs/python%MY_PY_VER%.lib ^
+ ..
+if errorlevel 1 exit 1
+ 
+REM Build step 
+ninja
+if errorlevel 1 exit 1
+
+REM Install step
+ninja install
+if errorlevel 1 exit 1
+
+REM copy the source
+cd ..
+xcopy src "%LIBRARY_PREFIX%\src\pythonocc-core\src" /s /e /i
+if errorlevel 1 exit 1

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -1,0 +1,34 @@
+# make an in source build do to some problems with install
+
+if [ "$PY3K" == "1" ]; then
+    MY_PY_VER="${PY_VER}m"
+else
+    MY_PY_VER="${PY_VER}"
+fi
+
+if [ `uname` == Darwin ]; then
+    PY_LIB="libpython${MY_PY_VER}.dylib"
+else
+    PY_LIB="libpython${MY_PY_VER}.so"
+fi
+
+# Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX=$PREFIX \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_PREFIX_PATH=$PREFIX \
+ -DCMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
+ -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON \
+ -DPYTHON_INCLUDE_DIR:PATH=$PREFIX/include/python$MY_PY_VER \
+ -DPYTHON_LIBRARY:FILEPATH=$PREFIX/lib/${PY_LIB} \
+ .
+
+# Build step
+ninja
+
+# Install step
+ninja install
+
+# copy the source
+mkdir -p $PREFIX/src
+mkdir -p $PREFIX/src/pythonocc-core
+cp -r src $PREFIX/src/pythonocc-core

--- a/ci/conda/fix_graphicshr_location.patch
+++ b/ci/conda/fix_graphicshr_location.patch
@@ -1,0 +1,15 @@
+# Fixes the changed path of TKOpenGL.dll
+
+diff --git src/addons/Display/OCCViewer.py src/addons/Display/OCCViewer.py
+index 7dd04d5..f460da4 100644
+--- src/addons/Display/OCCViewer.py
++++ src/addons/Display/OCCViewer.py
+@@ -58,7 +58,7 @@ if sys.platform == "win32":  # all of this is win specific
+     # if the CSF_GraphicShr variable is not set
+     # it should point to the TKOpenGl.dll library that is shipped with pythonocc binary
+     if not "CSF_GraphicShr" in os.environ:
+-        os.environ["CSF_GraphicShr"] = os.path.join(os.path.dirname(OCC.Aspect.__file__), "TKOpenGl.dll")
++        os.environ["CSF_GraphicShr"] = os.path.join(sys.prefix, "Library", "bin", "TKOpenGl.dll")
+ 
+ 
+ def color(r, g, b):

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,0 +1,41 @@
+﻿package:
+  name: pythonocc-core
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+
+source:
+  path: ../..
+  patches:
+    - fix_graphicshr_location.patch [win]
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  binary_relocation: true
+  features:
+    - vc9               [win and py27]
+    - vc10              [win and py34]
+    - vc14              [win and py35]
+
+requirements:
+  build:
+    - ninja
+    - patch             [win]
+    - python
+    - oce ==0.16.1
+    - cmake
+    - swig
+    - gcc               [linux]
+
+  run:
+    - pyqt
+    - oce ==0.16.1
+    - python
+
+test:
+  imports:
+    - OCC
+    - OCC.BRepPrimAPI
+
+about:
+  home: https://github.com/tpaviot/pythonocc-core
+  license: LGPL
+  summary: A python wrapper for the OCE library


### PR DESCRIPTION
This enables CI using conda-build. Just run ```conda build ci/conda``` to build the packages.