### PR TITLE
force cmake to version 3.3.1 in conda meta to prevent glibc travis issue

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - patch             [win]
     - python
     - oce ==0.17.2
-    - cmake
+    - cmake ==3.3.1
     - ninja             [win]
     - swig
     - freetype


### PR DESCRIPTION
Fix #361 