### PR TITLE
Run examples as tests

### DIFF
--- a/ci/conda/run_test.sh
+++ b/ci/conda/run_test.sh
@@ -1,5 +1,6 @@
 cd $SRC_DIR/test
 python run_tests.py
+python run_examples_as_tests.py
 python core_webgl_unittest.py
 if [ `uname` == Linux ]; then
 	# start xvfb

--- a/examples/core_geometry_airfoil.py
+++ b/examples/core_geometry_airfoil.py
@@ -21,7 +21,10 @@
 # Explanations for this script can be found at
 # http://pythonocc.wordpress.com/2013/04/01/using-external-airfoil-data-to-create-a-solid-wing/
 #
-import urllib2
+try:
+    import urllib.request as urllib2  # Python3
+except ImportError:
+    import urllib2  # Python2
 
 from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeFace
 from OCC.BRepPrimAPI import BRepPrimAPI_MakePrism
@@ -53,9 +56,7 @@ class UiucAirfoil(object):
 
         for line in f.readlines()[1:]:  # The first line contains info only
             # 2 - do some cleanup on the data (mostly dealing with spaces)
-            line = line.lstrip().rstrip().replace('    ', ' ').replace('   ', ' ').replace('  ', ' ')
-            data = line.split(' ')  # data[0] = x coord.    data[1] = y coord.
-
+            data = line.split()
             # 3 - create an array of points
             if len(data) == 2:  # two coordinates for each point
                 section_pts_2d.append(gp_Pnt2d(float(data[0])*self.chord,

--- a/examples/core_geometry_utils.py
+++ b/examples/core_geometry_utils.py
@@ -132,7 +132,7 @@ def midpoint(pntA, pntB):
     """
     vec1 = gp_Vec(pntA.XYZ())
     vec2 = gp_Vec(pntB.XYZ())
-    veccie = (vec1 + vec2) / 2.
+    veccie = (vec1 + vec2) * 0.5
     return gp_Pnt(veccie.XYZ())
 
 

--- a/examples/core_matplotlib_box.py
+++ b/examples/core_matplotlib_box.py
@@ -20,12 +20,17 @@
 # Small example how to use the Tesselator interface to draw
 # a shape with matplotlib
 
+import sys
+
 from OCC.Visualization import Tesselator
 from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib import pyplot as plt
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection, Line3DCollection
-
+try:
+    from mpl_toolkits.mplot3d import Axes3D
+    from matplotlib import pyplot as plt
+    from mpl_toolkits.mplot3d.art3d import Poly3DCollection, Line3DCollection
+except ImportError:
+    print("This example requires matplotlib.")
+    sys.exit(0)
 
 def draw_shape_mpl(shape):
     """

--- a/examples/core_parallel_slicer.py
+++ b/examples/core_parallel_slicer.py
@@ -82,7 +82,7 @@ def run(n_procs, compare_by_number_of_processors=False):
         z_slices = drange(z_min, z_max, z_delta/n_slices)
 
         slices = []
-        n = len(z_slices) / n_procs
+        n = len(z_slices) // n_procs
 
         _str_slices = []
         for i in range(1, n_procs+1):

--- a/examples/core_simple_mesh.py
+++ b/examples/core_simple_mesh.py
@@ -15,7 +15,7 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.BRep import BRep_Builder, BRep_Tool_Triangulation
+from OCC.BRep import BRep_Builder, BRep_Tool
 from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
 from OCC.BRepAlgoAPI import BRepAlgoAPI_Fuse
 from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
@@ -47,11 +47,12 @@ def simple_mesh():
     comp = TopoDS_Compound()
     builder.MakeCompound(comp)
 
+    bt = BRep_Tool()
     ex = TopExp_Explorer(shape, TopAbs_FACE)
     while ex.More():
         face = topods_Face(ex.Current())
         location = TopLoc_Location()
-        facing = (BRep_Tool_Triangulation(face, location)).GetObject()
+        facing = (bt.Triangulation(face, location)).GetObject()
         tab = facing.Nodes()
         tri = facing.Triangles()
         for i in range(1, facing.NbTriangles()+1):

--- a/examples/core_topology_glue.py
+++ b/examples/core_topology_glue.py
@@ -51,6 +51,13 @@ def tag_faces(_shape, _color, shape_name):
         display.DisplayMessage(center_pt, "{0}_nr_{1}".format(shape_name, n))
 
 
+def tag_edge(_edge, msg, _color=(1, 0, 0)):
+    """ tag an edge
+    """
+    pt = center_boundingbox(_edge)
+    display.DisplayMessage(pt, msg, None, _color, False)
+
+
 def glue_solids(event=None):
     display.EraseAll()
     display.Context.RemoveAll()
@@ -126,12 +133,8 @@ def glue_solids_edges(event=None):
         edge_from = common_edges.EdgeFrom()
         edge_to = common_edges.EdgeTo()
 
-        center_pt_edge_to = center_boundingbox(edge_to)
-        center_pt_edge_from = center_boundingbox(edge_from)
-
-        red = (1, 0, 0)
-        display.DisplayMessage(center_pt_edge_from, "edge_{0}_from".format(n), message_color=red)
-        display.DisplayMessage(center_pt_edge_to, "edge_{0}_to".format(n), message_color=red)
+        tag_edge(edge_from, "edge_{0}_from".format(n))
+        tag_edge(edge_to, "edge_{0}_to".format(n))
 
         glue2.Bind(edge_from, edge_to)
         common_edges.Next()

--- a/examples/core_topology_through_sections.py
+++ b/examples/core_topology_through_sections.py
@@ -36,7 +36,12 @@ def through_sections():
     wire_4 = BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeEdge(circle_4).Edge()).Wire()
 
     generatorA = BRepOffsetAPI_ThruSections(False, True)
-    map(generatorA.AddWire, [wire_1, wire_2, wire_3, wire_4])
+    # the use of the map function fails at producing the ThruSection
+    # on py3k. Why ?
+    # map(generatorA.AddWire, [wire_1, wire_2, wire_3, wire_4])
+    # we have to use a loop
+    for wir in [wire_1, wire_2, wire_3, wire_4]:
+        generatorA.AddWire(wir)
     generatorA.Build()
     display.DisplayShape(generatorA.Shape())
 
@@ -50,7 +55,10 @@ def through_sections():
     circle_4b = gp_Circ(gp_Ax2(gp_Pnt(200., 0., 200.), gp_Dir(0., 0., 1.)), 40.)
     wire_4b = BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeEdge(circle_4b).Edge()).Wire()
     generatorB = BRepOffsetAPI_ThruSections(True, False)
