### PR TITLE
Fixed deprecation warnig in wx

### DIFF
--- a/src/addons/Display/SimpleGui.py
+++ b/src/addons/Display/SimpleGui.py
@@ -66,7 +66,7 @@ def init_display(backend_str=None, size=(1024, 768)):
                     raise ValueError('the menu item %s does not exist' % menu_name)
                 self.Bind(wx.EVT_MENU, _callable, id=_id)
 
-        app = wx.PySimpleApp()
+        app = wx.App(False)
         win = AppFrame(None)
         win.Show(True)
         wx.SafeYield()


### PR DESCRIPTION
Use ```wx.App(False)``` instead of old ```wx.PySimpleApp()``` in SimpleGui.py
