### PR TITLE
Fix of the resizing issue of the qtViewer widget

### DIFF
--- a/src/Display/qtDisplay.py
+++ b/src/Display/qtDisplay.py
@@ -90,6 +90,7 @@ class qtBaseViewer(QtOpenGL.QGLWidget):
         return win_id
 
     def resizeEvent(self, event):
+        super(qtBaseViewer,self).resizeEvent(event)
         if self._inited:
             self._display.OnResize()
 


### PR DESCRIPTION
As mentioned on the google group this fixes the issue for ugly resizing of the viewer. 

It is tested on PyQt4.

![python_occ_resizing_issue](https://cloud.githubusercontent.com/assets/13981538/20406390/71e15474-ad0d-11e6-9c77-dc4b4c696ee7.png)
