### PR TITLE
allow creation of OCCViewer with OpenGL arguments

### DIFF
--- a/src/Visualization/Display3d.cpp
+++ b/src/Visualization/Display3d.cpp
@@ -34,7 +34,10 @@ static Handle(Graphic3d_GraphicDriver)& GetGraphicDriver()
   return aGraphicDriver;
 }
 
-void Display3d::Init(long window_handle)
+void Display3d::Init(long window_handle,
+                     bool ffpEnabled,
+                     bool buffersNoSwapEnabled,
+                     bool glslWarningsEnabled)
 {
   printf(" ###### 3D rendering pipe initialisation #####\n");
 	printf("Display3d class initialization starting ...\n");
@@ -53,7 +56,7 @@ void Display3d::Init(long window_handle)
   myAISContext = new AIS_InteractiveContext(myV3dViewer);
   printf("AIS_InteractiveContext created.\n");
   // Create view
-  myV3dView = myV3dViewer->CreateView();	
+  myV3dView = myV3dViewer->CreateView();
   printf("V3d_View created\n");
   // Create Graphic Window
   #ifdef WNT
@@ -67,6 +70,24 @@ void Display3d::Init(long window_handle)
                                (Aspect_Handle) window_handle);
       printf("Xw_Window created.\n");
   #endif
+
+  // Create V3dViewer and V3d_View
+  myV3dViewer = new V3d_Viewer(GetGraphicDriver(), (short* const)"viewer");
+  Handle(OpenGl_GraphicDriver) aDriver = Handle(OpenGl_GraphicDriver)::DownCast (myV3dViewer->Driver());
+  // Enables FFP (fixed-function pipeline), do not use built-in GLSL programs
+  // (ON by default on desktop OpenGL and OFF on OpenGL ES)
+  aDriver->ChangeOptions().ffpEnable = ffpEnabled;
+  // Specify that driver should not swap back/front buffers at the end of frame
+  // Useful when OCCT Viewer is integrated into existing OpenGL rendering pipeline as part
+  // thus swapping part is performed outside ( eg, let Qt handle this )
+  // Standard_False by default.
+  aDriver->ChangeOptions().buffersNoSwap = buffersNoSwapEnabled;
+  // Print GLSL program compilation/linkage warnings, if any
+  aDriver->ChangeOptions().glslWarnings = glslWarningsEnabled;
+
+  printf("V3d_Viewer created.\n");
+  myV3dView = myV3dViewer->CreateView();	
+  printf("V3d_View created\n");
   myV3dView->SetWindow(myWindow);
   if (!myWindow->IsMapped()) myWindow->Map();
   printf("Display3d class successfully initialized.\n");

--- a/src/Visualization/Display3d.cpp
+++ b/src/Visualization/Display3d.cpp
@@ -100,6 +100,29 @@ void Display3d::Init(long window_handle,
 	printf(" ########################################\n");
 }
 