-    map(generatorB.AddWire, [wire_1b, wire_2b, wire_3b, wire_4b])
+    # same here, the following line fails
+    # map(generatorB.AddWire, [wire_1b, wire_2b, wire_3b, wire_4b])
+    for wir in [wire_1b, wire_2b, wire_3b, wire_4b]:
+        generatorB.AddWire(wir)
     generatorB.Build()
     display.DisplayShape(generatorB.Shape(), update=True)
 

--- a/examples/core_topology_traverse.py
+++ b/examples/core_topology_traverse.py
@@ -533,6 +533,7 @@ def get_test_sphere_shape():
 topo = Topo(get_test_box_shape())
 assert topo
 
+
 def test_loop_faces():
     i = 0
     for face in topo.faces():
@@ -540,12 +541,14 @@ def test_loop_faces():
         assert(isinstance(face, TopoDS_Face))
     assert(i == 6)
 
+
 def test_loop_edges():
     i = 0
     for face in topo.edges():
         i += 1
         assert(isinstance(face, TopoDS_Edge))
     assert(i == 12)
+
 
 def number_of_topological_entities():
     assert(topo.number_of_faces() == 6)
@@ -557,12 +560,14 @@ def number_of_topological_entities():
     assert(topo.number_of_compounds() == 0)
     assert(topo.number_of_comp_solids() == 0)
 
+
 def test_nested_iteration():
     '''check nested looping'''
     for f in topo.faces():
         for e in topo.edges():
             assert isinstance(f, TopoDS_Face)
             assert isinstance(e, TopoDS_Edge)
