### PR TITLE
Fixed empty conda version, if conda can't get git tag

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,6 +1,6 @@
 ﻿package:
   name: pythonocc-core
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '0.17dev') }}
 
 source:
   path: ../..


### PR DESCRIPTION
Fixes #215