### PR TITLE
Travis fix/xvfb

### DIFF
--- a/ci/conda/run_test.sh
+++ b/ci/conda/run_test.sh
@@ -2,8 +2,13 @@ cd $SRC_DIR/test
 python run_tests.py
 python core_webgl_unittest.py
 if [ `uname` == Linux ]; then
-    xvfb-run -s "-screen 0 1024x768x16" python core_display_pyqt4_unittest.py
-    xvfb-run -s "-screen 0 1024x768x16" python core_display_pyqt5_unittest.py
-    xvfb-run -s "-screen 0 1024x768x16" python core_display_pyside_unittest.py
-    xvfb-run -s "-screen 0 1024x768x16" python core_display_wx_unittest.py
+	# start xvfb
+	export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start
+    sleep 3 # give xvfb some time to start
+    # then run GUI tests
+    python core_display_pyqt4_unittest.py
+    python core_display_pyqt5_unittest.py
+    python core_display_pyside_unittest.py
+    python core_display_wx_unittest.py
 fi


### PR DESCRIPTION
run an xvfb server before running the GUI tests on Linux/Travis. Fix an issue with failing GUI tests.
