### PR TITLE
qt backend fix

### DIFF
--- a/src/addons/Display/SimpleGui.py
+++ b/src/addons/Display/SimpleGui.py
@@ -21,7 +21,7 @@ import logging
 import sys
 
 from OCC import VERSION
-from OCC.Display.backend import get_backend, get_qt_modules
+from OCC.Display.backend import load_backend, get_qt_modules
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def check_callable(_callable):
 
 
 def init_display(backend_str=None, size=(1024, 768)):
-    used_backend = get_backend(backend_str)
+    used_backend = load_backend(backend_str)
 
     log.info("GUI backend set to: {0}".format(used_backend))
     # wxPython based simple GUI

--- a/src/addons/Display/backend.py
+++ b/src/addons/Display/backend.py
@@ -100,11 +100,10 @@ def get_loaded_backend():
     return BACKEND_MODULE
 
 
-def get_backend(backend_str=None):
+def load_backend(backend_str=None):
     """ loads a gui backend
 
-    A backend is preferable a Qt backend, such as PyQt5, PyQt4 or PySide
-    If no Qt backend is found, wx is loaded
+    If no Qt (such as PyQt5, PyQt4 or PySide) backend is found, wx is loaded
 
     The search order for pythonocc compatible gui modules is:
         PyQt5, PyQt4, PySide, Wx
@@ -144,10 +143,10 @@ def get_backend(backend_str=None):
     global HAVE_BACKEND, BACKEND_MODULE
 
     if HAVE_BACKEND:
-        msg = "a backend is already loaded..." \
-              "``get_backend`` can only be called once"
-        log.critical(msg)
-        raise ImportError(msg)
+        msg = "The {0} backend is already loaded..." \
+              "``load_backend`` can only be called once per session".format(BACKEND_MODULE)
+        log.info(msg)
+        return BACKEND_MODULE
 
     if backend_str is not None:
         compatible_backends = (PYQT5, PYQT4, PYSIDE, WX)
@@ -231,13 +230,13 @@ def get_qt_modules():
 
     ValueError
         when no Qt backend has been yet loaded
-        informs the user to call `get_backend` or that no Qt python module
+        informs the user to call `load_backend` or that no Qt python module
         ( PyQt5, PyQt4 or PySide ) is found
 
     """
     if not HAVE_BACKEND:
         raise ValueError("no backend has been imported yet with "
-                         "``get_backend``... ")
+                         "``load_backend``... ")
 
     if HAVE_PYQT5 or HAVE_PYQT4 or HAVE_PYSIDE:
         return QtCore, QtGui, QtWidgets, QtOpenGL
@@ -247,5 +246,5 @@ def get_qt_modules():
         msg = ("no Qt backend is loaded, hence cannot return any modules\n"
                "either you havent got PyQt5, PyQt4 or PySide installed\n"
                "or you havent yet loaded a backend with the "
-               "`OCC.Display.backend.get_backend` function")
+               "`OCC.Display.backend.load_backend` function")
         raise ValueError(msg)


### PR DESCRIPTION
* the ```get_backend```function name is replaced with ```load_backend```, which is more explicit

* if the ```load_backend``` function is called more than once, the second times it returns an info message and the string of the load backend.

The behaviour is now:

```
>>> load_backend("qt-pyqt4")
INFO:OCC.Display.backend:backend loaded: qt-pyqt4
'qt-pyqt4'
>>> load_backend("qt-pyqt5")
INFO:OCC.Display.backend:The qt-pyqt4 backend is already loaded...``load_backend
y be called once per session
'qt-pyqt4'
>>>
```

Should fix #224 