+
 
 def test_kept_reference():
     '''did we keep a reference after looping several time through a list
@@ -575,66 +580,74 @@ def test_kept_reference():
         _tmp.append(0 == f.IsNull())
     assert(all(_tmp))
 
+
 def test_edge_face():
-    edg = topo.edges().next()
-    face = topo.faces().next()
+    edg = next(topo.edges())
+    face = next(topo.faces())
     faces_from_edge = [i for i in topo.faces_from_edge(edg)]
     assert(len(faces_from_edge) == topo.number_of_faces_from_edge(edg))
     edges_from_face = [i for i in topo.edges_from_face(face)]
     assert(len(edges_from_face) == topo.number_of_edges_from_face(face))
 
+
 def test_edge_wire():
-    edg = topo.edges().next()
-    wire = topo.wires().next()
+    edg = next(topo.edges())
+    wire = next(topo.wires())
     wires_from_edge = [i for i in topo.wires_from_edge(edg)]
     assert(len(wires_from_edge) == topo.number_of_wires_from_edge(edg))
     edges_from_wire = [i for i in topo.edges_from_wire(wire)]
     assert(len(edges_from_wire) == topo.number_of_edges_from_wire(wire))
 
+
 def test_vertex_edge():
-    vert = topo.vertices().next()
-    edge = topo.edges().next()
+    vert = next(topo.vertices())
+    edge = next(topo.edges())
     verts_from_edge = [i for i in topo.vertices_from_edge(edge)]
     assert(len(verts_from_edge) == topo.number_of_vertices_from_edge(edge))
     edges_from_vert = [i for i in topo.edges_from_vertex(vert)]
     assert(len(edges_from_vert) == topo.number_of_edges_from_vertex(vert))
 
+
 def test_vertex_face():
-    vert = topo.vertices().next()
-    face = topo.faces().next()
+    vert = next(topo.vertices())
+    face = next(topo.faces())
     faces_from_vertex = [i for i in topo.faces_from_vertex(vert)]
     assert(len(faces_from_vertex) == topo.number_of_faces_from_vertex(vert))
     verts_from_face = [i for i in topo.vertices_from_face(face)]
     assert(len(verts_from_face) == topo.number_of_vertices_from_face(face))
 
+
 def test_face_solid():
-    face = topo.faces().next()
-    solid = topo.solids().next()
+    face = next(topo.faces())
+    solid = next(topo.solids())
     faces_from_solid = [i for i in topo.faces_from_solids(solid)]
     assert(len(faces_from_solid) == topo.number_of_faces_from_solids(solid))
     solids_from_face = [i for i in topo.solids_from_face(face)]
     assert(len(solids_from_face) == topo.number_of_solids_from_face(face))
 
+
 def test_wire_face():
-    wire = topo.wires().next()
-    face = topo.faces().next()
+    wire = next(topo.wires())
+    face = next(topo.faces())
     faces_from_wire = [i for i in topo.faces_from_wire(wire)]
     assert(len(faces_from_wire) == topo.number_of_faces_from_wires(wire))
     wires_from_face = [i for i in topo.wires_from_face(face)]
     assert(len(wires_from_face) == topo.number_of_wires_from_face(face))
 
+
 def test_edges_out_of_scope():
     # check pointers going out of scope
-    face = topo.faces().next()
+    face = next(topo.faces())
     _edges = []
     for edg in Topo(face).edges():
         _edges.append(edg)
     for edg in _edges:
         assert not edg.IsNull()
 
+
 def test_wires_out_of_scope():
     # check pointers going out of scope
-    wire = topo.wires().next()
+    wire = next(topo.wires())
     _edges, _vertices = [], []
     for edg in WireExplorer(wire).ordered_edges():
         _edges.append(edg)
@@ -658,4 +671,3 @@ if __name__ == "__main__":
     test_loop_faces()
     test_edges_out_of_scope()
     test_wires_out_of_scope()
-

--- a/src/addons/Display/OCCViewer.py
+++ b/src/addons/Display/OCCViewer.py
@@ -444,7 +444,7 @@ class Viewer3d(OCC.Visualization.Display3d):
     def SetSelectionMode(self, mode=None):
         self.Context.CloseAllContexts()
         self.Context.OpenLocalContext()
-        topo_level = modes.next()
+        topo_level = next(modes)
         if mode is None:
             self.Context.ActivateStandardMode(topo_level)
         else:

--- a/test/run_examples_as_tests.py
+++ b/test/run_examples_as_tests.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+##Copyright 2009-2016 Thomas Paviot (tpaviot@gmail.com)
+##
+##This file is part of pythonOCC.
+##
+##pythonOCC is free software: you can redistribute it and/or modify
+##it under the terms of the GNU Lesser General Public License as published by
+##the Free Software Foundation, either version 3 of the License, or
+##(at your option) any later version.
+##
+##pythonOCC is distributed in the hope that it will be useful,
+##but WITHOUT ANY WARRANTY; without even the implied warranty of
+##MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##GNU Lesser General Public License for more details.
+##
+##You should have received a copy of the GNU Lesser General Public License
+##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+# look for all example names
+import os
+import glob
+import sys
+from subprocess import check_output
+
+all_examples_file_names = glob.glob(os.path.join('..','examples','core_*.py'))
+tests_to_exclude = ['core_visualization_overpaint_viewer.py',
+                    'core_display_customize_prs3d.py',
+                    'core_visualization_graphic3d_custom_opengl.py',
+                    'core_visualization_overpaint_viewer.py',
+                    'core_display_quality.py',
+                    'core_display_export_to_EF.py']
+# remove examples to excludes
+for example in all_examples_file_names:
+	for test_to_exclude in tests_to_exclude:
+		if test_to_exclude in example:
+			all_examples_file_names.remove(example)
+nbr_examples = len(all_examples_file_names)
+succeed = 0
+failed = 0
+
+i = 1
+os.environ["PYTHONOCC_SHUNT_GUI"] = "1"
+os.chdir(os.path.join('..', 'examples'))
+#python_major_version = sys.version_info[0]
+for example in all_examples_file_names:
+	print("running %s ..." % example, end="")
+	try:
+		out = check_output([sys.executable, example])
+		succeed += 1
+		print("[passed]")
+	except:
+		failed += 1
+		print("[failed]")
+	#subprocess.call(['%s %s' % (sys.executable, example)])
+	# Python2
+	#if python_major_version == 2:
+#		execfile(example)
+	# Python3
+#	elif python_major_version == 3:
+#		exec(open(example).read())
+print("Test examples results :")
+print("\t %i/%i tests passed" % (succeed, nbr_examples))
+
+del(os.environ["PYTHONOCC_SHUNT_GUI"])
+
+if failed > 0:
+	raise AssertionError("%i tests failed" % (failed))

--- a/test/run_examples_as_tests.py
+++ b/test/run_examples_as_tests.py
@@ -24,46 +24,45 @@ import glob
 import sys
 from subprocess import check_output
 
-all_examples_file_names = glob.glob(os.path.join('..','examples','core_*.py'))
+all_examples_file_names = glob.glob(os.path.join('..', 'examples', 'core_*.py'))
+# some tests have to be excluded from the automatic
+# run.
 tests_to_exclude = ['core_visualization_overpaint_viewer.py',
                     'core_display_customize_prs3d.py',
                     'core_visualization_graphic3d_custom_opengl.py',
-                    'core_visualization_overpaint_viewer.py',
                     'core_display_quality.py',
-                    'core_display_export_to_EF.py']
+                    'core_display_export_to_EF.py',
+                    'core_matplotlib_box.py']
 # remove examples to excludes
-for example in all_examples_file_names:
-	for test_to_exclude in tests_to_exclude:
-		if test_to_exclude in example:
-			all_examples_file_names.remove(example)
+for test_name in tests_to_exclude:
+    test_fullpath = os.path.join('..', 'examples', test_name)
+    all_examples_file_names.remove(test_fullpath)
+
+#    for example in all_examples_file_names:
+#    for test_to_exclude in tests_to_exclude:
+#        if test_to_exclude in example:
+#            all_examples_file_names.remove(example)
 nbr_examples = len(all_examples_file_names)
 succeed = 0
 failed = 0
 
-i = 1
 os.environ["PYTHONOCC_SHUNT_GUI"] = "1"
 os.chdir(os.path.join('..', 'examples'))
 #python_major_version = sys.version_info[0]
 for example in all_examples_file_names:
-	print("running %s ..." % example, end="")
-	try:
-		out = check_output([sys.executable, example])
-		succeed += 1
-		print("[passed]")
-	except:
-		failed += 1
-		print("[failed]")
-	#subprocess.call(['%s %s' % (sys.executable, example)])
-	# Python2
-	#if python_major_version == 2:
-#		execfile(example)
-	# Python3
-#	elif python_major_version == 3:
-#		exec(open(example).read())
+    print("running %s ..." % example, end="")
+    try:
+        out = check_output([sys.executable, example])
+        succeed += 1
+        print("[passed]")
+    except:
+        failed += 1
+        print("[failed]")
+
 print("Test examples results :")
 print("\t %i/%i tests passed" % (succeed, nbr_examples))
 
 del(os.environ["PYTHONOCC_SHUNT_GUI"])
 
 if failed > 0:
-	raise AssertionError("%i tests failed" % (failed))
+    raise AssertionError("%i tests failed" % (failed))


### PR DESCRIPTION
This branch adds a feature to run the example suite as tests.

Every single example in the src/example is ran in a "blind gui" mode, allowing examples to be executed from a console without any gui needed.

Those tests are launched after the unittest suite passes.

The tests have been fixed on both py2 and py3 so that travis builds fine.

Checked on win32/mingw32.

Fix isse #244