+//void Display3d::ChangeRenderingParams( // Specifies rendering mode
+//                            // - Graphic3d_RM_RASTERIZATION: enables OpenGL rasterization mode;
+//                            // - Graphic3d_RM_RAYTRACING: enables GPU ray-tracing mode.
+//                            int RenderingMethod,
+//                            // Maximum ray-tracing depth.
+//                            int RaytracingDepth,
+//                            // Enables/disables shadows rendering.
+//                            bool IsShadowEnabled,
+//                            // Enables/disables specular reflections.
+//                            bool IsReflectionEnabled,
+//                            // Enables/disables adaptive anti-aliasing.
+//                            bool IsAntialiasingEnabled,
+//                            // Enables/disables light propagation through transparent media.
+//                            bool IsTransparentShadowEnabled)
+//{
+//  myV3dView->ChangeRenderingParams().Method = RenderingMethod
+//  myV3dView->ChangeRenderingParams().RaytracingDepth = RaytracingDepth
+//  myV3dView->ChangeRenderingParams().IsShadowEnabled = IsShadowEnabled
+//  myV3dView->ChangeRenderingParams().IsReflectionEnabled = IsReflectionEnabled
+//  myV3dView->ChangeRenderingParams().IsAntialiasingEnabled = IsAntialiasingEnabled
+//  myV3dView->ChangeRenderingParams().IsTransparentShadowEnabled = IsTransparentShadowEnabled
+//}
+
 void Display3d::Test()
 {
       BRepPrimAPI_MakeBox S(100,50,40);

--- a/src/Visualization/Display3d.cpp
+++ b/src/Visualization/Display3d.cpp
@@ -46,19 +46,10 @@ void Display3d::Init(long window_handle,
   printf("Aspect_DisplayConnection created.\n");
   if (GetGraphicDriver().IsNull())
   {
-  GetGraphicDriver() = new OpenGl_GraphicDriver (aDisplayConnection);
+    GetGraphicDriver() = new OpenGl_GraphicDriver (Handle(Aspect_DisplayConnection)());
   }
   printf("Graphic_Driver created.\n");
-  // Create V3dViewer and V3d_View
-  myV3dViewer = new V3d_Viewer(GetGraphicDriver(), (short* const)"viewer");
-  printf("V3d_Viewer created.\n");
-  // Create AISInteractiveViewer
-  myAISContext = new AIS_InteractiveContext(myV3dViewer);
-  printf("AIS_InteractiveContext created.\n");
-  // Create view
-  myV3dView = myV3dViewer->CreateView();
-  printf("V3d_View created\n");
-  // Create Graphic Window
+  // Create Graphic Device and Window
   #ifdef WNT
       myWindow = new WNT_Window((Aspect_Handle) window_handle);
       printf("WNT window created.\n");
@@ -66,8 +57,7 @@ void Display3d::Init(long window_handle,
       myWindow = new Cocoa_Window((NSView *) window_handle);
       printf("Cocoa window created.\n");
   #else
-      myWindow = new Xw_Window(myAISContext->CurrentViewer()->Driver()->GetDisplayConnection(),
-                               (Aspect_Handle) window_handle);
+      myWindow =new Xw_Window(aDisplayConnection, (Window) window_handle);
       printf("Xw_Window created.\n");
   #endif
 
@@ -90,6 +80,9 @@ void Display3d::Init(long window_handle,
   printf("V3d_View created\n");
   myV3dView->SetWindow(myWindow);
   if (!myWindow->IsMapped()) myWindow->Map();
+	// Create AISInteractiveViewer
+	myAISContext = new AIS_InteractiveContext(myV3dViewer);
+	printf("AIS_InteractiveContext created.\n");
   printf("Display3d class successfully initialized.\n");
 	printf(" ########################################\n");
 }

--- a/src/Visualization/Visualization.h
+++ b/src/Visualization/Visualization.h
@@ -46,9 +46,9 @@ public:
 	Standard_EXPORT virtual ~Display3d();
 	//Standard_EXPORT void Init(long window_handle);
 	Standard_EXPORT void Init(long window_handle,
-                              bool ffpEnabled=1,
-                              bool buffersNoSwapEnabled=0,
-                              bool glslWarningsEnabled=0);
+                              bool ffpEnabled=true,
+                              bool buffersNoSwapEnabled=false,
+                              bool glslWarningsEnabled=false);
 
 	Standard_EXPORT Handle_V3d_View& GetView() {return myV3dView;};
 	Standard_EXPORT Handle_V3d_Viewer& GetViewer() {return myV3dViewer;};

--- a/src/Visualization/Visualization.h
+++ b/src/Visualization/Visualization.h
@@ -44,7 +44,12 @@ class Display3d
 public:
 	Standard_EXPORT Display3d();
 	Standard_EXPORT virtual ~Display3d();
-	Standard_EXPORT void Init(long window_handle);
+	//Standard_EXPORT void Init(long window_handle);
+	Standard_EXPORT void Init(long window_handle,
+                              bool ffpEnabled=1,
+                              bool buffersNoSwapEnabled=0,
+                              bool glslWarningsEnabled=0);
+
 	Standard_EXPORT Handle_V3d_View& GetView() {return myV3dView;};
 	Standard_EXPORT Handle_V3d_Viewer& GetViewer() {return myV3dViewer;};
 	Standard_EXPORT Handle_AIS_InteractiveContext GetContext() {return myAISContext;};

--- a/src/Visualization/Visualization.h
+++ b/src/Visualization/Visualization.h
@@ -39,12 +39,13 @@
   #include <Xw_Window.hxx>
 #endif
 
+#include <Graphic3d_RenderingMode.hxx>
+
 class Display3d 
 {	
 public:
 	Standard_EXPORT Display3d();
 	Standard_EXPORT virtual ~Display3d();
-	//Standard_EXPORT void Init(long window_handle);
 	Standard_EXPORT void Init(long window_handle,
                               bool ffpEnabled=true,
                               bool buffersNoSwapEnabled=false,
@@ -54,7 +55,31 @@ public:
 	Standard_EXPORT Handle_V3d_Viewer& GetViewer() {return myV3dViewer;};
 	Standard_EXPORT Handle_AIS_InteractiveContext GetContext() {return myAISContext;};
 	Standard_EXPORT void Test();
-    
+
+    Standard_EXPORT void ChangeRenderingParams( // Specifies rendering mode
+                                                // - Graphic3d_RM_RASTERIZATION: enables OpenGL rasterization mode;
+                                                // - Graphic3d_RM_RAYTRACING: enables GPU ray-tracing mode.
+                                                int RenderingMethod,
+                                                // Maximum ray-tracing depth.
+                                                int RaytracingDepth,
+                                                // Enables/disables shadows rendering.
+                                                bool IsShadowEnabled,
+                                                // Enables/disables specular reflections.
+                                                bool IsReflectionEnabled,
+                                                // Enables/disables adaptive anti-aliasing.
+                                                bool IsAntialiasingEnabled,
+                                                // Enables/disables light propagation through transparent media.
+                                                bool IsTransparentShadowEnabled);
+{
+  GetView()->ChangeRenderingParams().Method = RenderingMethod;
+  GetView()->ChangeRenderingParams().RaytracingDepth = RaytracingDepth;
+  GetView()->ChangeRenderingParams().IsShadowEnabled = IsShadowEnabled;
+  GetView()->ChangeRenderingParams().IsReflectionEnabled = IsReflectionEnabled;
+  GetView()->ChangeRenderingParams().IsAntialiasingEnabled = IsAntialiasingEnabled;
+  GetView()->ChangeRenderingParams().IsTransparentShadowEnabled = IsTransparentShadowEnabled;
+}
+
+
 protected:
    Handle_AIS_InteractiveContext myAISContext;
    Handle_V3d_Viewer myV3dViewer;

--- a/src/Visualization/Visualization.i
+++ b/src/Visualization/Visualization.i
@@ -86,9 +86,9 @@ class Display3d {
 	~Display3d();
 	%feature("autodoc", "1");
 	void Init(const long handle,
-             bool ffpEnabled=1,
-             bool buffersNoSwapEnabled=0,
-             bool glslWarningsEnabled=0);
+             bool ffpEnabled=true,
+             bool buffersNoSwapEnabled=false,
+             bool glslWarningsEnabled=false);
 	%feature("autodoc", "1");
 	Handle_V3d_View& GetView();
 	%feature("autodoc", "1");

--- a/src/Visualization/Visualization.i
+++ b/src/Visualization/Visualization.i
@@ -22,6 +22,7 @@
 #include <Visualization.h>
 #include <Tesselator.h>
 #include <Standard.hxx>
+#include <Standard_Boolean.hxx>
 %}
 
 %include ../SWIG_files/common/ExceptionCatcher.i
@@ -84,7 +85,10 @@ class Display3d {
 	%feature("autodoc", "1");
 	~Display3d();
 	%feature("autodoc", "1");
-	void Init(const long handle);
+	void Init(const long handle,
+             bool ffpEnabled=1,
+             bool buffersNoSwapEnabled=0,
+             bool glslWarningsEnabled=0);
 	%feature("autodoc", "1");
 	Handle_V3d_View& GetView();
 	%feature("autodoc", "1");

--- a/src/Visualization/Visualization.i
+++ b/src/Visualization/Visualization.i
@@ -89,6 +89,7 @@ class Display3d {
              bool ffpEnabled=true,
              bool buffersNoSwapEnabled=false,
              bool glslWarningsEnabled=false);
+
 	%feature("autodoc", "1");
 	Handle_V3d_View& GetView();
 	%feature("autodoc", "1");
@@ -97,5 +98,14 @@ class Display3d {
 	Handle_AIS_InteractiveContext GetContext();
 	%feature("autodoc", "1");
 	void Test();
+
+	//%feature("autodoc", "1");
+    void ChangeRenderingParams(int RenderingMethod,
+                               int RaytracingDepth,
+                               bool IsShadowEnabled,
+                               bool IsReflectionEnabled,
+                               bool IsAntialiasingEnabled,
+                               bool IsTransparentShadowEnabled);
+
 };
 

--- a/src/addons/Display/OCCViewer.py
+++ b/src/addons/Display/OCCViewer.py
@@ -131,8 +131,8 @@ class Viewer3d(OCC.Visualization.Display3d):
         self.View.ZFitAll()
         self.View.FitAll()
 
-    def Create(self, create_default_lights=True):
-        self.Init(self._window_handle)
+    def Create(self, create_default_lights=True, ffpEnabled=True, buffersNoSwapEnabled=False, glslWarningsEnabled=False):
+        self.Init(self._window_handle, ffpEnabled, buffersNoSwapEnabled, glslWarningsEnabled)
         self.Context_handle = self.GetContext()
         self.Viewer_handle = self.GetViewer()
         self.View_handle = self.GetView()

--- a/src/addons/Display/qtDisplay.py
+++ b/src/addons/Display/qtDisplay.py
@@ -118,9 +118,33 @@ class qtViewer3d(qtBaseViewer):
         self._selection = None
         self._drawtext = True
 
-    def InitDriver(self):
+    def InitDriver(self,
+                   create_default_lights=True,
+                   ffpEnabled=True,
+                   buffersNoSwapEnabled=False,
+                   glslWarningsEnabled=False):
+
+        """
+
+        Parameters
+        ----------
+
+        create_default_lights : enable default lights in scen
+        ffpEnabled : toggle fixed function pipeline
+            this is a conservative setting, ffpEnabled=False, will enable modern OpenGL / a shader pipeline
+
+        buffersNoSwapEnabled :
+            allows GUI frameworks, like Qt to invoke swapping the OpenGL buffer
+            this is required for QML
+
+        glslWarningsEnabled:
+            toggles printing of GLSL warnings, useful for working with GLSL shaders
+        """
         self._display = OCCViewer.Viewer3d(self.GetHandle())
-        self._display.Create()
+        self._display.Create(ffpEnabled=ffpEnabled,
+                             buffersNoSwapEnabled=buffersNoSwapEnabled,
+                             glslWarningsEnabled=glslWarningsEnabled,
+                             create_default_lights=create_default_lights)
         # background gradient
         self._display.set_bg_gradient_color(206, 215, 222, 128, 128, 128)
         # background gradient
@@ -254,7 +278,7 @@ class qtViewer3d(qtBaseViewer):
             self._drawbox = False
         # DYNAMIC ZOOM
         elif (buttons == QtCore.Qt.RightButton and
-              not modifiers == QtCore.Qt.ShiftModifier):
+                  not modifiers == QtCore.Qt.ShiftModifier):
             self._display.Repaint()
             self._display.DynamicZoom(abs(self.dragStartPos.x),
                                       abs(self.dragStartPos.y), abs(pt.x),
@@ -273,12 +297,12 @@ class qtViewer3d(qtBaseViewer):
         # DRAW BOX
         # ZOOM WINDOW
         elif (buttons == QtCore.Qt.RightButton and
-              modifiers == QtCore.Qt.ShiftModifier):
+                      modifiers == QtCore.Qt.ShiftModifier):
             self._zoom_area = True
             self.DrawBox(evt)
         # SELECT AREA
         elif (buttons == QtCore.Qt.LeftButton and
-              modifiers == QtCore.Qt.ShiftModifier):
+                      modifiers == QtCore.Qt.ShiftModifier):
             self._select_area = True
             self.DrawBox(evt)
         else:


### PR DESCRIPTION
allow creation of OCCViewer with the following arguments:
    - ffpEnabled // toggle fixed function pipeline
    - buffersNoSwapEnabled // toggle the framework swapping the OpenGL buffer, required for QML
    - glslWarningsEnabled // toggles printing of GLSL warnings