### PR TITLE
Travis builds using conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
   - conda install -c https://conda.anaconda.org/dlr-sc oce
   # download/install swig
   - conda install swig
+  # install everything required to build the receipe
+  - conda install pip conda-build jinja2 binstar
   # and wxpython, pyside, pyqt are used for testing graphics
   # wxpython/pyside packages only available for python 2
   # pyqt is available for both
@@ -39,9 +41,12 @@ install:
     else
       conda install pyqt;
     fi
-script: ./.travis.build.sh
+
+script:
+  - conda build ci/conda
 
 after_script:
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,9 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
    # download/install OCE from DLR-SC channel
-  - conda install -c https://conda.anaconda.org/dlr-sc oce
-  # download/install swig
-  - conda install swig
+  - conda config --add channels https://conda.anaconda.org/dlr-sc
   # install everything required to build the receipe
-  - conda install pip conda-build jinja2 binstar
+  - conda install conda-build anaconda-client
   # and wxpython, pyside, pyqt are used for testing graphics
   # wxpython/pyside packages only available for python 2
   # pyqt is available for both
@@ -46,6 +44,8 @@ script:
   - conda build ci/conda
 
 after_script:
+  - conda install pythonocc-core --use-local
+  # TODO: run tests
 
 branches:
   only:

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -32,3 +32,12 @@ ninja install
 mkdir -p $PREFIX/src
 mkdir -p $PREFIX/src/pythonocc-core
 cp -r src $PREFIX/src/pythonocc-core
+
+# fix python and freetype loader path in all modules
+if [ `uname` == Darwin ]; then
+    for lib in `ls $SP_DIR/OCC/_*.so`; do
+      install_name_tool -change $PY_LIB @rpath/$PY_LIB $lib
+      install_name_tool -change libfreetype.6.dylib @rpath/libfreetype.6.dylib $lib
+      install_name_tool -rpath $PREFIX/lib @loader_path/../../../ $lib
+    done
+fi

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # Configure step
-cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX=$PREFIX \
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH=$PREFIX \
  -DCMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
@@ -23,10 +23,10 @@ cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX=$PREFIX \
  .
 
 # Build step
-ninja
+make -j 4
 
 # Install step
-ninja install
+make install
 
 # copy the source
 mkdir -p $PREFIX/src

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -8,8 +8,14 @@ source:
     - fix_graphicshr_location.patch [win]
 
 build:
+
+build:
+  script_env:
+    - CC
+    - CXX
+
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  binary_relocation: true
+  binary_relocation: false
   features:
     - vc9               [win and py27]
     - vc10              [win and py34]
@@ -23,7 +29,6 @@ requirements:
     - oce ==0.16.1
     - cmake
     - swig
-    - gcc               [linux]
 
   run:
     - pyqt

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -15,7 +15,7 @@ build:
     - CXX
 
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  binary_relocation: false
+  binary_relocation: false [osx]
   features:
     - vc9               [win and py27]
     - vc10              [win and py34]
@@ -23,7 +23,6 @@ build:
 
 requirements:
   build:
-    - ninja
     - patch             [win]
     - python
     - oce ==0.16.1


### PR DESCRIPTION
I enabled build on travis with conda. 

Features are:
  - Compilers from build matrix are used during build
  - Support for osx in build recipe
  - Manual binary relocation on osx

Still to be done:
   - Modify .travis.yml to build for osx