### PR TITLE
Review/overload repr

### DIFF
--- a/src/SWIG_files/common/CommonIncludes.i
+++ b/src/SWIG_files/common/CommonIncludes.i
@@ -27,3 +27,37 @@ along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 %include <python/std_list.i>
 %include <python/std_string.i>
 %include <python/std_basic_string.i>
+
+%pythoncode %{
+def _dumps_object(klass):
+    """ Improve string output for any oce object.
+    By default, __repr__ method returns something like:
+    <OCC.TopoDS.TopoDS_Shape; proxy of <Swig Object of type 'TopoDS_Shape *' at 0x02BB0758> >
+    This is too much verbose.
+    We prefer :
+    class<'gp_Pnt'>
+    or
+    class<'TopoDS_Shape'; Type:Solid; Id:59391729>
+    """
+    klass_name = str(klass.__class__).split(".")[2].split("'")[0]
+    repr_string = "class<'" + klass_name + "'"
+    # for TopoDS_Shape, we also look for the base type
+    if klass_name == "TopoDS_Shape":
+        st = klass.ShapeType()
+        types = {OCC.TopAbs.TopAbs_VERTEX:"Vertex",
+                 OCC.TopAbs.TopAbs_SOLID:"Solid",
+                 OCC.TopAbs.TopAbs_EDGE:"Edge",
+                 OCC.TopAbs.TopAbs_FACE:"Face",
+                 OCC.TopAbs.TopAbs_SHELL:"Shell",
+                 OCC.TopAbs.TopAbs_WIRE:"Wire",
+                 OCC.TopAbs.TopAbs_COMPOUND:"Compound",
+                 OCC.TopAbs.TopAbs_COMPSOLID:"Compsolid."}
+        repr_string += "; Type:%s" % types[st]        
+    # for each class that has an HashCode method define,
+    # print the id
+    if hasattr(klass, "HashCode"):
+        klass_id = hash(klass)
+        repr_string += "; id:%s" % klass_id
+    repr_string += ">"
+    return repr_string
+%}

--- a/src/SWIG_files/wrapper/AIS.i
+++ b/src/SWIG_files/wrapper/AIS.i
@@ -644,6 +644,11 @@ class AIS {
 };
 
 
+%extend AIS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_AttributeFilter;
 class AIS_AttributeFilter : public SelectMgr_Filter {
 	public:
@@ -766,6 +771,11 @@ class Handle_AIS_AttributeFilter : public Handle_SelectMgr_Filter {
     }
 };
 
+%extend AIS_AttributeFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_BadEdgeFilter;
 class AIS_BadEdgeFilter : public SelectMgr_Filter {
 	public:
@@ -862,6 +872,11 @@ class Handle_AIS_BadEdgeFilter : public Handle_SelectMgr_Filter {
     }
 };
 
+%extend AIS_BadEdgeFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_C0RegularityFilter;
 class AIS_C0RegularityFilter : public SelectMgr_Filter {
 	public:
@@ -932,6 +947,11 @@ class Handle_AIS_C0RegularityFilter : public Handle_SelectMgr_Filter {
     }
 };
 
+%extend AIS_C0RegularityFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapIteratorOfDataMapOfILC;
 class AIS_DataMapIteratorOfDataMapOfILC : public TCollection_BasicMapIterator {
 	public:
@@ -962,6 +982,11 @@ class AIS_DataMapIteratorOfDataMapOfILC : public TCollection_BasicMapIterator {
 };
 
 
+%extend AIS_DataMapIteratorOfDataMapOfILC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapIteratorOfDataMapOfIOStatus;
 class AIS_DataMapIteratorOfDataMapOfIOStatus : public TCollection_BasicMapIterator {
 	public:
@@ -992,6 +1017,11 @@ class AIS_DataMapIteratorOfDataMapOfIOStatus : public TCollection_BasicMapIterat
 };
 
 
+%extend AIS_DataMapIteratorOfDataMapOfIOStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapIteratorOfDataMapOfSelStat;
 class AIS_DataMapIteratorOfDataMapOfSelStat : public TCollection_BasicMapIterator {
 	public:
@@ -1022,6 +1052,11 @@ class AIS_DataMapIteratorOfDataMapOfSelStat : public TCollection_BasicMapIterato
 };
 
 
+%extend AIS_DataMapIteratorOfDataMapOfSelStat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapIteratorOfDataMapofIntegerListOfinteractive;
 class AIS_DataMapIteratorOfDataMapofIntegerListOfinteractive : public TCollection_BasicMapIterator {
 	public:
@@ -1052,6 +1087,11 @@ class AIS_DataMapIteratorOfDataMapofIntegerListOfinteractive : public TCollectio
 };
 
 
+%extend AIS_DataMapIteratorOfDataMapofIntegerListOfinteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapNodeOfDataMapOfILC;
 class AIS_DataMapNodeOfDataMapOfILC : public TCollection_MapNode {
 	public:
@@ -1131,6 +1171,11 @@ class Handle_AIS_DataMapNodeOfDataMapOfILC : public Handle_TCollection_MapNode {
     }
 };
 
+%extend AIS_DataMapNodeOfDataMapOfILC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapNodeOfDataMapOfIOStatus;
 class AIS_DataMapNodeOfDataMapOfIOStatus : public TCollection_MapNode {
 	public:
@@ -1201,6 +1246,11 @@ class Handle_AIS_DataMapNodeOfDataMapOfIOStatus : public Handle_TCollection_MapN
     }
 };
 
+%extend AIS_DataMapNodeOfDataMapOfIOStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapNodeOfDataMapOfSelStat;
 class AIS_DataMapNodeOfDataMapOfSelStat : public TCollection_MapNode {
 	public:
@@ -1271,6 +1321,11 @@ class Handle_AIS_DataMapNodeOfDataMapOfSelStat : public Handle_TCollection_MapNo
     }
 };
 
+%extend AIS_DataMapNodeOfDataMapOfSelStat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapNodeOfDataMapofIntegerListOfinteractive;
 class AIS_DataMapNodeOfDataMapofIntegerListOfinteractive : public TCollection_MapNode {
 	public:
@@ -1350,6 +1405,11 @@ class Handle_AIS_DataMapNodeOfDataMapofIntegerListOfinteractive : public Handle_
     }
 };
 
+%extend AIS_DataMapNodeOfDataMapofIntegerListOfinteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapOfILC;
 class AIS_DataMapOfILC : public TCollection_BasicMap {
 	public:
@@ -1428,6 +1488,11 @@ class AIS_DataMapOfILC : public TCollection_BasicMap {
 };
 
 
+%extend AIS_DataMapOfILC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapOfIOStatus;
 class AIS_DataMapOfIOStatus : public TCollection_BasicMap {
 	public:
@@ -1506,6 +1571,11 @@ class AIS_DataMapOfIOStatus : public TCollection_BasicMap {
 };
 
 
+%extend AIS_DataMapOfIOStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapOfSelStat;
 class AIS_DataMapOfSelStat : public TCollection_BasicMap {
 	public:
@@ -1584,6 +1654,11 @@ class AIS_DataMapOfSelStat : public TCollection_BasicMap {
 };
 
 
+%extend AIS_DataMapOfSelStat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DataMapofIntegerListOfinteractive;
 class AIS_DataMapofIntegerListOfinteractive : public TCollection_BasicMap {
 	public:
@@ -1662,6 +1737,11 @@ class AIS_DataMapofIntegerListOfinteractive : public TCollection_BasicMap {
 };
 
 
+%extend AIS_DataMapofIntegerListOfinteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DimensionOwner;
 class AIS_DimensionOwner : public SelectMgr_EntityOwner {
 	public:
@@ -1768,6 +1848,11 @@ class Handle_AIS_DimensionOwner : public Handle_SelectMgr_EntityOwner {
     }
 };
 
+%extend AIS_DimensionOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Drawer;
 class AIS_Drawer : public Prs3d_Drawer {
 	public:
@@ -2344,6 +2429,11 @@ class Handle_AIS_Drawer : public Handle_Prs3d_Drawer {
     }
 };
 
+%extend AIS_Drawer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ExclusionFilter;
 class AIS_ExclusionFilter : public SelectMgr_Filter {
 	public:
@@ -2496,6 +2586,11 @@ class Handle_AIS_ExclusionFilter : public Handle_SelectMgr_Filter {
     }
 };
 
+%extend AIS_ExclusionFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_GlobalStatus;
 class AIS_GlobalStatus : public MMgt_TShared {
 	public:
@@ -2668,6 +2763,11 @@ class Handle_AIS_GlobalStatus : public Handle_MMgt_TShared {
     }
 };
 
+%extend AIS_GlobalStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class AIS_GraphicTool {
 	public:
 		%feature("compactdefaultargs") GetLineColor;
@@ -2741,6 +2841,11 @@ class AIS_GraphicTool {
 };
 
 
+%extend AIS_GraphicTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_IndexedDataMapNodeOfIndexedDataMapOfOwnerPrs;
 class AIS_IndexedDataMapNodeOfIndexedDataMapOfOwnerPrs : public TCollection_MapNode {
 	public:
@@ -2832,6 +2937,11 @@ class Handle_AIS_IndexedDataMapNodeOfIndexedDataMapOfOwnerPrs : public Handle_TC
     }
 };
 
+%extend AIS_IndexedDataMapNodeOfIndexedDataMapOfOwnerPrs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_IndexedDataMapOfOwnerPrs;
 class AIS_IndexedDataMapOfOwnerPrs : public TCollection_BasicMap {
 	public:
@@ -2942,6 +3052,11 @@ class AIS_IndexedDataMapOfOwnerPrs : public TCollection_BasicMap {
 };
 
 
+%extend AIS_IndexedDataMapOfOwnerPrs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_InteractiveContext;
 class AIS_InteractiveContext : public MMgt_TShared {
 	public:
@@ -4898,6 +5013,11 @@ class Handle_AIS_InteractiveContext : public Handle_MMgt_TShared {
     }
 };
 
+%extend AIS_InteractiveContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_InteractiveObject;
 class AIS_InteractiveObject : public SelectMgr_SelectableObject {
 	public:
@@ -5390,6 +5510,11 @@ class Handle_AIS_InteractiveObject : public Handle_SelectMgr_SelectableObject {
     }
 };
 
+%extend AIS_InteractiveObject {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ListIteratorOfListOfInteractive;
 class AIS_ListIteratorOfListOfInteractive {
 	public:
@@ -5424,6 +5549,11 @@ class AIS_ListIteratorOfListOfInteractive {
 };
 
 
+%extend AIS_ListIteratorOfListOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ListNodeOfListOfInteractive;
 class AIS_ListNodeOfListOfInteractive : public TCollection_MapNode {
 	public:
@@ -5488,6 +5618,11 @@ class Handle_AIS_ListNodeOfListOfInteractive : public Handle_TCollection_MapNode
     }
 };
 
+%extend AIS_ListNodeOfListOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ListOfInteractive;
 class AIS_ListOfInteractive {
 	public:
@@ -5618,6 +5753,11 @@ class AIS_ListOfInteractive {
 };
 
 
+%extend AIS_ListOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_LocalContext;
 class AIS_LocalContext : public MMgt_TShared {
 	public:
@@ -6402,6 +6542,11 @@ class Handle_AIS_LocalContext : public Handle_MMgt_TShared {
     }
 };
 
+%extend AIS_LocalContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_LocalStatus;
 class AIS_LocalStatus : public MMgt_TShared {
 	public:
@@ -6586,6 +6731,11 @@ class Handle_AIS_LocalStatus : public Handle_MMgt_TShared {
     }
 };
 
+%extend AIS_LocalStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MapIteratorOfMapOfInteractive;
 class AIS_MapIteratorOfMapOfInteractive : public TCollection_BasicMapIterator {
 	public:
@@ -6612,6 +6762,11 @@ class AIS_MapIteratorOfMapOfInteractive : public TCollection_BasicMapIterator {
 };
 
 
+%extend AIS_MapIteratorOfMapOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MapOfInteractive;
 class AIS_MapOfInteractive : public TCollection_BasicMap {
 	public:
@@ -6670,6 +6825,11 @@ class AIS_MapOfInteractive : public TCollection_BasicMap {
 };
 
 
+%extend AIS_MapOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Selection;
 class AIS_Selection : public MMgt_TShared {
 	public:
@@ -6854,6 +7014,11 @@ class Handle_AIS_Selection : public Handle_MMgt_TShared {
     }
 };
 
+%extend AIS_Selection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SequenceNodeOfSequenceOfDimension;
 class AIS_SequenceNodeOfSequenceOfDimension : public TCollection_SeqNode {
 	public:
@@ -6920,6 +7085,11 @@ class Handle_AIS_SequenceNodeOfSequenceOfDimension : public Handle_TCollection_S
     }
 };
 
+%extend AIS_SequenceNodeOfSequenceOfDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SequenceNodeOfSequenceOfInteractive;
 class AIS_SequenceNodeOfSequenceOfInteractive : public TCollection_SeqNode {
 	public:
@@ -6986,6 +7156,11 @@ class Handle_AIS_SequenceNodeOfSequenceOfInteractive : public Handle_TCollection
     }
 };
 
+%extend AIS_SequenceNodeOfSequenceOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SequenceOfDimension;
 class AIS_SequenceOfDimension : public TCollection_BaseSequence {
 	public:
@@ -7124,6 +7299,11 @@ class AIS_SequenceOfDimension : public TCollection_BaseSequence {
 };
 
 
+%extend AIS_SequenceOfDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SequenceOfInteractive;
 class AIS_SequenceOfInteractive : public TCollection_BaseSequence {
 	public:
@@ -7262,6 +7442,11 @@ class AIS_SequenceOfInteractive : public TCollection_BaseSequence {
 };
 
 
+%extend AIS_SequenceOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_StdMapNodeOfMapOfInteractive;
 class AIS_StdMapNodeOfMapOfInteractive : public TCollection_MapNode {
 	public:
@@ -7326,6 +7511,11 @@ class Handle_AIS_StdMapNodeOfMapOfInteractive : public Handle_TCollection_MapNod
     }
 };
 
+%extend AIS_StdMapNodeOfMapOfInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_TypeFilter;
 class AIS_TypeFilter : public SelectMgr_Filter {
 	public:
@@ -7394,6 +7584,11 @@ class Handle_AIS_TypeFilter : public Handle_SelectMgr_Filter {
     }
 };
 
+%extend AIS_TypeFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Axis;
 class AIS_Axis : public AIS_InteractiveObject {
 	public:
@@ -7584,6 +7779,11 @@ class Handle_AIS_Axis : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Axis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Circle;
 class AIS_Circle : public AIS_InteractiveObject {
 	public:
@@ -7770,6 +7970,11 @@ class Handle_AIS_Circle : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Circle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ColoredDrawer;
 class AIS_ColoredDrawer : public AIS_Drawer {
 	public:
@@ -7875,6 +8080,11 @@ class Handle_AIS_ColoredDrawer : public Handle_AIS_Drawer {
     }
 };
 
+%extend AIS_ColoredDrawer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ConnectedInteractive;
 class AIS_ConnectedInteractive : public AIS_InteractiveObject {
 	public:
@@ -7989,6 +8199,11 @@ class Handle_AIS_ConnectedInteractive : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_ConnectedInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Dimension;
 class AIS_Dimension : public AIS_InteractiveObject {
 	public:
@@ -8240,6 +8455,11 @@ class Handle_AIS_Dimension : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Dimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Line;
 class AIS_Line : public AIS_InteractiveObject {
 	public:
@@ -8402,6 +8622,11 @@ class Handle_AIS_Line : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MultipleConnectedInteractive;
 class AIS_MultipleConnectedInteractive : public AIS_InteractiveObject {
 	public:
@@ -8546,6 +8771,11 @@ class Handle_AIS_MultipleConnectedInteractive : public Handle_AIS_InteractiveObj
     }
 };
 
+%extend AIS_MultipleConnectedInteractive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Plane;
 class AIS_Plane : public AIS_InteractiveObject {
 	public:
@@ -8852,6 +9082,11 @@ class Handle_AIS_Plane : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_PlaneTrihedron;
 class AIS_PlaneTrihedron : public AIS_InteractiveObject {
 	public:
@@ -9014,6 +9249,11 @@ class Handle_AIS_PlaneTrihedron : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_PlaneTrihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Point;
 class AIS_Point : public AIS_InteractiveObject {
 	public:
@@ -9166,6 +9406,11 @@ class Handle_AIS_Point : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_PointCloud;
 class AIS_PointCloud : public AIS_InteractiveObject {
 	public:
@@ -9308,6 +9553,11 @@ class Handle_AIS_PointCloud : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_PointCloud {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Relation;
 class AIS_Relation : public AIS_InteractiveObject {
 	public:
@@ -9556,6 +9806,11 @@ class Handle_AIS_Relation : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Relation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Shape;
 class AIS_Shape : public AIS_InteractiveObject {
 	public:
@@ -9896,6 +10151,11 @@ class Handle_AIS_Shape : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Shape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SignatureFilter;
 class AIS_SignatureFilter : public AIS_TypeFilter {
 	public:
@@ -9966,6 +10226,11 @@ class Handle_AIS_SignatureFilter : public Handle_AIS_TypeFilter {
     }
 };
 
+%extend AIS_SignatureFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Triangulation;
 class AIS_Triangulation : public AIS_InteractiveObject {
 	public:
@@ -10052,6 +10317,11 @@ class Handle_AIS_Triangulation : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Triangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Trihedron;
 class AIS_Trihedron : public AIS_InteractiveObject {
 	public:
@@ -10300,6 +10570,11 @@ class Handle_AIS_Trihedron : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend AIS_Trihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_AngleDimension;
 class AIS_AngleDimension : public AIS_Dimension {
 	public:
@@ -10552,6 +10827,11 @@ class Handle_AIS_AngleDimension : public Handle_AIS_Dimension {
     }
 };
 
+%extend AIS_AngleDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Chamf2dDimension;
 class AIS_Chamf2dDimension : public AIS_Relation {
 	public:
@@ -10662,6 +10942,11 @@ class Handle_AIS_Chamf2dDimension : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_Chamf2dDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_Chamf3dDimension;
 class AIS_Chamf3dDimension : public AIS_Relation {
 	public:
@@ -10768,6 +11053,11 @@ class Handle_AIS_Chamf3dDimension : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_Chamf3dDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ColoredShape;
 class AIS_ColoredShape : public AIS_Shape {
 	public:
@@ -10910,6 +11200,11 @@ class Handle_AIS_ColoredShape : public Handle_AIS_Shape {
     }
 };
 
+%extend AIS_ColoredShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ConcentricRelation;
 class AIS_ConcentricRelation : public AIS_Relation {
 	public:
@@ -10986,6 +11281,11 @@ class Handle_AIS_ConcentricRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_ConcentricRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_DiameterDimension;
 class AIS_DiameterDimension : public AIS_Dimension {
 	public:
@@ -11142,6 +11442,11 @@ class Handle_AIS_DiameterDimension : public Handle_AIS_Dimension {
     }
 };
 
+%extend AIS_DiameterDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_EllipseRadiusDimension;
 class AIS_EllipseRadiusDimension : public AIS_Relation {
 	public:
@@ -11206,6 +11511,11 @@ class Handle_AIS_EllipseRadiusDimension : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_EllipseRadiusDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_EqualDistanceRelation;
 class AIS_EqualDistanceRelation : public AIS_Relation {
 	public:
@@ -11424,6 +11734,11 @@ class Handle_AIS_EqualDistanceRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_EqualDistanceRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_EqualRadiusRelation;
 class AIS_EqualRadiusRelation : public AIS_Relation {
 	public:
@@ -11500,6 +11815,11 @@ class Handle_AIS_EqualRadiusRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_EqualRadiusRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_FixRelation;
 class AIS_FixRelation : public AIS_Relation {
 	public:
@@ -11636,6 +11956,11 @@ class Handle_AIS_FixRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_FixRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_IdenticRelation;
 class AIS_IdenticRelation : public AIS_Relation {
 	public:
@@ -11718,6 +12043,11 @@ class Handle_AIS_IdenticRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_IdenticRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_LengthDimension;
 class AIS_LengthDimension : public AIS_Dimension {
 	public:
@@ -11934,6 +12264,11 @@ class Handle_AIS_LengthDimension : public Handle_AIS_Dimension {
     }
 };
 
+%extend AIS_LengthDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MidPointRelation;
 class AIS_MidPointRelation : public AIS_Relation {
 	public:
@@ -12024,6 +12359,11 @@ class Handle_AIS_MidPointRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_MidPointRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_OffsetDimension;
 class AIS_OffsetDimension : public AIS_Relation {
 	public:
@@ -12122,6 +12462,11 @@ class Handle_AIS_OffsetDimension : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_OffsetDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_ParallelRelation;
 class AIS_ParallelRelation : public AIS_Relation {
 	public:
@@ -12222,6 +12567,11 @@ class Handle_AIS_ParallelRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_ParallelRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_PerpendicularRelation;
 class AIS_PerpendicularRelation : public AIS_Relation {
 	public:
@@ -12308,6 +12658,11 @@ class Handle_AIS_PerpendicularRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_PerpendicularRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_RadiusDimension;
 class AIS_RadiusDimension : public AIS_Dimension {
 	public:
@@ -12464,6 +12819,11 @@ class Handle_AIS_RadiusDimension : public Handle_AIS_Dimension {
     }
 };
 
+%extend AIS_RadiusDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_SymmetricRelation;
 class AIS_SymmetricRelation : public AIS_Relation {
 	public:
@@ -12562,6 +12922,11 @@ class Handle_AIS_SymmetricRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_SymmetricRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_TangentRelation;
 class AIS_TangentRelation : public AIS_Relation {
 	public:
@@ -12654,6 +13019,11 @@ class Handle_AIS_TangentRelation : public Handle_AIS_Relation {
     }
 };
 
+%extend AIS_TangentRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_TexturedShape;
 class AIS_TexturedShape : public AIS_Shape {
 	public:
@@ -12902,6 +13272,11 @@ class Handle_AIS_TexturedShape : public Handle_AIS_Shape {
     }
 };
 
+%extend AIS_TexturedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MaxRadiusDimension;
 class AIS_MaxRadiusDimension : public AIS_EllipseRadiusDimension {
 	public:
@@ -12996,6 +13371,11 @@ class Handle_AIS_MaxRadiusDimension : public Handle_AIS_EllipseRadiusDimension {
     }
 };
 
+%extend AIS_MaxRadiusDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AIS_MinRadiusDimension;
 class AIS_MinRadiusDimension : public AIS_EllipseRadiusDimension {
 	public:
@@ -13090,3 +13470,8 @@ class Handle_AIS_MinRadiusDimension : public Handle_AIS_EllipseRadiusDimension {
     }
 };
 
+%extend AIS_MinRadiusDimension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Adaptor2d.i
+++ b/src/SWIG_files/wrapper/Adaptor2d.i
@@ -252,6 +252,11 @@ class Adaptor2d_Curve2d {
 };
 
 
+%extend Adaptor2d_Curve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor2d_HCurve2d;
 class Adaptor2d_HCurve2d : public MMgt_TShared {
 	public:
@@ -472,6 +477,11 @@ class Handle_Adaptor2d_HCurve2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Adaptor2d_HCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor2d_HLine2d;
 class Adaptor2d_HLine2d : public Adaptor2d_HCurve2d {
 	public:
@@ -548,6 +558,11 @@ class Handle_Adaptor2d_HLine2d : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend Adaptor2d_HLine2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor2d_Line2d;
 class Adaptor2d_Line2d : public Adaptor2d_Curve2d {
 	public:
@@ -752,3 +767,8 @@ class Adaptor2d_Line2d : public Adaptor2d_Curve2d {
 };
 
 
+%extend Adaptor2d_Line2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Adaptor3d.i
+++ b/src/SWIG_files/wrapper/Adaptor3d.i
@@ -250,6 +250,11 @@ class Adaptor3d_Curve {
 };
 
 
+%extend Adaptor3d_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HCurve;
 class Adaptor3d_HCurve : public MMgt_TShared {
 	public:
@@ -478,6 +483,11 @@ class Handle_Adaptor3d_HCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend Adaptor3d_HCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HOffsetCurve;
 class Adaptor3d_HOffsetCurve : public Adaptor2d_HCurve2d {
 	public:
@@ -554,6 +564,11 @@ class Handle_Adaptor3d_HOffsetCurve : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend Adaptor3d_HOffsetCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HSurface;
 class Adaptor3d_HSurface : public MMgt_TShared {
 	public:
@@ -896,6 +911,11 @@ class Handle_Adaptor3d_HSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend Adaptor3d_HSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Adaptor3d_HSurfaceTool {
 	public:
 		%feature("compactdefaultargs") FirstUParameter;
@@ -1255,6 +1275,11 @@ class Adaptor3d_HSurfaceTool {
 };
 
 
+%extend Adaptor3d_HSurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HVertex;
 class Adaptor3d_HVertex : public MMgt_TShared {
 	public:
@@ -1349,6 +1374,11 @@ class Handle_Adaptor3d_HVertex : public Handle_MMgt_TShared {
     }
 };
 
+%extend Adaptor3d_HVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_InterFunc;
 class Adaptor3d_InterFunc : public math_FunctionWithDerivative {
 	public:
@@ -1399,6 +1429,11 @@ class Adaptor3d_InterFunc : public math_FunctionWithDerivative {
 };
 
 
+%extend Adaptor3d_InterFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_OffsetCurve;
 class Adaptor3d_OffsetCurve : public Adaptor2d_Curve2d {
 	public:
@@ -1661,6 +1696,11 @@ class Adaptor3d_OffsetCurve : public Adaptor2d_Curve2d {
 };
 
 
+%extend Adaptor3d_OffsetCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Adaptor3d_Surface {
 	public:
 		%feature("compactdefaultargs") Delete;
@@ -1984,6 +2024,11 @@ class Adaptor3d_Surface {
 };
 
 
+%extend Adaptor3d_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_TopolTool;
 class Adaptor3d_TopolTool : public MMgt_TShared {
 	public:
@@ -2256,6 +2301,11 @@ class Handle_Adaptor3d_TopolTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend Adaptor3d_TopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_CurveOnSurface;
 class Adaptor3d_CurveOnSurface : public Adaptor3d_Curve {
 	public:
@@ -2496,6 +2546,11 @@ class Adaptor3d_CurveOnSurface : public Adaptor3d_Curve {
 };
 
 
+%extend Adaptor3d_CurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HCurveOnSurface;
 class Adaptor3d_HCurveOnSurface : public Adaptor3d_HCurve {
 	public:
@@ -2576,6 +2631,11 @@ class Handle_Adaptor3d_HCurveOnSurface : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend Adaptor3d_HCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HIsoCurve;
 class Adaptor3d_HIsoCurve : public Adaptor3d_HCurve {
 	public:
@@ -2656,6 +2716,11 @@ class Handle_Adaptor3d_HIsoCurve : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend Adaptor3d_HIsoCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HSurfaceOfLinearExtrusion;
 class Adaptor3d_HSurfaceOfLinearExtrusion : public Adaptor3d_HSurface {
 	public:
@@ -2732,6 +2797,11 @@ class Handle_Adaptor3d_HSurfaceOfLinearExtrusion : public Handle_Adaptor3d_HSurf
     }
 };
 
+%extend Adaptor3d_HSurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_HSurfaceOfRevolution;
 class Adaptor3d_HSurfaceOfRevolution : public Adaptor3d_HSurface {
 	public:
@@ -2808,6 +2878,11 @@ class Handle_Adaptor3d_HSurfaceOfRevolution : public Handle_Adaptor3d_HSurface {
     }
 };
 
+%extend Adaptor3d_HSurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_IsoCurve;
 class Adaptor3d_IsoCurve : public Adaptor3d_Curve {
 	public:
@@ -3082,6 +3157,11 @@ class Adaptor3d_IsoCurve : public Adaptor3d_Curve {
 };
 
 
+%extend Adaptor3d_IsoCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_SurfaceOfLinearExtrusion;
 class Adaptor3d_SurfaceOfLinearExtrusion : public Adaptor3d_Surface {
 	public:
@@ -3434,6 +3514,11 @@ class Adaptor3d_SurfaceOfLinearExtrusion : public Adaptor3d_Surface {
 };
 
 
+%extend Adaptor3d_SurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Adaptor3d_SurfaceOfRevolution;
 class Adaptor3d_SurfaceOfRevolution : public Adaptor3d_Surface {
 	public:
@@ -3792,3 +3877,8 @@ class Adaptor3d_SurfaceOfRevolution : public Adaptor3d_Surface {
 };
 
 
+%extend Adaptor3d_SurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AdvApp2Var.i
+++ b/src/SWIG_files/wrapper/AdvApp2Var.i
@@ -296,6 +296,11 @@ class AdvApp2Var_ApproxAFunc2Var {
         };
 
 
+%extend AdvApp2Var_ApproxAFunc2Var {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_ApproxF2var;
 class AdvApp2Var_ApproxF2var {
 	public:
@@ -688,6 +693,11 @@ class AdvApp2Var_ApproxF2var {
 };
 
 
+%extend AdvApp2Var_ApproxF2var {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Context;
 class AdvApp2Var_Context {
 	public:
@@ -804,6 +814,11 @@ class AdvApp2Var_Context {
 };
 
 
+%extend AdvApp2Var_Context {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Criterion;
 class AdvApp2Var_Criterion {
 	public:
@@ -840,6 +855,11 @@ class AdvApp2Var_Criterion {
 };
 
 
+%extend AdvApp2Var_Criterion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Data;
 class AdvApp2Var_Data {
 	public:
@@ -890,6 +910,11 @@ class AdvApp2Var_Data {
 };
 
 
+%extend AdvApp2Var_Data {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Framework;
 class AdvApp2Var_Framework {
 	public:
@@ -1020,6 +1045,11 @@ class AdvApp2Var_Framework {
 };
 
 
+%extend AdvApp2Var_Framework {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_MathBase;
 class AdvApp2Var_MathBase {
 	public:
@@ -1680,6 +1710,11 @@ class AdvApp2Var_MathBase {
 };
 
 
+%extend AdvApp2Var_MathBase {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Network;
 class AdvApp2Var_Network {
 	public:
@@ -1770,6 +1805,11 @@ class AdvApp2Var_Network {
 };
 
 
+%extend AdvApp2Var_Network {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Node;
 class AdvApp2Var_Node {
 	public:
@@ -1854,6 +1894,11 @@ class AdvApp2Var_Node {
 };
 
 
+%extend AdvApp2Var_Node {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Patch;
 class AdvApp2Var_Patch {
 	public:
@@ -2036,6 +2081,11 @@ class AdvApp2Var_Patch {
 };
 
 
+%extend AdvApp2Var_Patch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceNodeOfSequenceOfNode;
 class AdvApp2Var_SequenceNodeOfSequenceOfNode : public TCollection_SeqNode {
 	public:
@@ -2102,6 +2152,11 @@ class Handle_AdvApp2Var_SequenceNodeOfSequenceOfNode : public Handle_TCollection
     }
 };
 
+%extend AdvApp2Var_SequenceNodeOfSequenceOfNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceNodeOfSequenceOfPatch;
 class AdvApp2Var_SequenceNodeOfSequenceOfPatch : public TCollection_SeqNode {
 	public:
@@ -2168,6 +2223,11 @@ class Handle_AdvApp2Var_SequenceNodeOfSequenceOfPatch : public Handle_TCollectio
     }
 };
 
+%extend AdvApp2Var_SequenceNodeOfSequenceOfPatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceNodeOfSequenceOfStrip;
 class AdvApp2Var_SequenceNodeOfSequenceOfStrip : public TCollection_SeqNode {
 	public:
@@ -2234,6 +2294,11 @@ class Handle_AdvApp2Var_SequenceNodeOfSequenceOfStrip : public Handle_TCollectio
     }
 };
 
+%extend AdvApp2Var_SequenceNodeOfSequenceOfStrip {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceNodeOfStrip;
 class AdvApp2Var_SequenceNodeOfStrip : public TCollection_SeqNode {
 	public:
@@ -2300,6 +2365,11 @@ class Handle_AdvApp2Var_SequenceNodeOfStrip : public Handle_TCollection_SeqNode 
     }
 };
 
+%extend AdvApp2Var_SequenceNodeOfStrip {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceOfNode;
 class AdvApp2Var_SequenceOfNode : public TCollection_BaseSequence {
 	public:
@@ -2438,6 +2508,11 @@ class AdvApp2Var_SequenceOfNode : public TCollection_BaseSequence {
 };
 
 
+%extend AdvApp2Var_SequenceOfNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceOfPatch;
 class AdvApp2Var_SequenceOfPatch : public TCollection_BaseSequence {
 	public:
@@ -2576,6 +2651,11 @@ class AdvApp2Var_SequenceOfPatch : public TCollection_BaseSequence {
 };
 
 
+%extend AdvApp2Var_SequenceOfPatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SequenceOfStrip;
 class AdvApp2Var_SequenceOfStrip : public TCollection_BaseSequence {
 	public:
@@ -2714,6 +2794,11 @@ class AdvApp2Var_SequenceOfStrip : public TCollection_BaseSequence {
 };
 
 
+%extend AdvApp2Var_SequenceOfStrip {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_Strip;
 class AdvApp2Var_Strip : public TCollection_BaseSequence {
 	public:
@@ -2852,6 +2937,11 @@ class AdvApp2Var_Strip : public TCollection_BaseSequence {
 };
 
 
+%extend AdvApp2Var_Strip {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApp2Var_SysBase;
 class AdvApp2Var_SysBase {
 	public:
@@ -3066,3 +3156,8 @@ class AdvApp2Var_SysBase {
 };
 
 
+%extend AdvApp2Var_SysBase {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AdvApprox.i
+++ b/src/SWIG_files/wrapper/AdvApprox.i
@@ -290,6 +290,11 @@ class AdvApprox_ApproxAFunction {
         };
 
 
+%extend AdvApprox_ApproxAFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApprox_Cutting;
 class AdvApprox_Cutting {
 	public:
@@ -310,6 +315,11 @@ class AdvApprox_Cutting {
 };
 
 
+%extend AdvApprox_Cutting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApprox_SimpleApprox;
 class AdvApprox_SimpleApprox {
 	public:
@@ -404,6 +414,11 @@ class AdvApprox_SimpleApprox {
         };
 
 
+%extend AdvApprox_SimpleApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApprox_DichoCutting;
 class AdvApprox_DichoCutting : public AdvApprox_Cutting {
 	public:
@@ -424,6 +439,11 @@ class AdvApprox_DichoCutting : public AdvApprox_Cutting {
 };
 
 
+%extend AdvApprox_DichoCutting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApprox_PrefAndRec;
 class AdvApprox_PrefAndRec : public AdvApprox_Cutting {
 	public:
@@ -452,6 +472,11 @@ class AdvApprox_PrefAndRec : public AdvApprox_Cutting {
 };
 
 
+%extend AdvApprox_PrefAndRec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AdvApprox_PrefCutting;
 class AdvApprox_PrefCutting : public AdvApprox_Cutting {
 	public:
@@ -474,3 +499,8 @@ class AdvApprox_PrefCutting : public AdvApprox_Cutting {
 };
 
 
+%extend AdvApprox_PrefCutting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppBlend.i
+++ b/src/SWIG_files/wrapper/AppBlend.i
@@ -192,3 +192,8 @@ class AppBlend_Approx {
 };
 
 
+%extend AppBlend_Approx {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppCont.i
+++ b/src/SWIG_files/wrapper/AppCont.i
@@ -98,6 +98,11 @@ class AppCont_FitFunction {
 };
 
 
+%extend AppCont_FitFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppCont_FitFunction2d;
 class AppCont_FitFunction2d {
 	public:
@@ -140,6 +145,11 @@ class AppCont_FitFunction2d {
 };
 
 
+%extend AppCont_FitFunction2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppCont_Function;
 class AppCont_Function {
 	public:
@@ -182,6 +192,11 @@ class AppCont_Function {
 };
 
 
+%extend AppCont_Function {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppCont_Function2d;
 class AppCont_Function2d {
 	public:
@@ -224,6 +239,11 @@ class AppCont_Function2d {
 };
 
 
+%extend AppCont_Function2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class AppCont_FunctionTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -329,6 +349,11 @@ class AppCont_FunctionTool {
 };
 
 
+%extend AppCont_FunctionTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class AppCont_FunctionTool2d {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -434,3 +459,8 @@ class AppCont_FunctionTool2d {
 };
 
 
+%extend AppCont_FunctionTool2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppDef.i
+++ b/src/SWIG_files/wrapper/AppDef.i
@@ -138,6 +138,11 @@ class AppDef_Array1OfMultiPointConstraint {
 };
 
 
+%extend AppDef_Array1OfMultiPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_BSpGradient_BFGSOfMyBSplGradientOfBSplineCompute;
 class AppDef_BSpGradient_BFGSOfMyBSplGradientOfBSplineCompute : public math_BFGS {
 	public:
@@ -166,6 +171,11 @@ class AppDef_BSpGradient_BFGSOfMyBSplGradientOfBSplineCompute : public math_BFGS
 };
 
 
+%extend AppDef_BSpGradient_BFGSOfMyBSplGradientOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_BSpParFunctionOfMyBSplGradientOfBSplineCompute;
 class AppDef_BSpParFunctionOfMyBSplGradientOfBSplineCompute : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -286,6 +296,11 @@ class AppDef_BSpParFunctionOfMyBSplGradientOfBSplineCompute : public math_Multip
 };
 
 
+%extend AppDef_BSpParFunctionOfMyBSplGradientOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_BSpParLeastSquareOfMyBSplGradientOfBSplineCompute;
 class AppDef_BSpParLeastSquareOfMyBSplGradientOfBSplineCompute {
 	public:
@@ -482,6 +497,11 @@ class AppDef_BSpParLeastSquareOfMyBSplGradientOfBSplineCompute {
 };
 
 
+%extend AppDef_BSpParLeastSquareOfMyBSplGradientOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_BSplineCompute;
 class AppDef_BSplineCompute {
 	public:
@@ -682,6 +702,11 @@ class AppDef_BSplineCompute {
 };
 
 
+%extend AppDef_BSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_Compute;
 class AppDef_Compute {
 	public:
@@ -872,6 +897,11 @@ class AppDef_Compute {
 };
 
 
+%extend AppDef_Compute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_Gradient_BFGSOfMyGradientOfCompute;
 class AppDef_Gradient_BFGSOfMyGradientOfCompute : public math_BFGS {
 	public:
@@ -900,6 +930,11 @@ class AppDef_Gradient_BFGSOfMyGradientOfCompute : public math_BFGS {
 };
 
 
+%extend AppDef_Gradient_BFGSOfMyGradientOfCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_Gradient_BFGSOfMyGradientbisOfBSplineCompute;
 class AppDef_Gradient_BFGSOfMyGradientbisOfBSplineCompute : public math_BFGS {
 	public:
@@ -928,6 +963,11 @@ class AppDef_Gradient_BFGSOfMyGradientbisOfBSplineCompute : public math_BFGS {
 };
 
 
+%extend AppDef_Gradient_BFGSOfMyGradientbisOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_Gradient_BFGSOfTheGradient;
 class AppDef_Gradient_BFGSOfTheGradient : public math_BFGS {
 	public:
@@ -956,6 +996,11 @@ class AppDef_Gradient_BFGSOfTheGradient : public math_BFGS {
 };
 
 
+%extend AppDef_Gradient_BFGSOfTheGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_HArray1OfMultiPointConstraint;
 class AppDef_HArray1OfMultiPointConstraint : public MMgt_TShared {
 	public:
@@ -1072,6 +1117,11 @@ class Handle_AppDef_HArray1OfMultiPointConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend AppDef_HArray1OfMultiPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_MultiLine;
 class AppDef_MultiLine {
 	public:
@@ -1154,6 +1204,11 @@ class AppDef_MultiLine {
         };
 
 
+%extend AppDef_MultiLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_MultiPointConstraint;
 class AppDef_MultiPointConstraint : public AppParCurves_MultiPoint {
 	public:
@@ -1370,6 +1425,11 @@ class AppDef_MultiPointConstraint : public AppParCurves_MultiPoint {
         };
 
 
+%extend AppDef_MultiPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_MyBSplGradientOfBSplineCompute;
 class AppDef_MyBSplGradientOfBSplineCompute {
 	public:
@@ -1458,6 +1518,11 @@ class AppDef_MyBSplGradientOfBSplineCompute {
 };
 
 
+%extend AppDef_MyBSplGradientOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_MyGradientOfCompute;
 class AppDef_MyGradientOfCompute {
 	public:
@@ -1512,6 +1577,11 @@ class AppDef_MyGradientOfCompute {
 };
 
 
+%extend AppDef_MyGradientOfCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_MyGradientbisOfBSplineCompute;
 class AppDef_MyGradientbisOfBSplineCompute {
 	public:
@@ -1566,6 +1636,11 @@ class AppDef_MyGradientbisOfBSplineCompute {
 };
 
 
+%extend AppDef_MyGradientbisOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class AppDef_MyLineTool {
 	public:
 		%feature("compactdefaultargs") FirstPoint;
@@ -1743,6 +1818,11 @@ class AppDef_MyLineTool {
 };
 
 
+%extend AppDef_MyLineTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParFunctionOfMyGradientOfCompute;
 class AppDef_ParFunctionOfMyGradientOfCompute : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -1835,6 +1915,11 @@ class AppDef_ParFunctionOfMyGradientOfCompute : public math_MultipleVarFunctionW
 };
 
 
+%extend AppDef_ParFunctionOfMyGradientOfCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParFunctionOfMyGradientbisOfBSplineCompute;
 class AppDef_ParFunctionOfMyGradientbisOfBSplineCompute : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -1927,6 +2012,11 @@ class AppDef_ParFunctionOfMyGradientbisOfBSplineCompute : public math_MultipleVa
 };
 
 
+%extend AppDef_ParFunctionOfMyGradientbisOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParFunctionOfTheGradient;
 class AppDef_ParFunctionOfTheGradient : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -2019,6 +2109,11 @@ class AppDef_ParFunctionOfTheGradient : public math_MultipleVarFunctionWithGradi
 };
 
 
+%extend AppDef_ParFunctionOfTheGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParLeastSquareOfMyGradientOfCompute;
 class AppDef_ParLeastSquareOfMyGradientOfCompute {
 	public:
@@ -2215,6 +2310,11 @@ class AppDef_ParLeastSquareOfMyGradientOfCompute {
 };
 
 
+%extend AppDef_ParLeastSquareOfMyGradientOfCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParLeastSquareOfMyGradientbisOfBSplineCompute;
 class AppDef_ParLeastSquareOfMyGradientbisOfBSplineCompute {
 	public:
@@ -2411,6 +2511,11 @@ class AppDef_ParLeastSquareOfMyGradientbisOfBSplineCompute {
 };
 
 
+%extend AppDef_ParLeastSquareOfMyGradientbisOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ParLeastSquareOfTheGradient;
 class AppDef_ParLeastSquareOfTheGradient {
 	public:
@@ -2607,6 +2712,11 @@ class AppDef_ParLeastSquareOfTheGradient {
 };
 
 
+%extend AppDef_ParLeastSquareOfTheGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ResConstraintOfMyGradientOfCompute;
 class AppDef_ResConstraintOfMyGradientOfCompute {
 	public:
@@ -2661,6 +2771,11 @@ class AppDef_ResConstraintOfMyGradientOfCompute {
 };
 
 
+%extend AppDef_ResConstraintOfMyGradientOfCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ResConstraintOfMyGradientbisOfBSplineCompute;
 class AppDef_ResConstraintOfMyGradientbisOfBSplineCompute {
 	public:
@@ -2715,6 +2830,11 @@ class AppDef_ResConstraintOfMyGradientbisOfBSplineCompute {
 };
 
 
+%extend AppDef_ResConstraintOfMyGradientbisOfBSplineCompute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_ResConstraintOfTheGradient;
 class AppDef_ResConstraintOfTheGradient {
 	public:
@@ -2769,6 +2889,11 @@ class AppDef_ResConstraintOfTheGradient {
 };
 
 
+%extend AppDef_ResConstraintOfTheGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_SmoothCriterion;
 class AppDef_SmoothCriterion : public MMgt_TShared {
 	public:
@@ -2957,6 +3082,11 @@ class Handle_AppDef_SmoothCriterion : public Handle_MMgt_TShared {
     }
 };
 
+%extend AppDef_SmoothCriterion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_TheFunction;
 class AppDef_TheFunction : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -3049,6 +3179,11 @@ class AppDef_TheFunction : public math_MultipleVarFunctionWithGradient {
 };
 
 
+%extend AppDef_TheFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_TheGradient;
 class AppDef_TheGradient {
 	public:
@@ -3103,6 +3238,11 @@ class AppDef_TheGradient {
 };
 
 
+%extend AppDef_TheGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_TheLeastSquares;
 class AppDef_TheLeastSquares {
 	public:
@@ -3299,6 +3439,11 @@ class AppDef_TheLeastSquares {
 };
 
 
+%extend AppDef_TheLeastSquares {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_TheResol;
 class AppDef_TheResol {
 	public:
@@ -3353,6 +3498,11 @@ class AppDef_TheResol {
 };
 
 
+%extend AppDef_TheResol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_Variational;
 class AppDef_Variational {
 	public:
@@ -3637,6 +3787,11 @@ class AppDef_Variational {
 };
 
 
+%extend AppDef_Variational {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppDef_LinearCriteria;
 class AppDef_LinearCriteria : public AppDef_SmoothCriterion {
 	public:
@@ -3844,3 +3999,8 @@ class Handle_AppDef_LinearCriteria : public Handle_AppDef_SmoothCriterion {
     }
 };
 
+%extend AppDef_LinearCriteria {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppParCurves.i
+++ b/src/SWIG_files/wrapper/AppParCurves.i
@@ -117,6 +117,11 @@ class AppParCurves {
 };
 
 
+%extend AppParCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_Array1OfConstraintCouple;
 class AppParCurves_Array1OfConstraintCouple {
 	public:
@@ -199,6 +204,11 @@ class AppParCurves_Array1OfConstraintCouple {
 };
 
 
+%extend AppParCurves_Array1OfConstraintCouple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_Array1OfMultiBSpCurve;
 class AppParCurves_Array1OfMultiBSpCurve {
 	public:
@@ -281,6 +291,11 @@ class AppParCurves_Array1OfMultiBSpCurve {
 };
 
 
+%extend AppParCurves_Array1OfMultiBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_Array1OfMultiCurve;
 class AppParCurves_Array1OfMultiCurve {
 	public:
@@ -363,6 +378,11 @@ class AppParCurves_Array1OfMultiCurve {
 };
 
 
+%extend AppParCurves_Array1OfMultiCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_Array1OfMultiPoint;
 class AppParCurves_Array1OfMultiPoint {
 	public:
@@ -445,6 +465,11 @@ class AppParCurves_Array1OfMultiPoint {
 };
 
 
+%extend AppParCurves_Array1OfMultiPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_ConstraintCouple;
 class AppParCurves_ConstraintCouple {
 	public:
@@ -495,6 +520,11 @@ class AppParCurves_ConstraintCouple {
 };
 
 
+%extend AppParCurves_ConstraintCouple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_HArray1OfConstraintCouple;
 class AppParCurves_HArray1OfConstraintCouple : public MMgt_TShared {
 	public:
@@ -611,6 +641,11 @@ class Handle_AppParCurves_HArray1OfConstraintCouple : public Handle_MMgt_TShared
     }
 };
 
+%extend AppParCurves_HArray1OfConstraintCouple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_HArray1OfMultiBSpCurve;
 class AppParCurves_HArray1OfMultiBSpCurve : public MMgt_TShared {
 	public:
@@ -727,6 +762,11 @@ class Handle_AppParCurves_HArray1OfMultiBSpCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend AppParCurves_HArray1OfMultiBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_HArray1OfMultiCurve;
 class AppParCurves_HArray1OfMultiCurve : public MMgt_TShared {
 	public:
@@ -843,6 +883,11 @@ class Handle_AppParCurves_HArray1OfMultiCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend AppParCurves_HArray1OfMultiCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_HArray1OfMultiPoint;
 class AppParCurves_HArray1OfMultiPoint : public MMgt_TShared {
 	public:
@@ -959,6 +1004,11 @@ class Handle_AppParCurves_HArray1OfMultiPoint : public Handle_MMgt_TShared {
     }
 };
 
+%extend AppParCurves_HArray1OfMultiPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_MultiCurve;
 class AppParCurves_MultiCurve {
 	public:
@@ -1211,6 +1261,11 @@ class AppParCurves_MultiCurve {
         };
 
 
+%extend AppParCurves_MultiCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_MultiPoint;
 class AppParCurves_MultiPoint {
 	public:
@@ -1363,6 +1418,11 @@ class AppParCurves_MultiPoint {
         };
 
 
+%extend AppParCurves_MultiPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_SequenceNodeOfSequenceOfMultiBSpCurve;
 class AppParCurves_SequenceNodeOfSequenceOfMultiBSpCurve : public TCollection_SeqNode {
 	public:
@@ -1429,6 +1489,11 @@ class Handle_AppParCurves_SequenceNodeOfSequenceOfMultiBSpCurve : public Handle_
     }
 };
 
+%extend AppParCurves_SequenceNodeOfSequenceOfMultiBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_SequenceNodeOfSequenceOfMultiCurve;
 class AppParCurves_SequenceNodeOfSequenceOfMultiCurve : public TCollection_SeqNode {
 	public:
@@ -1495,6 +1560,11 @@ class Handle_AppParCurves_SequenceNodeOfSequenceOfMultiCurve : public Handle_TCo
     }
 };
 
+%extend AppParCurves_SequenceNodeOfSequenceOfMultiCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_SequenceOfMultiBSpCurve;
 class AppParCurves_SequenceOfMultiBSpCurve : public TCollection_BaseSequence {
 	public:
@@ -1633,6 +1703,11 @@ class AppParCurves_SequenceOfMultiBSpCurve : public TCollection_BaseSequence {
 };
 
 
+%extend AppParCurves_SequenceOfMultiBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_SequenceOfMultiCurve;
 class AppParCurves_SequenceOfMultiCurve : public TCollection_BaseSequence {
 	public:
@@ -1771,6 +1846,11 @@ class AppParCurves_SequenceOfMultiCurve : public TCollection_BaseSequence {
 };
 
 
+%extend AppParCurves_SequenceOfMultiCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor AppParCurves_MultiBSpCurve;
 class AppParCurves_MultiBSpCurve : public AppParCurves_MultiCurve {
 	public:
@@ -1941,3 +2021,8 @@ class AppParCurves_MultiBSpCurve : public AppParCurves_MultiCurve {
         };
 
 
+%extend AppParCurves_MultiBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppStd.i
+++ b/src/SWIG_files/wrapper/AppStd.i
@@ -130,3 +130,8 @@ class Handle_AppStd_Application : public Handle_TDocStd_Application {
     }
 };
 
+%extend AppStd_Application {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/AppStdL.i
+++ b/src/SWIG_files/wrapper/AppStdL.i
@@ -130,3 +130,8 @@ class Handle_AppStdL_Application : public Handle_TDocStd_Application {
     }
 };
 
+%extend AppStdL_Application {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Approx.i
+++ b/src/SWIG_files/wrapper/Approx.i
@@ -150,6 +150,11 @@ class Approx_Array1OfAdHSurface {
 };
 
 
+%extend Approx_Array1OfAdHSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_Array1OfGTrsf2d;
 class Approx_Array1OfGTrsf2d {
 	public:
@@ -232,6 +237,11 @@ class Approx_Array1OfGTrsf2d {
 };
 
 
+%extend Approx_Array1OfGTrsf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_Curve2d;
 class Approx_Curve2d {
 	public:
@@ -278,6 +288,11 @@ class Approx_Curve2d {
 };
 
 
+%extend Approx_Curve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_Curve3d;
 class Approx_Curve3d {
 	public:
@@ -330,6 +345,11 @@ class Approx_Curve3d {
         };
 
 
+%extend Approx_Curve3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_CurveOnSurface;
 class Approx_CurveOnSurface {
 	public:
@@ -390,6 +410,11 @@ class Approx_CurveOnSurface {
 };
 
 
+%extend Approx_CurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_CurvilinearParameter;
 class Approx_CurvilinearParameter {
 	public:
@@ -504,6 +529,11 @@ class Approx_CurvilinearParameter {
         };
 
 
+%extend Approx_CurvilinearParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_CurvlinFunc;
 class Approx_CurvlinFunc : public MMgt_TShared {
 	public:
@@ -712,6 +742,11 @@ class Handle_Approx_CurvlinFunc : public Handle_MMgt_TShared {
     }
 };
 
+%extend Approx_CurvlinFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_FitAndDivide;
 class Approx_FitAndDivide {
 	public:
@@ -824,6 +859,11 @@ class Approx_FitAndDivide {
 };
 
 
+%extend Approx_FitAndDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_FitAndDivide2d;
 class Approx_FitAndDivide2d {
 	public:
@@ -936,6 +976,11 @@ class Approx_FitAndDivide2d {
 };
 
 
+%extend Approx_FitAndDivide2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_HArray1OfAdHSurface;
 class Approx_HArray1OfAdHSurface : public MMgt_TShared {
 	public:
@@ -1052,6 +1097,11 @@ class Handle_Approx_HArray1OfAdHSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend Approx_HArray1OfAdHSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_HArray1OfGTrsf2d;
 class Approx_HArray1OfGTrsf2d : public MMgt_TShared {
 	public:
@@ -1168,6 +1218,11 @@ class Handle_Approx_HArray1OfGTrsf2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Approx_HArray1OfGTrsf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_MCurvesToBSpCurve;
 class Approx_MCurvesToBSpCurve {
 	public:
@@ -1210,6 +1265,11 @@ class Approx_MCurvesToBSpCurve {
 };
 
 
+%extend Approx_MCurvesToBSpCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_MyLeastSquareOfFitAndDivide;
 class Approx_MyLeastSquareOfFitAndDivide {
 	public:
@@ -1252,6 +1312,11 @@ class Approx_MyLeastSquareOfFitAndDivide {
 };
 
 
+%extend Approx_MyLeastSquareOfFitAndDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_MyLeastSquareOfFitAndDivide2d;
 class Approx_MyLeastSquareOfFitAndDivide2d {
 	public:
@@ -1294,6 +1359,11 @@ class Approx_MyLeastSquareOfFitAndDivide2d {
 };
 
 
+%extend Approx_MyLeastSquareOfFitAndDivide2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_SameParameter;
 class Approx_SameParameter {
 	public:
@@ -1360,6 +1430,11 @@ class Approx_SameParameter {
 };
 
 
+%extend Approx_SameParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_SequenceNodeOfSequenceOfHArray1OfReal;
 class Approx_SequenceNodeOfSequenceOfHArray1OfReal : public TCollection_SeqNode {
 	public:
@@ -1426,6 +1501,11 @@ class Handle_Approx_SequenceNodeOfSequenceOfHArray1OfReal : public Handle_TColle
     }
 };
 
+%extend Approx_SequenceNodeOfSequenceOfHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_SequenceOfHArray1OfReal;
 class Approx_SequenceOfHArray1OfReal : public TCollection_BaseSequence {
 	public:
@@ -1564,6 +1644,11 @@ class Approx_SequenceOfHArray1OfReal : public TCollection_BaseSequence {
 };
 
 
+%extend Approx_SequenceOfHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_SweepApproximation;
 class Approx_SweepApproximation {
 	public:
@@ -1774,6 +1859,11 @@ class Approx_SweepApproximation {
         };
 
 
+%extend Approx_SweepApproximation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Approx_SweepFunction;
 class Approx_SweepFunction : public MMgt_TShared {
 	public:
@@ -2024,3 +2114,8 @@ class Handle_Approx_SweepFunction : public Handle_MMgt_TShared {
     }
 };
 
+%extend Approx_SweepFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ApproxInt.i
+++ b/src/SWIG_files/wrapper/ApproxInt.i
@@ -144,3 +144,8 @@ class ApproxInt_SvSurfaces {
 };
 
 
+%extend ApproxInt_SvSurfaces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Aspect.i
+++ b/src/SWIG_files/wrapper/Aspect.i
@@ -407,6 +407,11 @@ class Aspect {
 };
 
 
+%extend Aspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_Array1OfEdge;
 class Aspect_Array1OfEdge {
 	public:
@@ -489,6 +494,11 @@ class Aspect_Array1OfEdge {
 };
 
 
+%extend Aspect_Array1OfEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_AspectFillArea;
 class Aspect_AspectFillArea : public MMgt_TShared {
 	public:
@@ -635,6 +645,11 @@ class Handle_Aspect_AspectFillArea : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_AspectFillArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_AspectLine;
 class Aspect_AspectLine : public MMgt_TShared {
 	public:
@@ -723,6 +738,11 @@ class Handle_Aspect_AspectLine : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_AspectLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_AspectMarker;
 class Aspect_AspectMarker : public MMgt_TShared {
 	public:
@@ -811,6 +831,11 @@ class Handle_Aspect_AspectMarker : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_AspectMarker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_Background;
 class Aspect_Background {
 	public:
@@ -845,6 +870,11 @@ class Aspect_Background {
 };
 
 
+%extend Aspect_Background {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_ColorScale;
 class Aspect_ColorScale : public MMgt_TShared {
 	public:
@@ -1309,6 +1339,11 @@ class Handle_Aspect_ColorScale : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_ColorScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_Edge;
 class Aspect_Edge {
 	public:
@@ -1375,6 +1410,11 @@ class Aspect_Edge {
 };
 
 
+%extend Aspect_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_GenId;
 class Aspect_GenId {
 	public:
@@ -1441,6 +1481,11 @@ class Aspect_GenId {
 };
 
 
+%extend Aspect_GenId {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_GraphicCallbackStruct;
 class Aspect_GraphicCallbackStruct {
 	public:
@@ -1451,6 +1496,11 @@ class Aspect_GraphicCallbackStruct {
 };
 
 
+%extend Aspect_GraphicCallbackStruct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_Grid;
 class Aspect_Grid : public MMgt_TShared {
 	public:
@@ -1665,6 +1715,11 @@ class Handle_Aspect_Grid : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_Grid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_SequenceNodeOfSequenceOfColor;
 class Aspect_SequenceNodeOfSequenceOfColor : public TCollection_SeqNode {
 	public:
@@ -1731,6 +1786,11 @@ class Handle_Aspect_SequenceNodeOfSequenceOfColor : public Handle_TCollection_Se
     }
 };
 
+%extend Aspect_SequenceNodeOfSequenceOfColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_SequenceOfColor;
 class Aspect_SequenceOfColor : public TCollection_BaseSequence {
 	public:
@@ -1869,6 +1929,11 @@ class Aspect_SequenceOfColor : public TCollection_BaseSequence {
 };
 
 
+%extend Aspect_SequenceOfColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_Window;
 class Aspect_Window : public MMgt_TShared {
 	public:
@@ -2063,6 +2128,11 @@ class Handle_Aspect_Window : public Handle_MMgt_TShared {
     }
 };
 
+%extend Aspect_Window {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_CircularGrid;
 class Aspect_CircularGrid : public Aspect_Grid {
 	public:
@@ -2191,6 +2261,11 @@ class Handle_Aspect_CircularGrid : public Handle_Aspect_Grid {
     }
 };
 
+%extend Aspect_CircularGrid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_GradientBackground;
 class Aspect_GradientBackground : public Aspect_Background {
 	public:
@@ -2243,6 +2318,11 @@ class Aspect_GradientBackground : public Aspect_Background {
 };
 
 
+%extend Aspect_GradientBackground {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Aspect_RectangularGrid;
 class Aspect_RectangularGrid : public Aspect_Grid {
 	public:
@@ -2397,3 +2477,8 @@ class Handle_Aspect_RectangularGrid : public Handle_Aspect_Grid {
     }
 };
 
+%extend Aspect_RectangularGrid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BOPAlgo.i
+++ b/src/SWIG_files/wrapper/BOPAlgo.i
@@ -143,6 +143,11 @@ class BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_Algo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_ArgumentAnalyzer;
 class BOPAlgo_ArgumentAnalyzer {
 	public:
@@ -337,6 +342,11 @@ class BOPAlgo_ArgumentAnalyzer {
 };
 
 
+%extend BOPAlgo_ArgumentAnalyzer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_CheckResult;
 class BOPAlgo_CheckResult {
 	public:
@@ -475,6 +485,11 @@ class BOPAlgo_CheckResult {
 };
 
 
+%extend BOPAlgo_CheckResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_SectionAttribute;
 class BOPAlgo_SectionAttribute {
 	public:
@@ -535,6 +550,11 @@ class BOPAlgo_SectionAttribute {
 };
 
 
+%extend BOPAlgo_SectionAttribute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPAlgo_Tools {
 	public:
 		%feature("compactdefaultargs") MakeBlocksCnx;
@@ -616,6 +636,11 @@ class BOPAlgo_Tools {
 };
 
 
+%extend BOPAlgo_Tools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_WireEdgeSet;
 class BOPAlgo_WireEdgeSet {
 	public:
@@ -666,6 +691,11 @@ class BOPAlgo_WireEdgeSet {
 };
 
 
+%extend BOPAlgo_WireEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_BuilderArea;
 %ignore BOPAlgo_BuilderArea::~BOPAlgo_BuilderArea();
 class BOPAlgo_BuilderArea : public BOPAlgo_Algo {
@@ -697,6 +727,11 @@ class BOPAlgo_BuilderArea : public BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_BuilderArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_BuilderShape;
 %ignore BOPAlgo_BuilderShape::~BOPAlgo_BuilderShape();
 class BOPAlgo_BuilderShape : public BOPAlgo_Algo {
@@ -756,6 +791,11 @@ class BOPAlgo_BuilderShape : public BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_BuilderShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_PaveFiller;
 class BOPAlgo_PaveFiller : public BOPAlgo_Algo {
 	public:
@@ -804,6 +844,11 @@ class BOPAlgo_PaveFiller : public BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_PaveFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_ShellSplitter;
 class BOPAlgo_ShellSplitter : public BOPAlgo_Algo {
 	public:
@@ -856,6 +901,11 @@ class BOPAlgo_ShellSplitter : public BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_ShellSplitter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_WireSplitter;
 class BOPAlgo_WireSplitter : public BOPAlgo_Algo {
 	public:
@@ -902,6 +952,11 @@ class BOPAlgo_WireSplitter : public BOPAlgo_Algo {
 };
 
 
+%extend BOPAlgo_WireSplitter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_Builder;
 class BOPAlgo_Builder : public BOPAlgo_BuilderShape {
 	public:
@@ -1008,6 +1063,11 @@ class BOPAlgo_Builder : public BOPAlgo_BuilderShape {
 };
 
 
+%extend BOPAlgo_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_BuilderFace;
 class BOPAlgo_BuilderFace : public BOPAlgo_BuilderArea {
 	public:
@@ -1048,6 +1108,11 @@ class BOPAlgo_BuilderFace : public BOPAlgo_BuilderArea {
 };
 
 
+%extend BOPAlgo_BuilderFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_BuilderSolid;
 class BOPAlgo_BuilderSolid : public BOPAlgo_BuilderArea {
 	public:
@@ -1084,6 +1149,11 @@ class BOPAlgo_BuilderSolid : public BOPAlgo_BuilderArea {
 };
 
 
+%extend BOPAlgo_BuilderSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_CheckerSI;
 class BOPAlgo_CheckerSI : public BOPAlgo_PaveFiller {
 	public:
@@ -1120,6 +1190,11 @@ class BOPAlgo_CheckerSI : public BOPAlgo_PaveFiller {
 };
 
 
+%extend BOPAlgo_CheckerSI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_BOP;
 class BOPAlgo_BOP : public BOPAlgo_Builder {
 	public:
@@ -1166,6 +1241,11 @@ class BOPAlgo_BOP : public BOPAlgo_Builder {
 };
 
 
+%extend BOPAlgo_BOP {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_MakerVolume;
 class BOPAlgo_MakerVolume : public BOPAlgo_Builder {
 	public:
@@ -1224,6 +1304,11 @@ class BOPAlgo_MakerVolume : public BOPAlgo_Builder {
 };
 
 
+%extend BOPAlgo_MakerVolume {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPAlgo_Section;
 class BOPAlgo_Section : public BOPAlgo_Builder {
 	public:
@@ -1256,3 +1341,8 @@ class BOPAlgo_Section : public BOPAlgo_Builder {
 };
 
 
+%extend BOPAlgo_Section {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BOPCol.i
+++ b/src/SWIG_files/wrapper/BOPCol.i
@@ -141,6 +141,11 @@ class BOPCol_Box2DBndTreeSelector : public BOPCol_Box2DBndTree::Selector {
 };
 
 
+%extend BOPCol_Box2DBndTreeSelector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPCol_BoxBndTreeSelector;
 class BOPCol_BoxBndTreeSelector : public BOPCol_BoxBndTree::Selector {
 	public:
@@ -177,3 +182,8 @@ class BOPCol_BoxBndTreeSelector : public BOPCol_BoxBndTree::Selector {
 };
 
 
+%extend BOPCol_BoxBndTreeSelector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BOPDS.i
+++ b/src/SWIG_files/wrapper/BOPDS.i
@@ -281,6 +281,11 @@ class Handle_BOPDS_CommonBlock : public Handle_MMgt_TShared {
     }
 };
 
+%extend BOPDS_CommonBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_CoupleOfPaveBlocks;
 class BOPDS_CoupleOfPaveBlocks {
 	public:
@@ -379,6 +384,11 @@ class BOPDS_CoupleOfPaveBlocks {
 };
 
 
+%extend BOPDS_CoupleOfPaveBlocks {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_Curve;
 class BOPDS_Curve {
 	public:
@@ -481,6 +491,11 @@ class BOPDS_Curve {
 };
 
 
+%extend BOPDS_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_DS;
 class BOPDS_DS {
 	public:
@@ -1031,6 +1046,11 @@ class BOPDS_DS {
 };
 
 
+%extend BOPDS_DS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_FaceInfo;
 class BOPDS_FaceInfo {
 	public:
@@ -1141,6 +1161,11 @@ class BOPDS_FaceInfo {
 };
 
 
+%extend BOPDS_FaceInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_IndexRange;
 class BOPDS_IndexRange {
 	public:
@@ -1213,6 +1238,11 @@ class BOPDS_IndexRange {
 };
 
 
+%extend BOPDS_IndexRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_Iterator;
 class BOPDS_Iterator {
 	public:
@@ -1313,6 +1343,11 @@ class BOPDS_Iterator {
 };
 
 
+%extend BOPDS_Iterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_PassKey;
 class BOPDS_PassKey {
 	public:
@@ -1457,6 +1492,11 @@ class BOPDS_PassKey {
 };
 
 
+%extend BOPDS_PassKey {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPDS_PassKeyMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -1478,6 +1518,11 @@ class BOPDS_PassKeyMapHasher {
 };
 
 
+%extend BOPDS_PassKeyMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_Pave;
 class BOPDS_Pave {
 	public:
@@ -1568,6 +1613,11 @@ class BOPDS_Pave {
 };
 
 
+%extend BOPDS_Pave {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_PaveBlock;
 class BOPDS_PaveBlock : public MMgt_TShared {
 	public:
@@ -1826,6 +1876,11 @@ class Handle_BOPDS_PaveBlock : public Handle_MMgt_TShared {
     }
 };
 
+%extend BOPDS_PaveBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPDS_PaveMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -1847,6 +1902,11 @@ class BOPDS_PaveMapHasher {
 };
 
 
+%extend BOPDS_PaveMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_Point;
 class BOPDS_Point {
 	public:
@@ -1915,6 +1975,11 @@ class BOPDS_Point {
 };
 
 
+%extend BOPDS_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_ShapeInfo;
 class BOPDS_ShapeInfo {
 	public:
@@ -2065,6 +2130,11 @@ class BOPDS_ShapeInfo {
 };
 
 
+%extend BOPDS_ShapeInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_SubIterator;
 class BOPDS_SubIterator {
 	public:
@@ -2161,6 +2231,11 @@ class BOPDS_SubIterator {
 };
 
 
+%extend BOPDS_SubIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPDS_Tools {
 	public:
 		%feature("compactdefaultargs") TypeToInteger;
@@ -2200,6 +2275,11 @@ class BOPDS_Tools {
 };
 
 
+%extend BOPDS_Tools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfEE;
 class BOPDS_InterfEE : public BOPDS_Interf {
 	public:
@@ -2234,6 +2314,11 @@ class BOPDS_InterfEE : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfEE {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfEF;
 class BOPDS_InterfEF : public BOPDS_Interf {
 	public:
@@ -2268,6 +2353,11 @@ class BOPDS_InterfEF : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfEF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfEZ;
 class BOPDS_InterfEZ : public BOPDS_Interf {
 	public:
@@ -2288,6 +2378,11 @@ class BOPDS_InterfEZ : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfEZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfFF;
 class BOPDS_InterfFF : public BOPDS_Interf {
 	public:
@@ -2376,6 +2471,11 @@ class BOPDS_InterfFF : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfFF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfFZ;
 class BOPDS_InterfFZ : public BOPDS_Interf {
 	public:
@@ -2396,6 +2496,11 @@ class BOPDS_InterfFZ : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfFZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfVE;
 class BOPDS_InterfVE : public BOPDS_Interf {
 	public:
@@ -2430,6 +2535,11 @@ class BOPDS_InterfVE : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfVE {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfVF;
 class BOPDS_InterfVF : public BOPDS_Interf {
 	public:
@@ -2470,6 +2580,11 @@ class BOPDS_InterfVF : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfVF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfVV;
 class BOPDS_InterfVV : public BOPDS_Interf {
 	public:
@@ -2490,6 +2605,11 @@ class BOPDS_InterfVV : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfVV {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfVZ;
 class BOPDS_InterfVZ : public BOPDS_Interf {
 	public:
@@ -2510,6 +2630,11 @@ class BOPDS_InterfVZ : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfVZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_InterfZZ;
 class BOPDS_InterfZZ : public BOPDS_Interf {
 	public:
@@ -2530,6 +2655,11 @@ class BOPDS_InterfZZ : public BOPDS_Interf {
 };
 
 
+%extend BOPDS_InterfZZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_IteratorSI;
 class BOPDS_IteratorSI : public BOPDS_Iterator {
 	public:
@@ -2558,6 +2688,11 @@ class BOPDS_IteratorSI : public BOPDS_Iterator {
 };
 
 
+%extend BOPDS_IteratorSI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPDS_PassKeyBoolean;
 class BOPDS_PassKeyBoolean : public BOPDS_PassKey {
 	public:
@@ -2596,3 +2731,8 @@ class BOPDS_PassKeyBoolean : public BOPDS_PassKey {
 };
 
 
+%extend BOPDS_PassKeyBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BOPTools.i
+++ b/src/SWIG_files/wrapper/BOPTools.i
@@ -110,6 +110,11 @@ class BOPTools {
 };
 
 
+%extend BOPTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPTools_AlgoTools {
 	public:
 		%feature("compactdefaultargs") ComputeVV;
@@ -733,6 +738,11 @@ class BOPTools_AlgoTools {
 };
 
 
+%extend BOPTools_AlgoTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPTools_AlgoTools2D {
 	public:
 		%feature("compactdefaultargs") BuildPCurveForEdgeOnFace;
@@ -928,6 +938,11 @@ class BOPTools_AlgoTools2D {
 };
 
 
+%extend BOPTools_AlgoTools2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPTools_AlgoTools3D {
 	public:
 		%feature("compactdefaultargs") DoSplitSEAMOnFace;
@@ -1119,6 +1134,11 @@ class BOPTools_AlgoTools3D {
 };
 
 
+%extend BOPTools_AlgoTools3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPTools_ConnexityBlock;
 class BOPTools_ConnexityBlock {
 	public:
@@ -1161,6 +1181,11 @@ class BOPTools_ConnexityBlock {
 };
 
 
+%extend BOPTools_ConnexityBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPTools_CoupleOfShape;
 class BOPTools_CoupleOfShape {
 	public:
@@ -1191,6 +1216,11 @@ class BOPTools_CoupleOfShape {
 };
 
 
+%extend BOPTools_CoupleOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPTools_EdgeSet;
 class BOPTools_EdgeSet {
 	public:
@@ -1251,6 +1281,11 @@ class BOPTools_EdgeSet {
 };
 
 
+%extend BOPTools_EdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPTools_Set;
 class BOPTools_Set {
 	public:
@@ -1313,6 +1348,11 @@ class BOPTools_Set {
         };
 
 
+%extend BOPTools_Set {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BOPTools_SetMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -1334,6 +1374,11 @@ class BOPTools_SetMapHasher {
 };
 
 
+%extend BOPTools_SetMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BOPTools_ShapeSet;
 class BOPTools_ShapeSet {
 	public:
@@ -1426,3 +1471,8 @@ class BOPTools_ShapeSet {
 };
 
 
+%extend BOPTools_ShapeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRep.i
+++ b/src/SWIG_files/wrapper/BRep.i
@@ -731,6 +731,11 @@ class BRep_Builder : public TopoDS_Builder {
 };
 
 
+%extend BRep_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_CurveRepresentation;
 class BRep_CurveRepresentation : public MMgt_TShared {
 	public:
@@ -1003,6 +1008,11 @@ class Handle_BRep_CurveRepresentation : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRep_CurveRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListIteratorOfListOfCurveRepresentation;
 class BRep_ListIteratorOfListOfCurveRepresentation {
 	public:
@@ -1037,6 +1047,11 @@ class BRep_ListIteratorOfListOfCurveRepresentation {
 };
 
 
+%extend BRep_ListIteratorOfListOfCurveRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListIteratorOfListOfPointRepresentation;
 class BRep_ListIteratorOfListOfPointRepresentation {
 	public:
@@ -1071,6 +1086,11 @@ class BRep_ListIteratorOfListOfPointRepresentation {
 };
 
 
+%extend BRep_ListIteratorOfListOfPointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListNodeOfListOfCurveRepresentation;
 class BRep_ListNodeOfListOfCurveRepresentation : public TCollection_MapNode {
 	public:
@@ -1135,6 +1155,11 @@ class Handle_BRep_ListNodeOfListOfCurveRepresentation : public Handle_TCollectio
     }
 };
 
+%extend BRep_ListNodeOfListOfCurveRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListNodeOfListOfPointRepresentation;
 class BRep_ListNodeOfListOfPointRepresentation : public TCollection_MapNode {
 	public:
@@ -1199,6 +1224,11 @@ class Handle_BRep_ListNodeOfListOfPointRepresentation : public Handle_TCollectio
     }
 };
 
+%extend BRep_ListNodeOfListOfPointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListOfCurveRepresentation;
 class BRep_ListOfCurveRepresentation {
 	public:
@@ -1329,6 +1359,11 @@ class BRep_ListOfCurveRepresentation {
 };
 
 
+%extend BRep_ListOfCurveRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_ListOfPointRepresentation;
 class BRep_ListOfPointRepresentation {
 	public:
@@ -1459,6 +1494,11 @@ class BRep_ListOfPointRepresentation {
 };
 
 
+%extend BRep_ListOfPointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PointRepresentation;
 class BRep_PointRepresentation : public MMgt_TShared {
 	public:
@@ -1621,6 +1661,11 @@ class Handle_BRep_PointRepresentation : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRep_PointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_TEdge;
 class BRep_TEdge : public TopoDS_TEdge {
 	public:
@@ -1741,6 +1786,11 @@ class Handle_BRep_TEdge : public Handle_TopoDS_TEdge {
     }
 };
 
+%extend BRep_TEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_TFace;
 class BRep_TFace : public TopoDS_TFace {
 	public:
@@ -1855,6 +1905,11 @@ class Handle_BRep_TFace : public Handle_TopoDS_TFace {
     }
 };
 
+%extend BRep_TFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_TVertex;
 class BRep_TVertex : public TopoDS_TVertex {
 	public:
@@ -1953,6 +2008,11 @@ class Handle_BRep_TVertex : public Handle_TopoDS_TVertex {
     }
 };
 
+%extend BRep_TVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRep_Tool {
 	public:
 		%feature("compactdefaultargs") IsClosed;
@@ -2508,6 +2568,11 @@ class BRep_Tool {
 };
 
 
+%extend BRep_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_CurveOn2Surfaces;
 class BRep_CurveOn2Surfaces : public BRep_CurveRepresentation {
 	public:
@@ -2632,6 +2697,11 @@ class Handle_BRep_CurveOn2Surfaces : public Handle_BRep_CurveRepresentation {
     }
 };
 
+%extend BRep_CurveOn2Surfaces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_GCurve;
 class BRep_GCurve : public BRep_CurveRepresentation {
 	public:
@@ -2736,6 +2806,11 @@ class Handle_BRep_GCurve : public Handle_BRep_CurveRepresentation {
     }
 };
 
+%extend BRep_GCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PointOnCurve;
 class BRep_PointOnCurve : public BRep_PointRepresentation {
 	public:
@@ -2822,6 +2897,11 @@ class Handle_BRep_PointOnCurve : public Handle_BRep_PointRepresentation {
     }
 };
 
+%extend BRep_PointOnCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PointsOnSurface;
 class BRep_PointsOnSurface : public BRep_PointRepresentation {
 	public:
@@ -2884,6 +2964,11 @@ class Handle_BRep_PointsOnSurface : public Handle_BRep_PointRepresentation {
     }
 };
 
+%extend BRep_PointsOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_Polygon3D;
 class BRep_Polygon3D : public BRep_CurveRepresentation {
 	public:
@@ -2966,6 +3051,11 @@ class Handle_BRep_Polygon3D : public Handle_BRep_CurveRepresentation {
     }
 };
 
+%extend BRep_Polygon3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PolygonOnSurface;
 class BRep_PolygonOnSurface : public BRep_CurveRepresentation {
 	public:
@@ -3064,6 +3154,11 @@ class Handle_BRep_PolygonOnSurface : public Handle_BRep_CurveRepresentation {
     }
 };
 
+%extend BRep_PolygonOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PolygonOnTriangulation;
 class BRep_PolygonOnTriangulation : public BRep_CurveRepresentation {
 	public:
@@ -3164,6 +3259,11 @@ class Handle_BRep_PolygonOnTriangulation : public Handle_BRep_CurveRepresentatio
     }
 };
 
+%extend BRep_PolygonOnTriangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_Curve3D;
 class BRep_Curve3D : public BRep_GCurve {
 	public:
@@ -3256,6 +3356,11 @@ class Handle_BRep_Curve3D : public Handle_BRep_GCurve {
     }
 };
 
+%extend BRep_Curve3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_CurveOnSurface;
 class BRep_CurveOnSurface : public BRep_GCurve {
 	public:
@@ -3386,6 +3491,11 @@ class Handle_BRep_CurveOnSurface : public Handle_BRep_GCurve {
     }
 };
 
+%extend BRep_CurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PointOnCurveOnSurface;
 class BRep_PointOnCurveOnSurface : public BRep_PointsOnSurface {
 	public:
@@ -3476,6 +3586,11 @@ class Handle_BRep_PointOnCurveOnSurface : public Handle_BRep_PointsOnSurface {
     }
 };
 
+%extend BRep_PointOnCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PointOnSurface;
 class BRep_PointOnSurface : public BRep_PointsOnSurface {
 	public:
@@ -3562,6 +3677,11 @@ class Handle_BRep_PointOnSurface : public Handle_BRep_PointsOnSurface {
     }
 };
 
+%extend BRep_PointOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PolygonOnClosedSurface;
 class BRep_PolygonOnClosedSurface : public BRep_PolygonOnSurface {
 	public:
@@ -3648,6 +3768,11 @@ class Handle_BRep_PolygonOnClosedSurface : public Handle_BRep_PolygonOnSurface {
     }
 };
 
+%extend BRep_PolygonOnClosedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_PolygonOnClosedTriangulation;
 class BRep_PolygonOnClosedTriangulation : public BRep_PolygonOnTriangulation {
 	public:
@@ -3734,6 +3859,11 @@ class Handle_BRep_PolygonOnClosedTriangulation : public Handle_BRep_PolygonOnTri
     }
 };
 
+%extend BRep_PolygonOnClosedTriangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRep_CurveOnClosedSurface;
 class BRep_CurveOnClosedSurface : public BRep_CurveOnSurface {
 	public:
@@ -3886,3 +4016,8 @@ class Handle_BRep_CurveOnClosedSurface : public Handle_BRep_CurveOnSurface {
     }
 };
 
+%extend BRep_CurveOnClosedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepAdaptor.i
+++ b/src/SWIG_files/wrapper/BRepAdaptor.i
@@ -138,6 +138,11 @@ class BRepAdaptor_Array1OfCurve {
 };
 
 
+%extend BRepAdaptor_Array1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_CompCurve;
 class BRepAdaptor_CompCurve : public Adaptor3d_Curve {
 	public:
@@ -406,6 +411,11 @@ class BRepAdaptor_CompCurve : public Adaptor3d_Curve {
 };
 
 
+%extend BRepAdaptor_CompCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_Curve;
 class BRepAdaptor_Curve : public Adaptor3d_Curve {
 	public:
@@ -680,6 +690,11 @@ class BRepAdaptor_Curve : public Adaptor3d_Curve {
 };
 
 
+%extend BRepAdaptor_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_Curve2d;
 class BRepAdaptor_Curve2d : public Geom2dAdaptor_Curve {
 	public:
@@ -724,6 +739,11 @@ class BRepAdaptor_Curve2d : public Geom2dAdaptor_Curve {
 };
 
 
+%extend BRepAdaptor_Curve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_HArray1OfCurve;
 class BRepAdaptor_HArray1OfCurve : public MMgt_TShared {
 	public:
@@ -840,6 +860,11 @@ class Handle_BRepAdaptor_HArray1OfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepAdaptor_HArray1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_HCompCurve;
 class BRepAdaptor_HCompCurve : public Adaptor3d_HCurve {
 	public:
@@ -920,6 +945,11 @@ class Handle_BRepAdaptor_HCompCurve : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend BRepAdaptor_HCompCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_HCurve;
 class BRepAdaptor_HCurve : public Adaptor3d_HCurve {
 	public:
@@ -1000,6 +1030,11 @@ class Handle_BRepAdaptor_HCurve : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend BRepAdaptor_HCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_HCurve2d;
 class BRepAdaptor_HCurve2d : public Adaptor2d_HCurve2d {
 	public:
@@ -1076,6 +1111,11 @@ class Handle_BRepAdaptor_HCurve2d : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend BRepAdaptor_HCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_HSurface;
 class BRepAdaptor_HSurface : public Adaptor3d_HSurface {
 	public:
@@ -1152,6 +1192,11 @@ class Handle_BRepAdaptor_HSurface : public Handle_Adaptor3d_HSurface {
     }
 };
 
+%extend BRepAdaptor_HSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAdaptor_Surface;
 class BRepAdaptor_Surface : public Adaptor3d_Surface {
 	public:
@@ -1532,3 +1577,8 @@ class BRepAdaptor_Surface : public Adaptor3d_Surface {
 };
 
 
+%extend BRepAdaptor_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepAlgo.i
+++ b/src/SWIG_files/wrapper/BRepAlgo.i
@@ -117,6 +117,11 @@ class BRepAlgo {
 };
 
 
+%extend BRepAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_AsDes;
 class BRepAlgo_AsDes : public MMgt_TShared {
 	public:
@@ -265,6 +270,11 @@ class Handle_BRepAlgo_AsDes : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepAlgo_AsDes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_BooleanOperation;
 class BRepAlgo_BooleanOperation : public BRepBuilderAPI_MakeShape {
 	public:
@@ -317,6 +327,11 @@ class BRepAlgo_BooleanOperation : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepAlgo_BooleanOperation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_BooleanOperations;
 class BRepAlgo_BooleanOperations {
 	public:
@@ -447,6 +462,11 @@ class BRepAlgo_BooleanOperations {
 };
 
 
+%extend BRepAlgo_BooleanOperations {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DSAccess;
 class BRepAlgo_DSAccess {
 	public:
@@ -639,6 +659,11 @@ class BRepAlgo_DSAccess {
 };
 
 
+%extend BRepAlgo_DSAccess {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapIteratorOfDataMapOfShapeBoolean;
 class BRepAlgo_DataMapIteratorOfDataMapOfShapeBoolean : public TCollection_BasicMapIterator {
 	public:
@@ -669,6 +694,11 @@ class BRepAlgo_DataMapIteratorOfDataMapOfShapeBoolean : public TCollection_Basic
 };
 
 
+%extend BRepAlgo_DataMapIteratorOfDataMapOfShapeBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapIteratorOfDataMapOfShapeInterference;
 class BRepAlgo_DataMapIteratorOfDataMapOfShapeInterference : public TCollection_BasicMapIterator {
 	public:
@@ -699,6 +729,11 @@ class BRepAlgo_DataMapIteratorOfDataMapOfShapeInterference : public TCollection_
 };
 
 
+%extend BRepAlgo_DataMapIteratorOfDataMapOfShapeInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapNodeOfDataMapOfShapeBoolean;
 class BRepAlgo_DataMapNodeOfDataMapOfShapeBoolean : public TCollection_MapNode {
 	public:
@@ -778,6 +813,11 @@ class Handle_BRepAlgo_DataMapNodeOfDataMapOfShapeBoolean : public Handle_TCollec
     }
 };
 
+%extend BRepAlgo_DataMapNodeOfDataMapOfShapeBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapNodeOfDataMapOfShapeInterference;
 class BRepAlgo_DataMapNodeOfDataMapOfShapeInterference : public TCollection_MapNode {
 	public:
@@ -848,6 +888,11 @@ class Handle_BRepAlgo_DataMapNodeOfDataMapOfShapeInterference : public Handle_TC
     }
 };
 
+%extend BRepAlgo_DataMapNodeOfDataMapOfShapeInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapOfShapeBoolean;
 class BRepAlgo_DataMapOfShapeBoolean : public TCollection_BasicMap {
 	public:
@@ -926,6 +971,11 @@ class BRepAlgo_DataMapOfShapeBoolean : public TCollection_BasicMap {
 };
 
 
+%extend BRepAlgo_DataMapOfShapeBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_DataMapOfShapeInterference;
 class BRepAlgo_DataMapOfShapeInterference : public TCollection_BasicMap {
 	public:
@@ -1004,6 +1054,11 @@ class BRepAlgo_DataMapOfShapeInterference : public TCollection_BasicMap {
 };
 
 
+%extend BRepAlgo_DataMapOfShapeInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_EdgeConnector;
 class BRepAlgo_EdgeConnector : public MMgt_TShared {
 	public:
@@ -1112,6 +1167,11 @@ class Handle_BRepAlgo_EdgeConnector : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepAlgo_EdgeConnector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_FaceRestrictor;
 class BRepAlgo_FaceRestrictor {
 	public:
@@ -1170,6 +1230,11 @@ class BRepAlgo_FaceRestrictor {
 };
 
 
+%extend BRepAlgo_FaceRestrictor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Image;
 class BRepAlgo_Image {
 	public:
@@ -1304,6 +1369,11 @@ class BRepAlgo_Image {
 };
 
 
+%extend BRepAlgo_Image {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Loop;
 class BRepAlgo_Loop {
 	public:
@@ -1406,6 +1476,11 @@ class BRepAlgo_Loop {
 };
 
 
+%extend BRepAlgo_Loop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_NormalProjection;
 class BRepAlgo_NormalProjection {
 	public:
@@ -1536,6 +1611,11 @@ class BRepAlgo_NormalProjection {
 };
 
 
+%extend BRepAlgo_NormalProjection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_SequenceNodeOfSequenceOfSequenceOfInteger;
 class BRepAlgo_SequenceNodeOfSequenceOfSequenceOfInteger : public TCollection_SeqNode {
 	public:
@@ -1602,6 +1682,11 @@ class Handle_BRepAlgo_SequenceNodeOfSequenceOfSequenceOfInteger : public Handle_
     }
 };
 
+%extend BRepAlgo_SequenceNodeOfSequenceOfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_SequenceOfSequenceOfInteger;
 class BRepAlgo_SequenceOfSequenceOfInteger : public TCollection_BaseSequence {
 	public:
@@ -1740,6 +1825,11 @@ class BRepAlgo_SequenceOfSequenceOfInteger : public TCollection_BaseSequence {
 };
 
 
+%extend BRepAlgo_SequenceOfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepAlgo_Tool {
 	public:
 		%feature("compactdefaultargs") Deboucle3D;
@@ -1755,6 +1845,11 @@ class BRepAlgo_Tool {
 };
 
 
+%extend BRepAlgo_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Common;
 class BRepAlgo_Common : public BRepAlgo_BooleanOperation {
 	public:
@@ -1771,6 +1866,11 @@ class BRepAlgo_Common : public BRepAlgo_BooleanOperation {
 };
 
 
+%extend BRepAlgo_Common {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Cut;
 class BRepAlgo_Cut : public BRepAlgo_BooleanOperation {
 	public:
@@ -1787,6 +1887,11 @@ class BRepAlgo_Cut : public BRepAlgo_BooleanOperation {
 };
 
 
+%extend BRepAlgo_Cut {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Fuse;
 class BRepAlgo_Fuse : public BRepAlgo_BooleanOperation {
 	public:
@@ -1803,6 +1908,11 @@ class BRepAlgo_Fuse : public BRepAlgo_BooleanOperation {
 };
 
 
+%extend BRepAlgo_Fuse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgo_Section;
 class BRepAlgo_Section : public BRepAlgo_BooleanOperation {
 	public:
@@ -1959,3 +2069,8 @@ class BRepAlgo_Section : public BRepAlgo_BooleanOperation {
 };
 
 
+%extend BRepAlgo_Section {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepAlgoAPI.i
+++ b/src/SWIG_files/wrapper/BRepAlgoAPI.i
@@ -80,6 +80,11 @@ class BRepAlgoAPI {
 };
 
 
+%extend BRepAlgoAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_BooleanOperation;
 class BRepAlgoAPI_BooleanOperation : public BRepBuilderAPI_MakeShape {
 	public:
@@ -192,6 +197,11 @@ class BRepAlgoAPI_BooleanOperation : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepAlgoAPI_BooleanOperation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_Check;
 class BRepAlgoAPI_Check {
 	public:
@@ -278,6 +288,11 @@ class BRepAlgoAPI_Check {
 };
 
 
+%extend BRepAlgoAPI_Check {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_Common;
 class BRepAlgoAPI_Common : public BRepAlgoAPI_BooleanOperation {
 	public:
@@ -304,6 +319,11 @@ class BRepAlgoAPI_Common : public BRepAlgoAPI_BooleanOperation {
 };
 
 
+%extend BRepAlgoAPI_Common {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_Cut;
 class BRepAlgoAPI_Cut : public BRepAlgoAPI_BooleanOperation {
 	public:
@@ -334,6 +354,11 @@ class BRepAlgoAPI_Cut : public BRepAlgoAPI_BooleanOperation {
 };
 
 
+%extend BRepAlgoAPI_Cut {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_Fuse;
 class BRepAlgoAPI_Fuse : public BRepAlgoAPI_BooleanOperation {
 	public:
@@ -362,6 +387,11 @@ class BRepAlgoAPI_Fuse : public BRepAlgoAPI_BooleanOperation {
 };
 
 
+%extend BRepAlgoAPI_Fuse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepAlgoAPI_Section;
 class BRepAlgoAPI_Section : public BRepAlgoAPI_BooleanOperation {
 	public:
@@ -538,3 +568,8 @@ class BRepAlgoAPI_Section : public BRepAlgoAPI_BooleanOperation {
 };
 
 
+%extend BRepAlgoAPI_Section {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepApprox.i
+++ b/src/SWIG_files/wrapper/BRepApprox.i
@@ -128,6 +128,11 @@ class BRepApprox_Approx {
 };
 
 
+%extend BRepApprox_Approx {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ApproxLine;
 class BRepApprox_ApproxLine : public MMgt_TShared {
 	public:
@@ -208,6 +213,11 @@ class Handle_BRepApprox_ApproxLine : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepApprox_ApproxLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfApprox;
 class BRepApprox_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfApprox : public math_BFGS {
 	public:
@@ -236,6 +246,11 @@ class BRepApprox_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfApprox : publ
 };
 
 
+%extend BRepApprox_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfApprox;
 class BRepApprox_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -356,6 +371,11 @@ class BRepApprox_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfApprox : public
 };
 
 
+%extend BRepApprox_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfApprox;
 class BRepApprox_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfApprox {
 	public:
@@ -552,6 +572,11 @@ class BRepApprox_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfApprox;
 class BRepApprox_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfApprox : public math_BFGS {
 	public:
@@ -580,6 +605,11 @@ class BRepApprox_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfApprox : publi
 };
 
 
+%extend BRepApprox_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfApprox;
 class BRepApprox_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfApprox : public math_BFGS {
 	public:
@@ -608,6 +638,11 @@ class BRepApprox_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfApprox : public m
 };
 
 
+%extend BRepApprox_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_MyBSplGradientOfTheComputeLineOfApprox;
 class BRepApprox_MyBSplGradientOfTheComputeLineOfApprox {
 	public:
@@ -696,6 +731,11 @@ class BRepApprox_MyBSplGradientOfTheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_MyBSplGradientOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_MyGradientOfTheComputeLineBezierOfApprox;
 class BRepApprox_MyGradientOfTheComputeLineBezierOfApprox {
 	public:
@@ -750,6 +790,11 @@ class BRepApprox_MyGradientOfTheComputeLineBezierOfApprox {
 };
 
 
+%extend BRepApprox_MyGradientOfTheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_MyGradientbisOfTheComputeLineOfApprox;
 class BRepApprox_MyGradientbisOfTheComputeLineOfApprox {
 	public:
@@ -804,6 +849,11 @@ class BRepApprox_MyGradientbisOfTheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_MyGradientbisOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ParFunctionOfMyGradientOfTheComputeLineBezierOfApprox;
 class BRepApprox_ParFunctionOfMyGradientOfTheComputeLineBezierOfApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -896,6 +946,11 @@ class BRepApprox_ParFunctionOfMyGradientOfTheComputeLineBezierOfApprox : public 
 };
 
 
+%extend BRepApprox_ParFunctionOfMyGradientOfTheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ParFunctionOfMyGradientbisOfTheComputeLineOfApprox;
 class BRepApprox_ParFunctionOfMyGradientbisOfTheComputeLineOfApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -988,6 +1043,11 @@ class BRepApprox_ParFunctionOfMyGradientbisOfTheComputeLineOfApprox : public mat
 };
 
 
+%extend BRepApprox_ParFunctionOfMyGradientbisOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfApprox;
 class BRepApprox_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfApprox {
 	public:
@@ -1184,6 +1244,11 @@ class BRepApprox_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfApprox {
 };
 
 
+%extend BRepApprox_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ParLeastSquareOfMyGradientbisOfTheComputeLineOfApprox;
 class BRepApprox_ParLeastSquareOfMyGradientbisOfTheComputeLineOfApprox {
 	public:
@@ -1380,6 +1445,11 @@ class BRepApprox_ParLeastSquareOfMyGradientbisOfTheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_ParLeastSquareOfMyGradientbisOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ResConstraintOfMyGradientOfTheComputeLineBezierOfApprox;
 class BRepApprox_ResConstraintOfMyGradientOfTheComputeLineBezierOfApprox {
 	public:
@@ -1434,6 +1504,11 @@ class BRepApprox_ResConstraintOfMyGradientOfTheComputeLineBezierOfApprox {
 };
 
 
+%extend BRepApprox_ResConstraintOfMyGradientOfTheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ResConstraintOfMyGradientbisOfTheComputeLineOfApprox;
 class BRepApprox_ResConstraintOfMyGradientbisOfTheComputeLineOfApprox {
 	public:
@@ -1488,6 +1563,11 @@ class BRepApprox_ResConstraintOfMyGradientbisOfTheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_ResConstraintOfMyGradientbisOfTheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheComputeLineBezierOfApprox;
 class BRepApprox_TheComputeLineBezierOfApprox {
 	public:
@@ -1678,6 +1758,11 @@ class BRepApprox_TheComputeLineBezierOfApprox {
 };
 
 
+%extend BRepApprox_TheComputeLineBezierOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheComputeLineOfApprox;
 class BRepApprox_TheComputeLineOfApprox {
 	public:
@@ -1878,6 +1963,11 @@ class BRepApprox_TheComputeLineOfApprox {
 };
 
 
+%extend BRepApprox_TheComputeLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfApprox;
 class BRepApprox_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfApprox : public math_FunctionSetWithDerivatives {
 	public:
@@ -1984,6 +2074,11 @@ class BRepApprox_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfApprox : public mat
 };
 
 
+%extend BRepApprox_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheImpPrmSvSurfacesOfApprox;
 class BRepApprox_TheImpPrmSvSurfacesOfApprox : public ApproxInt_SvSurfaces {
 	public:
@@ -2082,6 +2177,11 @@ class BRepApprox_TheImpPrmSvSurfacesOfApprox : public ApproxInt_SvSurfaces {
 };
 
 
+%extend BRepApprox_TheImpPrmSvSurfacesOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheInt2SOfThePrmPrmSvSurfacesOfApprox;
 class BRepApprox_TheInt2SOfThePrmPrmSvSurfacesOfApprox {
 	public:
@@ -2164,6 +2264,11 @@ class BRepApprox_TheInt2SOfThePrmPrmSvSurfacesOfApprox {
 };
 
 
+%extend BRepApprox_TheInt2SOfThePrmPrmSvSurfacesOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheMultiLineOfApprox;
 class BRepApprox_TheMultiLineOfApprox {
 	public:
@@ -2342,6 +2447,11 @@ class BRepApprox_TheMultiLineOfApprox {
 };
 
 
+%extend BRepApprox_TheMultiLineOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepApprox_TheMultiLineToolOfApprox {
 	public:
 		%feature("compactdefaultargs") FirstPoint;
@@ -2489,6 +2599,11 @@ class BRepApprox_TheMultiLineToolOfApprox {
 };
 
 
+%extend BRepApprox_TheMultiLineToolOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_ThePrmPrmSvSurfacesOfApprox;
 class BRepApprox_ThePrmPrmSvSurfacesOfApprox : public ApproxInt_SvSurfaces {
 	public:
@@ -2579,6 +2694,11 @@ class BRepApprox_ThePrmPrmSvSurfacesOfApprox : public ApproxInt_SvSurfaces {
 };
 
 
+%extend BRepApprox_ThePrmPrmSvSurfacesOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepApprox_TheZerImpFuncOfTheImpPrmSvSurfacesOfApprox;
 class BRepApprox_TheZerImpFuncOfTheImpPrmSvSurfacesOfApprox : public math_FunctionSetWithDerivatives {
 	public:
@@ -2687,3 +2807,8 @@ class BRepApprox_TheZerImpFuncOfTheImpPrmSvSurfacesOfApprox : public math_Functi
 };
 
 
+%extend BRepApprox_TheZerImpFuncOfTheImpPrmSvSurfacesOfApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepBlend.i
+++ b/src/SWIG_files/wrapper/BRepBlend.i
@@ -338,6 +338,11 @@ class Handle_BRepBlend_AppFuncRoot : public Handle_Approx_SweepFunction {
     }
 };
 
+%extend BRepBlend_AppFuncRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_AppSurf;
 class BRepBlend_AppSurf : public AppBlend_Approx {
 	public:
@@ -574,6 +579,11 @@ class BRepBlend_AppSurf : public AppBlend_Approx {
 };
 
 
+%extend BRepBlend_AppSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_AppSurface;
 class BRepBlend_AppSurface : public AppBlend_Approx {
 	public:
@@ -752,6 +762,11 @@ class BRepBlend_AppSurface : public AppBlend_Approx {
         };
 
 
+%extend BRepBlend_AppSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepBlend_BlendTool {
 	public:
 		%feature("compactdefaultargs") Project;
@@ -873,6 +888,11 @@ class BRepBlend_BlendTool {
 };
 
 
+%extend BRepBlend_BlendTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_CSWalking;
 class BRepBlend_CSWalking {
 	public:
@@ -927,6 +947,11 @@ class BRepBlend_CSWalking {
 };
 
 
+%extend BRepBlend_CSWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_CurvPointRadInv;
 class BRepBlend_CurvPointRadInv : public Blend_CurvPointFuncInv {
 	public:
@@ -1023,6 +1048,11 @@ class BRepBlend_CurvPointRadInv : public Blend_CurvPointFuncInv {
 };
 
 
+%extend BRepBlend_CurvPointRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_Extremity;
 class BRepBlend_Extremity {
 	public:
@@ -1225,6 +1255,11 @@ class BRepBlend_Extremity {
 };
 
 
+%extend BRepBlend_Extremity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_Line;
 class BRepBlend_Line : public MMgt_TShared {
 	public:
@@ -1417,6 +1452,11 @@ class Handle_BRepBlend_Line : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepBlend_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_PointOnRst;
 class BRepBlend_PointOnRst {
 	public:
@@ -1481,6 +1521,11 @@ class BRepBlend_PointOnRst {
 };
 
 
+%extend BRepBlend_PointOnRst {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_RstRstConstRad;
 class BRepBlend_RstRstConstRad : public Blend_RstRstFunction {
 	public:
@@ -1867,6 +1912,11 @@ class BRepBlend_RstRstConstRad : public Blend_RstRstFunction {
 };
 
 
+%extend BRepBlend_RstRstConstRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_RstRstEvolRad;
 class BRepBlend_RstRstEvolRad : public Blend_RstRstFunction {
 	public:
@@ -2253,6 +2303,11 @@ class BRepBlend_RstRstEvolRad : public Blend_RstRstFunction {
 };
 
 
+%extend BRepBlend_RstRstEvolRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_RstRstLineBuilder;
 class BRepBlend_RstRstLineBuilder {
 	public:
@@ -2381,6 +2436,11 @@ class BRepBlend_RstRstLineBuilder {
 };
 
 
+%extend BRepBlend_RstRstLineBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SequenceNodeOfSequenceOfLine;
 class BRepBlend_SequenceNodeOfSequenceOfLine : public TCollection_SeqNode {
 	public:
@@ -2447,6 +2507,11 @@ class Handle_BRepBlend_SequenceNodeOfSequenceOfLine : public Handle_TCollection_
     }
 };
 
+%extend BRepBlend_SequenceNodeOfSequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SequenceNodeOfSequenceOfPointOnRst;
 class BRepBlend_SequenceNodeOfSequenceOfPointOnRst : public TCollection_SeqNode {
 	public:
@@ -2513,6 +2578,11 @@ class Handle_BRepBlend_SequenceNodeOfSequenceOfPointOnRst : public Handle_TColle
     }
 };
 
+%extend BRepBlend_SequenceNodeOfSequenceOfPointOnRst {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SequenceOfLine;
 class BRepBlend_SequenceOfLine : public TCollection_BaseSequence {
 	public:
@@ -2651,6 +2721,11 @@ class BRepBlend_SequenceOfLine : public TCollection_BaseSequence {
 };
 
 
+%extend BRepBlend_SequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SequenceOfPointOnRst;
 class BRepBlend_SequenceOfPointOnRst : public TCollection_BaseSequence {
 	public:
@@ -2789,6 +2864,11 @@ class BRepBlend_SequenceOfPointOnRst : public TCollection_BaseSequence {
 };
 
 
+%extend BRepBlend_SequenceOfPointOnRst {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfCurvConstRadInv;
 class BRepBlend_SurfCurvConstRadInv : public Blend_SurfCurvFuncInv {
 	public:
@@ -2889,6 +2969,11 @@ class BRepBlend_SurfCurvConstRadInv : public Blend_SurfCurvFuncInv {
 };
 
 
+%extend BRepBlend_SurfCurvConstRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfCurvEvolRadInv;
 class BRepBlend_SurfCurvEvolRadInv : public Blend_SurfCurvFuncInv {
 	public:
@@ -2989,6 +3074,11 @@ class BRepBlend_SurfCurvEvolRadInv : public Blend_SurfCurvFuncInv {
 };
 
 
+%extend BRepBlend_SurfCurvEvolRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfPointConstRadInv;
 class BRepBlend_SurfPointConstRadInv : public Blend_SurfPointFuncInv {
 	public:
@@ -3087,6 +3177,11 @@ class BRepBlend_SurfPointConstRadInv : public Blend_SurfPointFuncInv {
 };
 
 
+%extend BRepBlend_SurfPointConstRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfPointEvolRadInv;
 class BRepBlend_SurfPointEvolRadInv : public Blend_SurfPointFuncInv {
 	public:
@@ -3185,6 +3280,11 @@ class BRepBlend_SurfPointEvolRadInv : public Blend_SurfPointFuncInv {
 };
 
 
+%extend BRepBlend_SurfPointEvolRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfRstConstRad;
 class BRepBlend_SurfRstConstRad : public Blend_SurfRstFunction {
 	public:
@@ -3541,6 +3641,11 @@ class BRepBlend_SurfRstConstRad : public Blend_SurfRstFunction {
 };
 
 
+%extend BRepBlend_SurfRstConstRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfRstEvolRad;
 class BRepBlend_SurfRstEvolRad : public Blend_SurfRstFunction {
 	public:
@@ -3897,6 +4002,11 @@ class BRepBlend_SurfRstEvolRad : public Blend_SurfRstFunction {
 };
 
 
+%extend BRepBlend_SurfRstEvolRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_SurfRstLineBuilder;
 class BRepBlend_SurfRstLineBuilder {
 	public:
@@ -4021,6 +4131,11 @@ class BRepBlend_SurfRstLineBuilder {
 };
 
 
+%extend BRepBlend_SurfRstLineBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_Walking;
 class BRepBlend_Walking {
 	public:
@@ -4193,6 +4308,11 @@ class BRepBlend_Walking {
 };
 
 
+%extend BRepBlend_Walking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_AppFunc;
 class BRepBlend_AppFunc : public BRepBlend_AppFuncRoot {
 	public:
@@ -4277,6 +4397,11 @@ class Handle_BRepBlend_AppFunc : public Handle_BRepBlend_AppFuncRoot {
     }
 };
 
+%extend BRepBlend_AppFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_AppFuncRst;
 class BRepBlend_AppFuncRst : public BRepBlend_AppFuncRoot {
 	public:
@@ -4361,6 +4486,11 @@ class Handle_BRepBlend_AppFuncRst : public Handle_BRepBlend_AppFuncRoot {
     }
 };
 
+%extend BRepBlend_AppFuncRst {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBlend_AppFuncRstRst;
 class BRepBlend_AppFuncRstRst : public BRepBlend_AppFuncRoot {
 	public:
@@ -4445,3 +4575,8 @@ class Handle_BRepBlend_AppFuncRstRst : public Handle_BRepBlend_AppFuncRoot {
     }
 };
 
+%extend BRepBlend_AppFuncRstRst {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepBndLib.i
+++ b/src/SWIG_files/wrapper/BRepBndLib.i
@@ -84,3 +84,8 @@ class BRepBndLib {
 };
 
 
+%extend BRepBndLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepBuilderAPI.i
+++ b/src/SWIG_files/wrapper/BRepBuilderAPI.i
@@ -146,6 +146,11 @@ class BRepBuilderAPI {
 };
 
 
+%extend BRepBuilderAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_Collect;
 class BRepBuilderAPI_Collect {
 	public:
@@ -194,6 +199,11 @@ class BRepBuilderAPI_Collect {
 };
 
 
+%extend BRepBuilderAPI_Collect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_Command;
 class BRepBuilderAPI_Command {
 	public:
@@ -214,6 +224,11 @@ class BRepBuilderAPI_Command {
 };
 
 
+%extend BRepBuilderAPI_Command {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_FindPlane;
 class BRepBuilderAPI_FindPlane {
 	public:
@@ -258,6 +273,11 @@ class BRepBuilderAPI_FindPlane {
 };
 
 
+%extend BRepBuilderAPI_FindPlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_Sewing;
 class BRepBuilderAPI_Sewing : public MMgt_TShared {
 	public:
@@ -648,6 +668,11 @@ class Handle_BRepBuilderAPI_Sewing : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepBuilderAPI_Sewing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_VertexInspector;
 class BRepBuilderAPI_VertexInspector : public NCollection_CellFilter_InspectorXYZ {
 	public:
@@ -699,6 +724,11 @@ typedef Standard_Integer Target;
 };
 
 
+%extend BRepBuilderAPI_VertexInspector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_BndBoxTreeSelector;
 class BRepBuilderAPI_BndBoxTreeSelector : public BRepBuilderAPI_BndBoxTree::Selector {
 	public:
@@ -747,6 +777,11 @@ class BRepBuilderAPI_BndBoxTreeSelector : public BRepBuilderAPI_BndBoxTree::Sele
 };
 
 
+%extend BRepBuilderAPI_BndBoxTreeSelector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeShape;
 class BRepBuilderAPI_MakeShape : public BRepBuilderAPI_Command {
 	public:
@@ -797,6 +832,11 @@ class BRepBuilderAPI_MakeShape : public BRepBuilderAPI_Command {
 };
 
 
+%extend BRepBuilderAPI_MakeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeEdge;
 class BRepBuilderAPI_MakeEdge : public BRepBuilderAPI_MakeShape {
 	public:
@@ -1321,6 +1361,11 @@ class BRepBuilderAPI_MakeEdge : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeEdge2d;
 class BRepBuilderAPI_MakeEdge2d : public BRepBuilderAPI_MakeShape {
 	public:
@@ -1681,6 +1726,11 @@ class BRepBuilderAPI_MakeEdge2d : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeEdge2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeFace;
 class BRepBuilderAPI_MakeFace : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2009,6 +2059,11 @@ class BRepBuilderAPI_MakeFace : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakePolygon;
 class BRepBuilderAPI_MakePolygon : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2155,6 +2210,11 @@ class BRepBuilderAPI_MakePolygon : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakePolygon {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeShell;
 class BRepBuilderAPI_MakeShell : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2235,6 +2295,11 @@ class BRepBuilderAPI_MakeShell : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeSolid;
 class BRepBuilderAPI_MakeSolid : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2333,6 +2398,11 @@ class BRepBuilderAPI_MakeSolid : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeVertex;
 class BRepBuilderAPI_MakeVertex : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2357,6 +2427,11 @@ class BRepBuilderAPI_MakeVertex : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_MakeWire;
 class BRepBuilderAPI_MakeWire : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2489,6 +2564,11 @@ class BRepBuilderAPI_MakeWire : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_MakeWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_ModifyShape;
 class BRepBuilderAPI_ModifyShape : public BRepBuilderAPI_MakeShape {
 	public:
@@ -2511,6 +2591,11 @@ class BRepBuilderAPI_ModifyShape : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepBuilderAPI_ModifyShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_Copy;
 class BRepBuilderAPI_Copy : public BRepBuilderAPI_ModifyShape {
 	public:
@@ -2543,6 +2628,11 @@ class BRepBuilderAPI_Copy : public BRepBuilderAPI_ModifyShape {
 };
 
 
+%extend BRepBuilderAPI_Copy {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_GTransform;
 class BRepBuilderAPI_GTransform : public BRepBuilderAPI_ModifyShape {
 	public:
@@ -2595,6 +2685,11 @@ class BRepBuilderAPI_GTransform : public BRepBuilderAPI_ModifyShape {
 };
 
 
+%extend BRepBuilderAPI_GTransform {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_NurbsConvert;
 class BRepBuilderAPI_NurbsConvert : public BRepBuilderAPI_ModifyShape {
 	public:
@@ -2627,6 +2722,11 @@ class BRepBuilderAPI_NurbsConvert : public BRepBuilderAPI_ModifyShape {
 };
 
 
+%extend BRepBuilderAPI_NurbsConvert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepBuilderAPI_Transform;
 class BRepBuilderAPI_Transform : public BRepBuilderAPI_ModifyShape {
 	public:
@@ -2679,3 +2779,8 @@ class BRepBuilderAPI_Transform : public BRepBuilderAPI_ModifyShape {
 };
 
 
+%extend BRepBuilderAPI_Transform {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepCheck.i
+++ b/src/SWIG_files/wrapper/BRepCheck.i
@@ -128,6 +128,11 @@ class BRepCheck {
 };
 
 
+%extend BRepCheck {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Analyzer;
 class BRepCheck_Analyzer {
 	public:
@@ -174,6 +179,11 @@ class BRepCheck_Analyzer {
 };
 
 
+%extend BRepCheck_Analyzer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapIteratorOfDataMapOfShapeListOfStatus;
 class BRepCheck_DataMapIteratorOfDataMapOfShapeListOfStatus : public TCollection_BasicMapIterator {
 	public:
@@ -204,6 +214,11 @@ class BRepCheck_DataMapIteratorOfDataMapOfShapeListOfStatus : public TCollection
 };
 
 
+%extend BRepCheck_DataMapIteratorOfDataMapOfShapeListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapIteratorOfDataMapOfShapeResult;
 class BRepCheck_DataMapIteratorOfDataMapOfShapeResult : public TCollection_BasicMapIterator {
 	public:
@@ -234,6 +249,11 @@ class BRepCheck_DataMapIteratorOfDataMapOfShapeResult : public TCollection_Basic
 };
 
 
+%extend BRepCheck_DataMapIteratorOfDataMapOfShapeResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapNodeOfDataMapOfShapeListOfStatus;
 class BRepCheck_DataMapNodeOfDataMapOfShapeListOfStatus : public TCollection_MapNode {
 	public:
@@ -304,6 +324,11 @@ class Handle_BRepCheck_DataMapNodeOfDataMapOfShapeListOfStatus : public Handle_T
     }
 };
 
+%extend BRepCheck_DataMapNodeOfDataMapOfShapeListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapNodeOfDataMapOfShapeResult;
 class BRepCheck_DataMapNodeOfDataMapOfShapeResult : public TCollection_MapNode {
 	public:
@@ -374,6 +399,11 @@ class Handle_BRepCheck_DataMapNodeOfDataMapOfShapeResult : public Handle_TCollec
     }
 };
 
+%extend BRepCheck_DataMapNodeOfDataMapOfShapeResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapOfShapeListOfStatus;
 class BRepCheck_DataMapOfShapeListOfStatus : public TCollection_BasicMap {
 	public:
@@ -452,6 +482,11 @@ class BRepCheck_DataMapOfShapeListOfStatus : public TCollection_BasicMap {
 };
 
 
+%extend BRepCheck_DataMapOfShapeListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_DataMapOfShapeResult;
 class BRepCheck_DataMapOfShapeResult : public TCollection_BasicMap {
 	public:
@@ -530,6 +565,11 @@ class BRepCheck_DataMapOfShapeResult : public TCollection_BasicMap {
 };
 
 
+%extend BRepCheck_DataMapOfShapeResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_ListIteratorOfListOfStatus;
 class BRepCheck_ListIteratorOfListOfStatus {
 	public:
@@ -564,6 +604,11 @@ class BRepCheck_ListIteratorOfListOfStatus {
 };
 
 
+%extend BRepCheck_ListIteratorOfListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_ListNodeOfListOfStatus;
 class BRepCheck_ListNodeOfListOfStatus : public TCollection_MapNode {
 	public:
@@ -628,6 +673,11 @@ class Handle_BRepCheck_ListNodeOfListOfStatus : public Handle_TCollection_MapNod
     }
 };
 
+%extend BRepCheck_ListNodeOfListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_ListOfStatus;
 class BRepCheck_ListOfStatus {
 	public:
@@ -758,6 +808,11 @@ class BRepCheck_ListOfStatus {
 };
 
 
+%extend BRepCheck_ListOfStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Result;
 class BRepCheck_Result : public MMgt_TShared {
 	public:
@@ -876,6 +931,11 @@ class Handle_BRepCheck_Result : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepCheck_Result {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Edge;
 class BRepCheck_Edge : public BRepCheck_Result {
 	public:
@@ -978,6 +1038,11 @@ class Handle_BRepCheck_Edge : public Handle_BRepCheck_Result {
     }
 };
 
+%extend BRepCheck_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Face;
 class BRepCheck_Face : public BRepCheck_Result {
 	public:
@@ -1094,6 +1159,11 @@ class Handle_BRepCheck_Face : public Handle_BRepCheck_Result {
     }
 };
 
+%extend BRepCheck_Face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Shell;
 class BRepCheck_Shell : public BRepCheck_Result {
 	public:
@@ -1196,6 +1266,11 @@ class Handle_BRepCheck_Shell : public Handle_BRepCheck_Result {
     }
 };
 
+%extend BRepCheck_Shell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Vertex;
 class BRepCheck_Vertex : public BRepCheck_Result {
 	public:
@@ -1272,6 +1347,11 @@ class Handle_BRepCheck_Vertex : public Handle_BRepCheck_Result {
     }
 };
 
+%extend BRepCheck_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepCheck_Wire;
 class BRepCheck_Wire : public BRepCheck_Result {
 	public:
@@ -1414,3 +1494,8 @@ class Handle_BRepCheck_Wire : public Handle_BRepCheck_Result {
     }
 };
 
+%extend BRepCheck_Wire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepClass.i
+++ b/src/SWIG_files/wrapper/BRepClass.i
@@ -90,6 +90,11 @@ class BRepClass_Edge {
 };
 
 
+%extend BRepClass_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass_FClass2dOfFClassifier;
 class BRepClass_FClass2dOfFClassifier {
 	public:
@@ -138,6 +143,11 @@ class BRepClass_FClass2dOfFClassifier {
 };
 
 
+%extend BRepClass_FClass2dOfFClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass_FClassifier;
 class BRepClass_FClassifier {
 	public:
@@ -192,6 +202,11 @@ class BRepClass_FClassifier {
 };
 
 
+%extend BRepClass_FClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass_FaceExplorer;
 class BRepClass_FaceExplorer {
 	public:
@@ -302,6 +317,11 @@ class BRepClass_FaceExplorer {
 };
 
 
+%extend BRepClass_FaceExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass_FacePassiveClassifier;
 class BRepClass_FacePassiveClassifier {
 	public:
@@ -350,6 +370,11 @@ class BRepClass_FacePassiveClassifier {
 };
 
 
+%extend BRepClass_FacePassiveClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass_Intersector;
 class BRepClass_Intersector : public Geom2dInt_IntConicCurveOfGInter {
 	public:
@@ -390,3 +415,8 @@ class BRepClass_Intersector : public Geom2dInt_IntConicCurveOfGInter {
 };
 
 
+%extend BRepClass_Intersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepClass3d.i
+++ b/src/SWIG_files/wrapper/BRepClass3d.i
@@ -70,6 +70,11 @@ class BRepClass3d {
 };
 
 
+%extend BRepClass3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_DataMapIteratorOfMapOfInter;
 class BRepClass3d_DataMapIteratorOfMapOfInter : public TCollection_BasicMapIterator {
 	public:
@@ -100,6 +105,11 @@ class BRepClass3d_DataMapIteratorOfMapOfInter : public TCollection_BasicMapItera
 };
 
 
+%extend BRepClass3d_DataMapIteratorOfMapOfInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_DataMapNodeOfMapOfInter;
 class BRepClass3d_DataMapNodeOfMapOfInter : public TCollection_MapNode {
 	public:
@@ -170,6 +180,11 @@ class Handle_BRepClass3d_DataMapNodeOfMapOfInter : public Handle_TCollection_Map
     }
 };
 
+%extend BRepClass3d_DataMapNodeOfMapOfInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_Intersector3d;
 class BRepClass3d_Intersector3d {
 	public:
@@ -250,6 +265,11 @@ class BRepClass3d_Intersector3d {
 };
 
 
+%extend BRepClass3d_Intersector3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_MapOfInter;
 class BRepClass3d_MapOfInter : public TCollection_BasicMap {
 	public:
@@ -328,6 +348,11 @@ class BRepClass3d_MapOfInter : public TCollection_BasicMap {
 };
 
 
+%extend BRepClass3d_MapOfInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_SClassifier;
 class BRepClass3d_SClassifier {
 	public:
@@ -398,6 +423,11 @@ class BRepClass3d_SClassifier {
 };
 
 
+%extend BRepClass3d_SClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_SolidExplorer;
 class BRepClass3d_SolidExplorer {
 	public:
@@ -708,6 +738,11 @@ class BRepClass3d_SolidExplorer {
 };
 
 
+%extend BRepClass3d_SolidExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_SolidPassiveClassifier;
 class BRepClass3d_SolidPassiveClassifier {
 	public:
@@ -752,6 +787,11 @@ class BRepClass3d_SolidPassiveClassifier {
 };
 
 
+%extend BRepClass3d_SolidPassiveClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepClass3d_SolidClassifier;
 class BRepClass3d_SolidClassifier : public BRepClass3d_SClassifier {
 	public:
@@ -812,3 +852,8 @@ class BRepClass3d_SolidClassifier : public BRepClass3d_SClassifier {
 };
 
 
+%extend BRepClass3d_SolidClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepExtrema.i
+++ b/src/SWIG_files/wrapper/BRepExtrema.i
@@ -269,6 +269,11 @@ class BRepExtrema_DistShapeShape {
 };
 
 
+%extend BRepExtrema_DistShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_DistanceSS;
 class BRepExtrema_DistanceSS {
 	public:
@@ -357,6 +362,11 @@ class BRepExtrema_DistanceSS {
 };
 
 
+%extend BRepExtrema_DistanceSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_ExtCC;
 class BRepExtrema_ExtCC {
 	public:
@@ -471,6 +481,11 @@ class BRepExtrema_ExtCC {
 };
 
 
+%extend BRepExtrema_ExtCC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_ExtCF;
 class BRepExtrema_ExtCF {
 	public:
@@ -571,6 +586,11 @@ class BRepExtrema_ExtCF {
 };
 
 
+%extend BRepExtrema_ExtCF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_ExtFF;
 class BRepExtrema_ExtFF {
 	public:
@@ -673,6 +693,11 @@ class BRepExtrema_ExtFF {
 };
 
 
+%extend BRepExtrema_ExtFF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_ExtPC;
 class BRepExtrema_ExtPC {
 	public:
@@ -765,6 +790,11 @@ class BRepExtrema_ExtPC {
 };
 
 
+%extend BRepExtrema_ExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_ExtPF;
 class BRepExtrema_ExtPF {
 	public:
@@ -861,6 +891,11 @@ class BRepExtrema_ExtPF {
 };
 
 
+%extend BRepExtrema_ExtPF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_Poly;
 class BRepExtrema_Poly {
 	public:
@@ -883,6 +918,11 @@ class BRepExtrema_Poly {
 };
 
 
+%extend BRepExtrema_Poly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepExtrema_SolutionElem;
 class BRepExtrema_SolutionElem {
 	public:
@@ -997,3 +1037,8 @@ class BRepExtrema_SolutionElem {
 };
 
 
+%extend BRepExtrema_SolutionElem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepFeat.i
+++ b/src/SWIG_files/wrapper/BRepFeat.i
@@ -189,6 +189,11 @@ class BRepFeat {
 };
 
 
+%extend BRepFeat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_Builder;
 class BRepFeat_Builder : public BOPAlgo_BOP {
 	public:
@@ -313,6 +318,11 @@ class BRepFeat_Builder : public BOPAlgo_BOP {
 };
 
 
+%extend BRepFeat_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_Form;
 class BRepFeat_Form : public BRepBuilderAPI_MakeShape {
 	public:
@@ -421,6 +431,11 @@ class BRepFeat_Form : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFeat_Form {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_Gluer;
 class BRepFeat_Gluer : public BRepBuilderAPI_MakeShape {
 	public:
@@ -513,6 +528,11 @@ class BRepFeat_Gluer : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFeat_Gluer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_RibSlot;
 class BRepFeat_RibSlot : public BRepBuilderAPI_MakeShape {
 	public:
@@ -599,6 +619,11 @@ class BRepFeat_RibSlot : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFeat_RibSlot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_SplitShape;
 class BRepFeat_SplitShape : public BRepBuilderAPI_MakeShape {
 	public:
@@ -709,6 +734,11 @@ class BRepFeat_SplitShape : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFeat_SplitShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakeCylindricalHole;
 class BRepFeat_MakeCylindricalHole : public BRepFeat_Builder {
 	public:
@@ -805,6 +835,11 @@ class BRepFeat_MakeCylindricalHole : public BRepFeat_Builder {
 };
 
 
+%extend BRepFeat_MakeCylindricalHole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakeDPrism;
 class BRepFeat_MakeDPrism : public BRepFeat_Form {
 	public:
@@ -943,6 +978,11 @@ class BRepFeat_MakeDPrism : public BRepFeat_Form {
 };
 
 
+%extend BRepFeat_MakeDPrism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakeLinearForm;
 class BRepFeat_MakeLinearForm : public BRepFeat_RibSlot {
 	public:
@@ -1025,6 +1065,11 @@ class BRepFeat_MakeLinearForm : public BRepFeat_RibSlot {
 };
 
 
+%extend BRepFeat_MakeLinearForm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakePipe;
 class BRepFeat_MakePipe : public BRepFeat_Form {
 	public:
@@ -1113,6 +1158,11 @@ class BRepFeat_MakePipe : public BRepFeat_Form {
 };
 
 
+%extend BRepFeat_MakePipe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakePrism;
 class BRepFeat_MakePrism : public BRepFeat_Form {
 	public:
@@ -1237,6 +1287,11 @@ class BRepFeat_MakePrism : public BRepFeat_Form {
 };
 
 
+%extend BRepFeat_MakePrism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakeRevol;
 class BRepFeat_MakeRevol : public BRepFeat_Form {
 	public:
@@ -1341,6 +1396,11 @@ class BRepFeat_MakeRevol : public BRepFeat_Form {
 };
 
 
+%extend BRepFeat_MakeRevol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFeat_MakeRevolutionForm;
 class BRepFeat_MakeRevolutionForm : public BRepFeat_RibSlot {
 	public:
@@ -1427,3 +1487,8 @@ class BRepFeat_MakeRevolutionForm : public BRepFeat_RibSlot {
 };
 
 
+%extend BRepFeat_MakeRevolutionForm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepFill.i
+++ b/src/SWIG_files/wrapper/BRepFill.i
@@ -132,6 +132,11 @@ class BRepFill {
 };
 
 
+%extend BRepFill {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ApproxSeewing;
 class BRepFill_ApproxSeewing {
 	public:
@@ -176,6 +181,11 @@ class BRepFill_ApproxSeewing {
 };
 
 
+%extend BRepFill_ApproxSeewing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_CompatibleWires;
 class BRepFill_CompatibleWires {
 	public:
@@ -234,6 +244,11 @@ class BRepFill_CompatibleWires {
 };
 
 
+%extend BRepFill_CompatibleWires {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ComputeCLine;
 class BRepFill_ComputeCLine {
 	public:
@@ -346,6 +361,11 @@ class BRepFill_ComputeCLine {
 };
 
 
+%extend BRepFill_ComputeCLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_CurveConstraint;
 class BRepFill_CurveConstraint : public GeomPlate_CurveConstraint {
 	public:
@@ -428,6 +448,11 @@ class Handle_BRepFill_CurveConstraint : public Handle_GeomPlate_CurveConstraint 
     }
 };
 
+%extend BRepFill_CurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfNodeDataMapOfShapeShape;
 class BRepFill_DataMapIteratorOfDataMapOfNodeDataMapOfShapeShape : public TCollection_BasicMapIterator {
 	public:
@@ -458,6 +483,11 @@ class BRepFill_DataMapIteratorOfDataMapOfNodeDataMapOfShapeShape : public TColle
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfNodeDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfNodeShape;
 class BRepFill_DataMapIteratorOfDataMapOfNodeShape : public TCollection_BasicMapIterator {
 	public:
@@ -488,6 +518,11 @@ class BRepFill_DataMapIteratorOfDataMapOfNodeShape : public TCollection_BasicMap
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfNodeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfOrientedShapeListOfShape;
 class BRepFill_DataMapIteratorOfDataMapOfOrientedShapeListOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -518,6 +553,11 @@ class BRepFill_DataMapIteratorOfDataMapOfOrientedShapeListOfShape : public TColl
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfOrientedShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfShapeDataMapOfShapeListOfShape;
 class BRepFill_DataMapIteratorOfDataMapOfShapeDataMapOfShapeListOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -548,6 +588,11 @@ class BRepFill_DataMapIteratorOfDataMapOfShapeDataMapOfShapeListOfShape : public
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfShapeDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfShapeHArray2OfShape;
 class BRepFill_DataMapIteratorOfDataMapOfShapeHArray2OfShape : public TCollection_BasicMapIterator {
 	public:
@@ -578,6 +623,11 @@ class BRepFill_DataMapIteratorOfDataMapOfShapeHArray2OfShape : public TCollectio
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfShapeHArray2OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfPnt;
 class BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfPnt : public TCollection_BasicMapIterator {
 	public:
@@ -608,6 +658,11 @@ class BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfPnt : public TCollection
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfReal;
 class BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfReal : public TCollection_BasicMapIterator {
 	public:
@@ -638,6 +693,11 @@ class BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfReal : public TCollectio
 };
 
 
+%extend BRepFill_DataMapIteratorOfDataMapOfShapeSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfNodeDataMapOfShapeShape;
 class BRepFill_DataMapNodeOfDataMapOfNodeDataMapOfShapeShape : public TCollection_MapNode {
 	public:
@@ -708,6 +768,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfNodeDataMapOfShapeShape : public Han
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfNodeDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfNodeShape;
 class BRepFill_DataMapNodeOfDataMapOfNodeShape : public TCollection_MapNode {
 	public:
@@ -778,6 +843,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfNodeShape : public Handle_TCollectio
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfNodeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfOrientedShapeListOfShape;
 class BRepFill_DataMapNodeOfDataMapOfOrientedShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -848,6 +918,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfOrientedShapeListOfShape : public Ha
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfOrientedShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfShapeDataMapOfShapeListOfShape;
 class BRepFill_DataMapNodeOfDataMapOfShapeDataMapOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -918,6 +993,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfShapeDataMapOfShapeListOfShape : pub
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfShapeDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfShapeHArray2OfShape;
 class BRepFill_DataMapNodeOfDataMapOfShapeHArray2OfShape : public TCollection_MapNode {
 	public:
@@ -988,6 +1068,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfShapeHArray2OfShape : public Handle_
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfShapeHArray2OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfPnt;
 class BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfPnt : public TCollection_MapNode {
 	public:
@@ -1058,6 +1143,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfPnt : public Handle_T
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfReal;
 class BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfReal : public TCollection_MapNode {
 	public:
@@ -1128,6 +1218,11 @@ class Handle_BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfReal : public Handle_
     }
 };
 
+%extend BRepFill_DataMapNodeOfDataMapOfShapeSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfNodeDataMapOfShapeShape;
 class BRepFill_DataMapOfNodeDataMapOfShapeShape : public TCollection_BasicMap {
 	public:
@@ -1206,6 +1301,11 @@ class BRepFill_DataMapOfNodeDataMapOfShapeShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfNodeDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfNodeShape;
 class BRepFill_DataMapOfNodeShape : public TCollection_BasicMap {
 	public:
@@ -1284,6 +1384,11 @@ class BRepFill_DataMapOfNodeShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfNodeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfOrientedShapeListOfShape;
 class BRepFill_DataMapOfOrientedShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -1362,6 +1467,11 @@ class BRepFill_DataMapOfOrientedShapeListOfShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfOrientedShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfShapeDataMapOfShapeListOfShape;
 class BRepFill_DataMapOfShapeDataMapOfShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -1440,6 +1550,11 @@ class BRepFill_DataMapOfShapeDataMapOfShapeListOfShape : public TCollection_Basi
 };
 
 
+%extend BRepFill_DataMapOfShapeDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfShapeHArray2OfShape;
 class BRepFill_DataMapOfShapeHArray2OfShape : public TCollection_BasicMap {
 	public:
@@ -1518,6 +1633,11 @@ class BRepFill_DataMapOfShapeHArray2OfShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfShapeHArray2OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfShapeSequenceOfPnt;
 class BRepFill_DataMapOfShapeSequenceOfPnt : public TCollection_BasicMap {
 	public:
@@ -1596,6 +1716,11 @@ class BRepFill_DataMapOfShapeSequenceOfPnt : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfShapeSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DataMapOfShapeSequenceOfReal;
 class BRepFill_DataMapOfShapeSequenceOfReal : public TCollection_BasicMap {
 	public:
@@ -1674,6 +1799,11 @@ class BRepFill_DataMapOfShapeSequenceOfReal : public TCollection_BasicMap {
 };
 
 
+%extend BRepFill_DataMapOfShapeSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Draft;
 class BRepFill_Draft {
 	public:
@@ -1750,6 +1880,11 @@ class BRepFill_Draft {
 };
 
 
+%extend BRepFill_Draft {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_EdgeFaceAndOrder;
 class BRepFill_EdgeFaceAndOrder {
 	public:
@@ -1770,6 +1905,11 @@ class BRepFill_EdgeFaceAndOrder {
 };
 
 
+%extend BRepFill_EdgeFaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Evolved;
 class BRepFill_Evolved {
 	public:
@@ -1880,6 +2020,11 @@ class BRepFill_Evolved {
 };
 
 
+%extend BRepFill_Evolved {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_FaceAndOrder;
 class BRepFill_FaceAndOrder {
 	public:
@@ -1898,6 +2043,11 @@ class BRepFill_FaceAndOrder {
 };
 
 
+%extend BRepFill_FaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Filling;
 class BRepFill_Filling {
 	public:
@@ -2086,6 +2236,11 @@ class BRepFill_Filling {
 };
 
 
+%extend BRepFill_Filling {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Generator;
 class BRepFill_Generator {
 	public:
@@ -2126,6 +2281,11 @@ class BRepFill_Generator {
 };
 
 
+%extend BRepFill_Generator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_IndexedDataMapNodeOfIndexedDataMapOfOrientedShapeListOfShape;
 class BRepFill_IndexedDataMapNodeOfIndexedDataMapOfOrientedShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -2217,6 +2377,11 @@ class Handle_BRepFill_IndexedDataMapNodeOfIndexedDataMapOfOrientedShapeListOfSha
     }
 };
 
+%extend BRepFill_IndexedDataMapNodeOfIndexedDataMapOfOrientedShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_IndexedDataMapOfOrientedShapeListOfShape;
 class BRepFill_IndexedDataMapOfOrientedShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -2327,6 +2492,11 @@ class BRepFill_IndexedDataMapOfOrientedShapeListOfShape : public TCollection_Bas
 };
 
 
+%extend BRepFill_IndexedDataMapOfOrientedShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ListIteratorOfListOfOffsetWire;
 class BRepFill_ListIteratorOfListOfOffsetWire {
 	public:
@@ -2361,6 +2531,11 @@ class BRepFill_ListIteratorOfListOfOffsetWire {
 };
 
 
+%extend BRepFill_ListIteratorOfListOfOffsetWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ListNodeOfListOfOffsetWire;
 class BRepFill_ListNodeOfListOfOffsetWire : public TCollection_MapNode {
 	public:
@@ -2425,6 +2600,11 @@ class Handle_BRepFill_ListNodeOfListOfOffsetWire : public Handle_TCollection_Map
     }
 };
 
+%extend BRepFill_ListNodeOfListOfOffsetWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ListOfOffsetWire;
 class BRepFill_ListOfOffsetWire {
 	public:
@@ -2555,6 +2735,11 @@ class BRepFill_ListOfOffsetWire {
 };
 
 
+%extend BRepFill_ListOfOffsetWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_LocationLaw;
 class BRepFill_LocationLaw : public MMgt_TShared {
 	public:
@@ -2755,6 +2940,11 @@ class Handle_BRepFill_LocationLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepFill_LocationLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_MultiLine;
 class BRepFill_MultiLine {
 	public:
@@ -2855,6 +3045,11 @@ class BRepFill_MultiLine {
 };
 
 
+%extend BRepFill_MultiLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepFill_MultiLineTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -2968,6 +3163,11 @@ class BRepFill_MultiLineTool {
 };
 
 
+%extend BRepFill_MultiLineTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_MyLeastSquareOfComputeCLine;
 class BRepFill_MyLeastSquareOfComputeCLine {
 	public:
@@ -3010,6 +3210,11 @@ class BRepFill_MyLeastSquareOfComputeCLine {
 };
 
 
+%extend BRepFill_MyLeastSquareOfComputeCLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_OffsetAncestors;
 class BRepFill_OffsetAncestors {
 	public:
@@ -3050,6 +3255,11 @@ class BRepFill_OffsetAncestors {
 };
 
 
+%extend BRepFill_OffsetAncestors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_OffsetWire;
 class BRepFill_OffsetWire {
 	public:
@@ -3136,6 +3346,11 @@ class BRepFill_OffsetWire {
 };
 
 
+%extend BRepFill_OffsetWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Pipe;
 class BRepFill_Pipe {
 	public:
@@ -3230,6 +3445,11 @@ class BRepFill_Pipe {
 };
 
 
+%extend BRepFill_Pipe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_PipeShell;
 class BRepFill_PipeShell : public MMgt_TShared {
 	public:
@@ -3516,6 +3736,11 @@ class Handle_BRepFill_PipeShell : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepFill_PipeShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Section;
 class BRepFill_Section {
 	public:
@@ -3564,6 +3789,11 @@ class BRepFill_Section {
 };
 
 
+%extend BRepFill_Section {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SectionLaw;
 class BRepFill_SectionLaw : public MMgt_TShared {
 	public:
@@ -3690,6 +3920,11 @@ class Handle_BRepFill_SectionLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepFill_SectionLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SectionPlacement;
 class BRepFill_SectionPlacement {
 	public:
@@ -3734,6 +3969,11 @@ class BRepFill_SectionPlacement {
 };
 
 
+%extend BRepFill_SectionPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceNodeOfSequenceOfEdgeFaceAndOrder;
 class BRepFill_SequenceNodeOfSequenceOfEdgeFaceAndOrder : public TCollection_SeqNode {
 	public:
@@ -3800,6 +4040,11 @@ class Handle_BRepFill_SequenceNodeOfSequenceOfEdgeFaceAndOrder : public Handle_T
     }
 };
 
+%extend BRepFill_SequenceNodeOfSequenceOfEdgeFaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceNodeOfSequenceOfFaceAndOrder;
 class BRepFill_SequenceNodeOfSequenceOfFaceAndOrder : public TCollection_SeqNode {
 	public:
@@ -3866,6 +4111,11 @@ class Handle_BRepFill_SequenceNodeOfSequenceOfFaceAndOrder : public Handle_TColl
     }
 };
 
+%extend BRepFill_SequenceNodeOfSequenceOfFaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceNodeOfSequenceOfSection;
 class BRepFill_SequenceNodeOfSequenceOfSection : public TCollection_SeqNode {
 	public:
@@ -3932,6 +4182,11 @@ class Handle_BRepFill_SequenceNodeOfSequenceOfSection : public Handle_TCollectio
     }
 };
 
+%extend BRepFill_SequenceNodeOfSequenceOfSection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceOfEdgeFaceAndOrder;
 class BRepFill_SequenceOfEdgeFaceAndOrder : public TCollection_BaseSequence {
 	public:
@@ -4070,6 +4325,11 @@ class BRepFill_SequenceOfEdgeFaceAndOrder : public TCollection_BaseSequence {
 };
 
 
+%extend BRepFill_SequenceOfEdgeFaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceOfFaceAndOrder;
 class BRepFill_SequenceOfFaceAndOrder : public TCollection_BaseSequence {
 	public:
@@ -4208,6 +4468,11 @@ class BRepFill_SequenceOfFaceAndOrder : public TCollection_BaseSequence {
 };
 
 
+%extend BRepFill_SequenceOfFaceAndOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_SequenceOfSection;
 class BRepFill_SequenceOfSection : public TCollection_BaseSequence {
 	public:
@@ -4346,6 +4611,11 @@ class BRepFill_SequenceOfSection : public TCollection_BaseSequence {
 };
 
 
+%extend BRepFill_SequenceOfSection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Sweep;
 class BRepFill_Sweep {
 	public:
@@ -4454,6 +4724,11 @@ class BRepFill_Sweep {
 };
 
 
+%extend BRepFill_Sweep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_TrimEdgeTool;
 class BRepFill_TrimEdgeTool {
 	public:
@@ -4504,6 +4779,11 @@ class BRepFill_TrimEdgeTool {
 };
 
 
+%extend BRepFill_TrimEdgeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_TrimShellCorner;
 class BRepFill_TrimShellCorner {
 	public:
@@ -4570,6 +4850,11 @@ class BRepFill_TrimShellCorner {
 };
 
 
+%extend BRepFill_TrimShellCorner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_TrimSurfaceTool;
 class BRepFill_TrimSurfaceTool {
 	public:
@@ -4640,6 +4925,11 @@ class BRepFill_TrimSurfaceTool {
 };
 
 
+%extend BRepFill_TrimSurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ACRLaw;
 class BRepFill_ACRLaw : public BRepFill_LocationLaw {
 	public:
@@ -4700,6 +4990,11 @@ class Handle_BRepFill_ACRLaw : public Handle_BRepFill_LocationLaw {
     }
 };
 
+%extend BRepFill_ACRLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_Edge3DLaw;
 class BRepFill_Edge3DLaw : public BRepFill_LocationLaw {
 	public:
@@ -4760,6 +5055,11 @@ class Handle_BRepFill_Edge3DLaw : public Handle_BRepFill_LocationLaw {
     }
 };
 
+%extend BRepFill_Edge3DLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_EdgeOnSurfLaw;
 class BRepFill_EdgeOnSurfLaw : public BRepFill_LocationLaw {
 	public:
@@ -4826,6 +5126,11 @@ class Handle_BRepFill_EdgeOnSurfLaw : public Handle_BRepFill_LocationLaw {
     }
 };
 
+%extend BRepFill_EdgeOnSurfLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_NSections;
 class BRepFill_NSections : public BRepFill_SectionLaw {
 	public:
@@ -4956,6 +5261,11 @@ class Handle_BRepFill_NSections : public Handle_BRepFill_SectionLaw {
     }
 };
 
+%extend BRepFill_NSections {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_ShapeLaw;
 class BRepFill_ShapeLaw : public BRepFill_SectionLaw {
 	public:
@@ -5096,6 +5406,11 @@ class Handle_BRepFill_ShapeLaw : public Handle_BRepFill_SectionLaw {
     }
 };
 
+%extend BRepFill_ShapeLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFill_DraftLaw;
 class BRepFill_DraftLaw : public BRepFill_Edge3DLaw {
 	public:
@@ -5164,3 +5479,8 @@ class Handle_BRepFill_DraftLaw : public Handle_BRepFill_Edge3DLaw {
     }
 };
 
+%extend BRepFill_DraftLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepFilletAPI.i
+++ b/src/SWIG_files/wrapper/BRepFilletAPI.i
@@ -204,6 +204,11 @@ class BRepFilletAPI_LocalOperation : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFilletAPI_LocalOperation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFilletAPI_MakeFillet2d;
 class BRepFilletAPI_MakeFillet2d : public BRepBuilderAPI_MakeShape {
 	public:
@@ -422,6 +427,11 @@ class BRepFilletAPI_MakeFillet2d : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepFilletAPI_MakeFillet2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFilletAPI_MakeChamfer;
 class BRepFilletAPI_MakeChamfer : public BRepFilletAPI_LocalOperation {
 	public:
@@ -750,6 +760,11 @@ class BRepFilletAPI_MakeChamfer : public BRepFilletAPI_LocalOperation {
 };
 
 
+%extend BRepFilletAPI_MakeChamfer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepFilletAPI_MakeFillet;
 class BRepFilletAPI_MakeFillet : public BRepFilletAPI_LocalOperation {
 	public:
@@ -1242,3 +1257,8 @@ class BRepFilletAPI_MakeFillet : public BRepFilletAPI_LocalOperation {
 };
 
 
+%extend BRepFilletAPI_MakeFillet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepGProp.i
+++ b/src/SWIG_files/wrapper/BRepGProp.i
@@ -158,6 +158,11 @@ class BRepGProp {
 };
 
 
+%extend BRepGProp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_Cinert;
 class BRepGProp_Cinert : public GProp_GProps {
 	public:
@@ -188,6 +193,11 @@ class BRepGProp_Cinert : public GProp_GProps {
 };
 
 
+%extend BRepGProp_Cinert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_Domain;
 class BRepGProp_Domain {
 	public:
@@ -240,6 +250,11 @@ class BRepGProp_Domain {
 };
 
 
+%extend BRepGProp_Domain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepGProp_EdgeTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -315,6 +330,11 @@ class BRepGProp_EdgeTool {
 };
 
 
+%extend BRepGProp_EdgeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_Face;
 class BRepGProp_Face {
 	public:
@@ -511,6 +531,11 @@ class BRepGProp_Face {
 };
 
 
+%extend BRepGProp_Face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_Sinert;
 class BRepGProp_Sinert : public GProp_GProps {
 	public:
@@ -607,6 +632,11 @@ class BRepGProp_Sinert : public GProp_GProps {
 };
 
 
+%extend BRepGProp_Sinert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_TFunction;
 class BRepGProp_TFunction : public math_Function {
 	public:
@@ -687,6 +717,11 @@ class BRepGProp_TFunction : public math_Function {
 };
 
 
+%extend BRepGProp_TFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_UFunction;
 class BRepGProp_UFunction : public math_Function {
 	public:
@@ -733,6 +768,11 @@ class BRepGProp_UFunction : public math_Function {
 };
 
 
+%extend BRepGProp_UFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_Vinert;
 class BRepGProp_Vinert : public GProp_GProps {
 	public:
@@ -1027,6 +1067,11 @@ class BRepGProp_Vinert : public GProp_GProps {
 };
 
 
+%extend BRepGProp_Vinert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepGProp_VinertGK;
 class BRepGProp_VinertGK : public GProp_GProps {
 	public:
@@ -1261,3 +1306,8 @@ class BRepGProp_VinertGK : public GProp_GProps {
 };
 
 
+%extend BRepGProp_VinertGK {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepIntCurveSurface.i
+++ b/src/SWIG_files/wrapper/BRepIntCurveSurface.i
@@ -170,3 +170,8 @@ class BRepIntCurveSurface_Inter {
 };
 
 
+%extend BRepIntCurveSurface_Inter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepLProp.i
+++ b/src/SWIG_files/wrapper/BRepLProp.i
@@ -94,6 +94,11 @@ class BRepLProp {
 };
 
 
+%extend BRepLProp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLProp_CLProps;
 class BRepLProp_CLProps {
 	public:
@@ -184,6 +189,11 @@ class BRepLProp_CLProps {
 };
 
 
+%extend BRepLProp_CLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepLProp_CurveTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -273,6 +283,11 @@ class BRepLProp_CurveTool {
 };
 
 
+%extend BRepLProp_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLProp_SLProps;
 class BRepLProp_SLProps {
 	public:
@@ -409,6 +424,11 @@ class BRepLProp_SLProps {
 };
 
 
+%extend BRepLProp_SLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepLProp_SurfaceTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -508,3 +528,8 @@ class BRepLProp_SurfaceTool {
 };
 
 
+%extend BRepLProp_SurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepLib.i
+++ b/src/SWIG_files/wrapper/BRepLib.i
@@ -298,6 +298,11 @@ class BRepLib {
 };
 
 
+%extend BRepLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_Command;
 class BRepLib_Command {
 	public:
@@ -318,6 +323,11 @@ class BRepLib_Command {
 };
 
 
+%extend BRepLib_Command {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_FindSurface;
 class BRepLib_FindSurface {
 	public:
@@ -380,6 +390,11 @@ class BRepLib_FindSurface {
 };
 
 
+%extend BRepLib_FindSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_FuseEdges;
 class BRepLib_FuseEdges {
 	public:
@@ -454,6 +469,11 @@ class BRepLib_FuseEdges {
 };
 
 
+%extend BRepLib_FuseEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeShape;
 class BRepLib_MakeShape : public BRepLib_Command {
 	public:
@@ -520,6 +540,11 @@ class BRepLib_MakeShape : public BRepLib_Command {
 };
 
 
+%extend BRepLib_MakeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeEdge;
 class BRepLib_MakeEdge : public BRepLib_MakeShape {
 	public:
@@ -1032,6 +1057,11 @@ class BRepLib_MakeEdge : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeEdge2d;
 class BRepLib_MakeEdge2d : public BRepLib_MakeShape {
 	public:
@@ -1388,6 +1418,11 @@ class BRepLib_MakeEdge2d : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeEdge2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeFace;
 class BRepLib_MakeFace : public BRepLib_MakeShape {
 	public:
@@ -1708,6 +1743,11 @@ class BRepLib_MakeFace : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakePolygon;
 class BRepLib_MakePolygon : public BRepLib_MakeShape {
 	public:
@@ -1836,6 +1876,11 @@ class BRepLib_MakePolygon : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakePolygon {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeShell;
 class BRepLib_MakeShell : public BRepLib_MakeShape {
 	public:
@@ -1904,6 +1949,11 @@ class BRepLib_MakeShell : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeSolid;
 class BRepLib_MakeSolid : public BRepLib_MakeShape {
 	public:
@@ -1998,6 +2048,11 @@ class BRepLib_MakeSolid : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeVertex;
 class BRepLib_MakeVertex : public BRepLib_MakeShape {
 	public:
@@ -2018,6 +2073,11 @@ class BRepLib_MakeVertex : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepLib_MakeWire;
 class BRepLib_MakeWire : public BRepLib_MakeShape {
 	public:
@@ -2142,3 +2202,8 @@ class BRepLib_MakeWire : public BRepLib_MakeShape {
 };
 
 
+%extend BRepLib_MakeWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepMAT2d.i
+++ b/src/SWIG_files/wrapper/BRepMAT2d.i
@@ -154,6 +154,11 @@ class BRepMAT2d_BisectingLocus {
 };
 
 
+%extend BRepMAT2d_BisectingLocus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapIteratorOfDataMapOfBasicEltShape;
 class BRepMAT2d_DataMapIteratorOfDataMapOfBasicEltShape : public TCollection_BasicMapIterator {
 	public:
@@ -184,6 +189,11 @@ class BRepMAT2d_DataMapIteratorOfDataMapOfBasicEltShape : public TCollection_Bas
 };
 
 
+%extend BRepMAT2d_DataMapIteratorOfDataMapOfBasicEltShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapIteratorOfDataMapOfShapeSequenceOfBasicElt;
 class BRepMAT2d_DataMapIteratorOfDataMapOfShapeSequenceOfBasicElt : public TCollection_BasicMapIterator {
 	public:
@@ -214,6 +224,11 @@ class BRepMAT2d_DataMapIteratorOfDataMapOfShapeSequenceOfBasicElt : public TColl
 };
 
 
+%extend BRepMAT2d_DataMapIteratorOfDataMapOfShapeSequenceOfBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapNodeOfDataMapOfBasicEltShape;
 class BRepMAT2d_DataMapNodeOfDataMapOfBasicEltShape : public TCollection_MapNode {
 	public:
@@ -284,6 +299,11 @@ class Handle_BRepMAT2d_DataMapNodeOfDataMapOfBasicEltShape : public Handle_TColl
     }
 };
 
+%extend BRepMAT2d_DataMapNodeOfDataMapOfBasicEltShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapNodeOfDataMapOfShapeSequenceOfBasicElt;
 class BRepMAT2d_DataMapNodeOfDataMapOfShapeSequenceOfBasicElt : public TCollection_MapNode {
 	public:
@@ -354,6 +374,11 @@ class Handle_BRepMAT2d_DataMapNodeOfDataMapOfShapeSequenceOfBasicElt : public Ha
     }
 };
 
+%extend BRepMAT2d_DataMapNodeOfDataMapOfShapeSequenceOfBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapOfBasicEltShape;
 class BRepMAT2d_DataMapOfBasicEltShape : public TCollection_BasicMap {
 	public:
@@ -432,6 +457,11 @@ class BRepMAT2d_DataMapOfBasicEltShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepMAT2d_DataMapOfBasicEltShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_DataMapOfShapeSequenceOfBasicElt;
 class BRepMAT2d_DataMapOfShapeSequenceOfBasicElt : public TCollection_BasicMap {
 	public:
@@ -510,6 +540,11 @@ class BRepMAT2d_DataMapOfShapeSequenceOfBasicElt : public TCollection_BasicMap {
 };
 
 
+%extend BRepMAT2d_DataMapOfShapeSequenceOfBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_Explorer;
 class BRepMAT2d_Explorer {
 	public:
@@ -606,6 +641,11 @@ class BRepMAT2d_Explorer {
 };
 
 
+%extend BRepMAT2d_Explorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMAT2d_LinkTopoBilo;
 class BRepMAT2d_LinkTopoBilo {
 	public:
@@ -670,3 +710,8 @@ class BRepMAT2d_LinkTopoBilo {
 };
 
 
+%extend BRepMAT2d_LinkTopoBilo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepMesh.i
+++ b/src/SWIG_files/wrapper/BRepMesh.i
@@ -177,6 +177,11 @@ class BRepMesh_Circle {
 };
 
 
+%extend BRepMesh_Circle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_CircleInspector;
 class BRepMesh_CircleInspector : public NCollection_CellFilter_InspectorXY {
 	public:
@@ -252,6 +257,11 @@ typedef Standard_Integer Target;
 };
 
 
+%extend BRepMesh_CircleInspector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_CircleTool;
 class BRepMesh_CircleTool {
 	public:
@@ -360,6 +370,11 @@ class BRepMesh_CircleTool {
 };
 
 
+%extend BRepMesh_CircleTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_Classifier;
 class BRepMesh_Classifier {
 	public:
@@ -404,6 +419,11 @@ class BRepMesh_Classifier {
 };
 
 
+%extend BRepMesh_Classifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_DataStructureOfDelaun;
 class BRepMesh_DataStructureOfDelaun : public Standard_Transient {
 	public:
@@ -686,6 +706,11 @@ class Handle_BRepMesh_DataStructureOfDelaun : public Handle_Standard_Transient {
     }
 };
 
+%extend BRepMesh_DataStructureOfDelaun {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_Delaun;
 class BRepMesh_Delaun {
 	public:
@@ -794,6 +819,11 @@ class BRepMesh_Delaun {
 };
 
 
+%extend BRepMesh_Delaun {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_DiscretFactory;
 %ignore BRepMesh_DiscretFactory::~BRepMesh_DiscretFactory();
 class BRepMesh_DiscretFactory {
@@ -869,6 +899,11 @@ class BRepMesh_DiscretFactory {
 };
 
 
+%extend BRepMesh_DiscretFactory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_DiscretRoot;
 class BRepMesh_DiscretRoot : public Standard_Transient {
 	public:
@@ -973,6 +1008,11 @@ class Handle_BRepMesh_DiscretRoot : public Handle_Standard_Transient {
     }
 };
 
+%extend BRepMesh_DiscretRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_EdgeChecker;
 class BRepMesh_EdgeChecker {
 	public:
@@ -993,6 +1033,11 @@ class BRepMesh_EdgeChecker {
 };
 
 
+%extend BRepMesh_EdgeChecker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_FaceChecker;
 class BRepMesh_FaceChecker {
 	public:
@@ -1013,6 +1058,11 @@ class BRepMesh_FaceChecker {
 };
 
 
+%extend BRepMesh_FaceChecker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_FastDiscret;
 class BRepMesh_FastDiscret : public Standard_Transient {
 	public:
@@ -1205,6 +1255,11 @@ class Handle_BRepMesh_FastDiscret : public Handle_Standard_Transient {
     }
 };
 
+%extend BRepMesh_FastDiscret {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_FastDiscretFace;
 class BRepMesh_FastDiscretFace : public Standard_Transient {
 	public:
@@ -1269,6 +1324,11 @@ class Handle_BRepMesh_FastDiscretFace : public Handle_Standard_Transient {
     }
 };
 
+%extend BRepMesh_FastDiscretFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_GeomTool;
 class BRepMesh_GeomTool {
 	public:
@@ -1377,6 +1437,11 @@ enum IntFlag {
 };
 
 
+%extend BRepMesh_GeomTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_IEdgeTool;
 class BRepMesh_IEdgeTool : public Standard_Transient {
 	public:
@@ -1449,6 +1514,11 @@ class Handle_BRepMesh_IEdgeTool : public Handle_Standard_Transient {
     }
 };
 
+%extend BRepMesh_IEdgeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_OrientedEdge;
 class BRepMesh_OrientedEdge {
 	public:
@@ -1519,6 +1589,11 @@ class BRepMesh_OrientedEdge {
         };
 
 
+%extend BRepMesh_OrientedEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_PairOfIndex;
 class BRepMesh_PairOfIndex {
 	public:
@@ -1603,6 +1678,11 @@ class BRepMesh_PairOfIndex {
 };
 
 
+%extend BRepMesh_PairOfIndex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_PairOfPolygon;
 class BRepMesh_PairOfPolygon {
 	public:
@@ -1649,6 +1729,11 @@ class BRepMesh_PairOfPolygon {
 };
 
 
+%extend BRepMesh_PairOfPolygon {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_SelectorOfDataStructureOfDelaun;
 class BRepMesh_SelectorOfDataStructureOfDelaun {
 	public:
@@ -1771,6 +1856,11 @@ class BRepMesh_SelectorOfDataStructureOfDelaun {
 };
 
 
+%extend BRepMesh_SelectorOfDataStructureOfDelaun {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepMesh_ShapeTool {
 	public:
 		%feature("compactdefaultargs") MaxFaceTolerance;
@@ -1904,6 +1994,11 @@ class BRepMesh_ShapeTool {
 };
 
 
+%extend BRepMesh_ShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_Triangle;
 class BRepMesh_Triangle {
 	public:
@@ -2000,6 +2095,11 @@ class BRepMesh_Triangle {
         };
 
 
+%extend BRepMesh_Triangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_Vertex;
 class BRepMesh_Vertex {
 	public:
@@ -2116,6 +2216,11 @@ class BRepMesh_Vertex {
         };
 
 
+%extend BRepMesh_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_VertexInspector;
 class BRepMesh_VertexInspector : public NCollection_CellFilter_InspectorXY {
 	public:
@@ -2237,6 +2342,11 @@ typedef Standard_Integer Target;
 };
 
 
+%extend BRepMesh_VertexInspector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_VertexTool;
 class BRepMesh_VertexTool {
 	public:
@@ -2377,6 +2487,11 @@ class BRepMesh_VertexTool {
         };
 
 
+%extend BRepMesh_VertexTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_WireChecker;
 class BRepMesh_WireChecker {
 	public:
@@ -2423,6 +2538,11 @@ class BRepMesh_WireChecker {
 };
 
 
+%extend BRepMesh_WireChecker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_Edge;
 class BRepMesh_Edge : public BRepMesh_OrientedEdge {
 	public:
@@ -2491,6 +2611,11 @@ class BRepMesh_Edge : public BRepMesh_OrientedEdge {
         };
 
 
+%extend BRepMesh_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepMesh_IncrementalMesh;
 class BRepMesh_IncrementalMesh : public BRepMesh_DiscretRoot {
 	public:
@@ -2639,3 +2764,8 @@ class Handle_BRepMesh_IncrementalMesh : public Handle_BRepMesh_DiscretRoot {
     }
 };
 
+%extend BRepMesh_IncrementalMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepOffset.i
+++ b/src/SWIG_files/wrapper/BRepOffset.i
@@ -104,6 +104,11 @@ class BRepOffset {
 };
 
 
+%extend BRepOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_Analyse;
 class BRepOffset_Analyse {
 	public:
@@ -244,6 +249,11 @@ class BRepOffset_Analyse {
 };
 
 
+%extend BRepOffset_Analyse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapIteratorOfDataMapOfShapeListOfInterval;
 class BRepOffset_DataMapIteratorOfDataMapOfShapeListOfInterval : public TCollection_BasicMapIterator {
 	public:
@@ -274,6 +284,11 @@ class BRepOffset_DataMapIteratorOfDataMapOfShapeListOfInterval : public TCollect
 };
 
 
+%extend BRepOffset_DataMapIteratorOfDataMapOfShapeListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapIteratorOfDataMapOfShapeMapOfShape;
 class BRepOffset_DataMapIteratorOfDataMapOfShapeMapOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -304,6 +319,11 @@ class BRepOffset_DataMapIteratorOfDataMapOfShapeMapOfShape : public TCollection_
 };
 
 
+%extend BRepOffset_DataMapIteratorOfDataMapOfShapeMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapIteratorOfDataMapOfShapeOffset;
 class BRepOffset_DataMapIteratorOfDataMapOfShapeOffset : public TCollection_BasicMapIterator {
 	public:
@@ -334,6 +354,11 @@ class BRepOffset_DataMapIteratorOfDataMapOfShapeOffset : public TCollection_Basi
 };
 
 
+%extend BRepOffset_DataMapIteratorOfDataMapOfShapeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapNodeOfDataMapOfShapeListOfInterval;
 class BRepOffset_DataMapNodeOfDataMapOfShapeListOfInterval : public TCollection_MapNode {
 	public:
@@ -404,6 +429,11 @@ class Handle_BRepOffset_DataMapNodeOfDataMapOfShapeListOfInterval : public Handl
     }
 };
 
+%extend BRepOffset_DataMapNodeOfDataMapOfShapeListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapNodeOfDataMapOfShapeMapOfShape;
 class BRepOffset_DataMapNodeOfDataMapOfShapeMapOfShape : public TCollection_MapNode {
 	public:
@@ -474,6 +504,11 @@ class Handle_BRepOffset_DataMapNodeOfDataMapOfShapeMapOfShape : public Handle_TC
     }
 };
 
+%extend BRepOffset_DataMapNodeOfDataMapOfShapeMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapNodeOfDataMapOfShapeOffset;
 class BRepOffset_DataMapNodeOfDataMapOfShapeOffset : public TCollection_MapNode {
 	public:
@@ -544,6 +579,11 @@ class Handle_BRepOffset_DataMapNodeOfDataMapOfShapeOffset : public Handle_TColle
     }
 };
 
+%extend BRepOffset_DataMapNodeOfDataMapOfShapeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapOfShapeListOfInterval;
 class BRepOffset_DataMapOfShapeListOfInterval : public TCollection_BasicMap {
 	public:
@@ -622,6 +662,11 @@ class BRepOffset_DataMapOfShapeListOfInterval : public TCollection_BasicMap {
 };
 
 
+%extend BRepOffset_DataMapOfShapeListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapOfShapeMapOfShape;
 class BRepOffset_DataMapOfShapeMapOfShape : public TCollection_BasicMap {
 	public:
@@ -700,6 +745,11 @@ class BRepOffset_DataMapOfShapeMapOfShape : public TCollection_BasicMap {
 };
 
 
+%extend BRepOffset_DataMapOfShapeMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_DataMapOfShapeOffset;
 class BRepOffset_DataMapOfShapeOffset : public TCollection_BasicMap {
 	public:
@@ -778,6 +828,11 @@ class BRepOffset_DataMapOfShapeOffset : public TCollection_BasicMap {
 };
 
 
+%extend BRepOffset_DataMapOfShapeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepOffset_Inter2d {
 	public:
 		%feature("compactdefaultargs") Compute;
@@ -815,6 +870,11 @@ class BRepOffset_Inter2d {
 };
 
 
+%extend BRepOffset_Inter2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_Inter3d;
 class BRepOffset_Inter3d {
 	public:
@@ -943,6 +1003,11 @@ class BRepOffset_Inter3d {
 };
 
 
+%extend BRepOffset_Inter3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_Interval;
 class BRepOffset_Interval {
 	public:
@@ -993,6 +1058,11 @@ class BRepOffset_Interval {
 };
 
 
+%extend BRepOffset_Interval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_ListIteratorOfListOfInterval;
 class BRepOffset_ListIteratorOfListOfInterval {
 	public:
@@ -1027,6 +1097,11 @@ class BRepOffset_ListIteratorOfListOfInterval {
 };
 
 
+%extend BRepOffset_ListIteratorOfListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_ListNodeOfListOfInterval;
 class BRepOffset_ListNodeOfListOfInterval : public TCollection_MapNode {
 	public:
@@ -1091,6 +1166,11 @@ class Handle_BRepOffset_ListNodeOfListOfInterval : public Handle_TCollection_Map
     }
 };
 
+%extend BRepOffset_ListNodeOfListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_ListOfInterval;
 class BRepOffset_ListOfInterval {
 	public:
@@ -1221,6 +1301,11 @@ class BRepOffset_ListOfInterval {
 };
 
 
+%extend BRepOffset_ListOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_MakeLoops;
 class BRepOffset_MakeLoops {
 	public:
@@ -1265,6 +1350,11 @@ class BRepOffset_MakeLoops {
 };
 
 
+%extend BRepOffset_MakeLoops {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_MakeOffset;
 class BRepOffset_MakeOffset {
 	public:
@@ -1383,6 +1473,11 @@ class BRepOffset_MakeOffset {
 };
 
 
+%extend BRepOffset_MakeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffset_Offset;
 class BRepOffset_Offset {
 	public:
@@ -1591,6 +1686,11 @@ class BRepOffset_Offset {
 };
 
 
+%extend BRepOffset_Offset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BRepOffset_Tool {
 	public:
 		%feature("compactdefaultargs") EdgeVertices;
@@ -1834,3 +1934,8 @@ class BRepOffset_Tool {
 };
 
 
+%extend BRepOffset_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepOffsetAPI.i
+++ b/src/SWIG_files/wrapper/BRepOffsetAPI.i
@@ -174,6 +174,11 @@ class BRepOffsetAPI_DraftAngle : public BRepBuilderAPI_ModifyShape {
 };
 
 
+%extend BRepOffsetAPI_DraftAngle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_FindContigousEdges;
 class BRepOffsetAPI_FindContigousEdges {
 	public:
@@ -288,6 +293,11 @@ class BRepOffsetAPI_FindContigousEdges {
 };
 
 
+%extend BRepOffsetAPI_FindContigousEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeDraft;
 class BRepOffsetAPI_MakeDraft : public BRepBuilderAPI_MakeShape {
 	public:
@@ -368,6 +378,11 @@ class BRepOffsetAPI_MakeDraft : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MakeDraft {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeEvolved;
 class BRepOffsetAPI_MakeEvolved : public BRepBuilderAPI_MakeShape {
 	public:
@@ -448,6 +463,11 @@ class BRepOffsetAPI_MakeEvolved : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MakeEvolved {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeFilling;
 class BRepOffsetAPI_MakeFilling : public BRepBuilderAPI_MakeShape {
 	public:
@@ -646,6 +666,11 @@ class BRepOffsetAPI_MakeFilling : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MakeFilling {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeOffset;
 class BRepOffsetAPI_MakeOffset : public BRepBuilderAPI_MakeShape {
 	public:
@@ -734,6 +759,11 @@ class BRepOffsetAPI_MakeOffset : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MakeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeOffsetShape;
 class BRepOffsetAPI_MakeOffsetShape : public BRepBuilderAPI_MakeShape {
 	public:
@@ -796,6 +826,11 @@ class BRepOffsetAPI_MakeOffsetShape : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MakeOffsetShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakePipe;
 class BRepOffsetAPI_MakePipe : public BRepPrimAPI_MakeSweep {
 	public:
@@ -860,6 +895,11 @@ class BRepOffsetAPI_MakePipe : public BRepPrimAPI_MakeSweep {
 };
 
 
+%extend BRepOffsetAPI_MakePipe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakePipeShell;
 class BRepOffsetAPI_MakePipeShell : public BRepPrimAPI_MakeSweep {
 	public:
@@ -1090,6 +1130,11 @@ class BRepOffsetAPI_MakePipeShell : public BRepPrimAPI_MakeSweep {
 };
 
 
+%extend BRepOffsetAPI_MakePipeShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MiddlePath;
 class BRepOffsetAPI_MiddlePath : public BRepBuilderAPI_MakeShape {
 	public:
@@ -1112,6 +1157,11 @@ class BRepOffsetAPI_MiddlePath : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_MiddlePath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_NormalProjection;
 class BRepOffsetAPI_NormalProjection : public BRepBuilderAPI_MakeShape {
 	public:
@@ -1238,6 +1288,11 @@ class BRepOffsetAPI_NormalProjection : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_NormalProjection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfReal;
 class BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfReal : public TCollection_SeqNode {
 	public:
@@ -1304,6 +1359,11 @@ class Handle_BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfReal : public Handl
     }
 };
 
+%extend BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfShape;
 class BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfShape : public TCollection_SeqNode {
 	public:
@@ -1370,6 +1430,11 @@ class Handle_BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfShape : public Hand
     }
 };
 
+%extend BRepOffsetAPI_SequenceNodeOfSequenceOfSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_SequenceOfSequenceOfReal;
 class BRepOffsetAPI_SequenceOfSequenceOfReal : public TCollection_BaseSequence {
 	public:
@@ -1508,6 +1573,11 @@ class BRepOffsetAPI_SequenceOfSequenceOfReal : public TCollection_BaseSequence {
 };
 
 
+%extend BRepOffsetAPI_SequenceOfSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_SequenceOfSequenceOfShape;
 class BRepOffsetAPI_SequenceOfSequenceOfShape : public TCollection_BaseSequence {
 	public:
@@ -1646,6 +1716,11 @@ class BRepOffsetAPI_SequenceOfSequenceOfShape : public TCollection_BaseSequence 
 };
 
 
+%extend BRepOffsetAPI_SequenceOfSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_ThruSections;
 class BRepOffsetAPI_ThruSections : public BRepBuilderAPI_MakeShape {
 	public:
@@ -1802,6 +1877,11 @@ class BRepOffsetAPI_ThruSections : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepOffsetAPI_ThruSections {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepOffsetAPI_MakeThickSolid;
 class BRepOffsetAPI_MakeThickSolid : public BRepOffsetAPI_MakeOffsetShape {
 	public:
@@ -1848,3 +1928,8 @@ class BRepOffsetAPI_MakeThickSolid : public BRepOffsetAPI_MakeOffsetShape {
 };
 
 
+%extend BRepOffsetAPI_MakeThickSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepPrim.i
+++ b/src/SWIG_files/wrapper/BRepPrim.i
@@ -305,6 +305,11 @@ class BRepPrim_Builder {
 };
 
 
+%extend BRepPrim_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_FaceBuilder;
 class BRepPrim_FaceBuilder {
 	public:
@@ -387,6 +392,11 @@ class BRepPrim_FaceBuilder {
 };
 
 
+%extend BRepPrim_FaceBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_GWedge;
 class BRepPrim_GWedge {
 	public:
@@ -659,6 +669,11 @@ class BRepPrim_GWedge {
 };
 
 
+%extend BRepPrim_GWedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_OneAxis;
 class BRepPrim_OneAxis {
 	public:
@@ -975,6 +990,11 @@ class BRepPrim_OneAxis {
 };
 
 
+%extend BRepPrim_OneAxis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Revolution;
 class BRepPrim_Revolution : public BRepPrim_OneAxis {
 	public:
@@ -1029,6 +1049,11 @@ class BRepPrim_Revolution : public BRepPrim_OneAxis {
 };
 
 
+%extend BRepPrim_Revolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Wedge;
 class BRepPrim_Wedge : public BRepPrim_GWedge {
 	public:
@@ -1093,6 +1118,11 @@ class BRepPrim_Wedge : public BRepPrim_GWedge {
 };
 
 
+%extend BRepPrim_Wedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Cone;
 class BRepPrim_Cone : public BRepPrim_Revolution {
 	public:
@@ -1187,6 +1217,11 @@ class BRepPrim_Cone : public BRepPrim_Revolution {
 };
 
 
+%extend BRepPrim_Cone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Cylinder;
 class BRepPrim_Cylinder : public BRepPrim_Revolution {
 	public:
@@ -1261,6 +1296,11 @@ class BRepPrim_Cylinder : public BRepPrim_Revolution {
 };
 
 
+%extend BRepPrim_Cylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Sphere;
 class BRepPrim_Sphere : public BRepPrim_Revolution {
 	public:
@@ -1301,6 +1341,11 @@ class BRepPrim_Sphere : public BRepPrim_Revolution {
 };
 
 
+%extend BRepPrim_Sphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrim_Torus;
 class BRepPrim_Torus : public BRepPrim_Revolution {
 	public:
@@ -1347,3 +1392,8 @@ class BRepPrim_Torus : public BRepPrim_Revolution {
 };
 
 
+%extend BRepPrim_Torus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepPrimAPI.i
+++ b/src/SWIG_files/wrapper/BRepPrimAPI.i
@@ -180,6 +180,11 @@ class BRepPrimAPI_MakeBox : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepPrimAPI_MakeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeHalfSpace;
 class BRepPrimAPI_MakeHalfSpace : public BRepBuilderAPI_MakeShape {
 	public:
@@ -216,6 +221,11 @@ class BRepPrimAPI_MakeHalfSpace : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepPrimAPI_MakeHalfSpace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeOneAxis;
 class BRepPrimAPI_MakeOneAxis : public BRepBuilderAPI_MakeShape {
 	public:
@@ -264,6 +274,11 @@ class BRepPrimAPI_MakeOneAxis : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepPrimAPI_MakeOneAxis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeSweep;
 class BRepPrimAPI_MakeSweep : public BRepBuilderAPI_MakeShape {
 	public:
@@ -282,6 +297,11 @@ class BRepPrimAPI_MakeSweep : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepPrimAPI_MakeSweep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeWedge;
 class BRepPrimAPI_MakeWedge : public BRepBuilderAPI_MakeShape {
 	public:
@@ -392,6 +412,11 @@ class BRepPrimAPI_MakeWedge : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend BRepPrimAPI_MakeWedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeCone;
 class BRepPrimAPI_MakeCone : public BRepPrimAPI_MakeOneAxis {
 	public:
@@ -466,6 +491,11 @@ class BRepPrimAPI_MakeCone : public BRepPrimAPI_MakeOneAxis {
 };
 
 
+%extend BRepPrimAPI_MakeCone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeCylinder;
 class BRepPrimAPI_MakeCylinder : public BRepPrimAPI_MakeOneAxis {
 	public:
@@ -532,6 +562,11 @@ class BRepPrimAPI_MakeCylinder : public BRepPrimAPI_MakeOneAxis {
 };
 
 
+%extend BRepPrimAPI_MakeCylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakePrism;
 class BRepPrimAPI_MakePrism : public BRepPrimAPI_MakeSweep {
 	public:
@@ -616,6 +651,11 @@ class BRepPrimAPI_MakePrism : public BRepPrimAPI_MakeSweep {
 };
 
 
+%extend BRepPrimAPI_MakePrism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeRevol;
 class BRepPrimAPI_MakeRevol : public BRepPrimAPI_MakeSweep {
 	public:
@@ -704,6 +744,11 @@ class BRepPrimAPI_MakeRevol : public BRepPrimAPI_MakeSweep {
 };
 
 
+%extend BRepPrimAPI_MakeRevol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeRevolution;
 class BRepPrimAPI_MakeRevolution : public BRepPrimAPI_MakeOneAxis {
 	public:
@@ -818,6 +863,11 @@ class BRepPrimAPI_MakeRevolution : public BRepPrimAPI_MakeOneAxis {
 };
 
 
+%extend BRepPrimAPI_MakeRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeSphere;
 class BRepPrimAPI_MakeSphere : public BRepPrimAPI_MakeOneAxis {
 	public:
@@ -984,6 +1034,11 @@ class BRepPrimAPI_MakeSphere : public BRepPrimAPI_MakeOneAxis {
 };
 
 
+%extend BRepPrimAPI_MakeSphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepPrimAPI_MakeTorus;
 class BRepPrimAPI_MakeTorus : public BRepPrimAPI_MakeOneAxis {
 	public:
@@ -1114,3 +1169,8 @@ class BRepPrimAPI_MakeTorus : public BRepPrimAPI_MakeOneAxis {
 };
 
 
+%extend BRepPrimAPI_MakeTorus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepProj.i
+++ b/src/SWIG_files/wrapper/BRepProj.i
@@ -122,3 +122,8 @@ class BRepProj_Projection {
 };
 
 
+%extend BRepProj_Projection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepSweep.i
+++ b/src/SWIG_files/wrapper/BRepSweep.i
@@ -136,6 +136,11 @@ class BRepSweep_Builder {
 };
 
 
+%extend BRepSweep_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Iterator;
 class BRepSweep_Iterator {
 	public:
@@ -178,6 +183,11 @@ class BRepSweep_Iterator {
 };
 
 
+%extend BRepSweep_Iterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_NumLinearRegularSweep;
 class BRepSweep_NumLinearRegularSweep {
 	public:
@@ -472,6 +482,11 @@ class BRepSweep_NumLinearRegularSweep {
 };
 
 
+%extend BRepSweep_NumLinearRegularSweep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Prism;
 class BRepSweep_Prism {
 	public:
@@ -556,6 +571,11 @@ class BRepSweep_Prism {
 };
 
 
+%extend BRepSweep_Prism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Revol;
 class BRepSweep_Revol {
 	public:
@@ -642,6 +662,11 @@ class BRepSweep_Revol {
 };
 
 
+%extend BRepSweep_Revol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Tool;
 class BRepSweep_Tool {
 	public:
@@ -704,6 +729,11 @@ class BRepSweep_Tool {
 };
 
 
+%extend BRepSweep_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Trsf;
 class BRepSweep_Trsf : public BRepSweep_NumLinearRegularSweep {
 	public:
@@ -948,6 +978,11 @@ class BRepSweep_Trsf : public BRepSweep_NumLinearRegularSweep {
 };
 
 
+%extend BRepSweep_Trsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Rotation;
 class BRepSweep_Rotation : public BRepSweep_Trsf {
 	public:
@@ -1210,6 +1245,11 @@ class BRepSweep_Rotation : public BRepSweep_Trsf {
 };
 
 
+%extend BRepSweep_Rotation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepSweep_Translation;
 class BRepSweep_Translation : public BRepSweep_Trsf {
 	public:
@@ -1462,3 +1502,8 @@ class BRepSweep_Translation : public BRepSweep_Trsf {
 };
 
 
+%extend BRepSweep_Translation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepTools.i
+++ b/src/SWIG_files/wrapper/BRepTools.i
@@ -364,6 +364,11 @@ class BRepTools {
 };
 
 
+%extend BRepTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_DataMapIteratorOfMapOfVertexPnt2d;
 class BRepTools_DataMapIteratorOfMapOfVertexPnt2d : public TCollection_BasicMapIterator {
 	public:
@@ -394,6 +399,11 @@ class BRepTools_DataMapIteratorOfMapOfVertexPnt2d : public TCollection_BasicMapI
 };
 
 
+%extend BRepTools_DataMapIteratorOfMapOfVertexPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_DataMapNodeOfMapOfVertexPnt2d;
 class BRepTools_DataMapNodeOfMapOfVertexPnt2d : public TCollection_MapNode {
 	public:
@@ -464,6 +474,11 @@ class Handle_BRepTools_DataMapNodeOfMapOfVertexPnt2d : public Handle_TCollection
     }
 };
 
+%extend BRepTools_DataMapNodeOfMapOfVertexPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_MapOfVertexPnt2d;
 class BRepTools_MapOfVertexPnt2d : public TCollection_BasicMap {
 	public:
@@ -542,6 +557,11 @@ class BRepTools_MapOfVertexPnt2d : public TCollection_BasicMap {
 };
 
 
+%extend BRepTools_MapOfVertexPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_Modification;
 class BRepTools_Modification : public MMgt_TShared {
 	public:
@@ -688,6 +708,11 @@ class Handle_BRepTools_Modification : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepTools_Modification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_Modifier;
 class BRepTools_Modifier {
 	public:
@@ -750,6 +775,11 @@ class BRepTools_Modifier {
 };
 
 
+%extend BRepTools_Modifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_Quilt;
 class BRepTools_Quilt {
 	public:
@@ -810,6 +840,11 @@ class BRepTools_Quilt {
 };
 
 
+%extend BRepTools_Quilt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_ReShape;
 class BRepTools_ReShape : public MMgt_TShared {
 	public:
@@ -972,6 +1007,11 @@ class Handle_BRepTools_ReShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend BRepTools_ReShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_ShapeSet;
 class BRepTools_ShapeSet : public TopTools_ShapeSet {
 	public:
@@ -1158,6 +1198,11 @@ class BRepTools_ShapeSet : public TopTools_ShapeSet {
         };
 
 
+%extend BRepTools_ShapeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_Substitution;
 class BRepTools_Substitution {
 	public:
@@ -1208,6 +1253,11 @@ class BRepTools_Substitution {
 };
 
 
+%extend BRepTools_Substitution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_WireExplorer;
 class BRepTools_WireExplorer {
 	public:
@@ -1292,6 +1342,11 @@ class BRepTools_WireExplorer {
 };
 
 
+%extend BRepTools_WireExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_GTrsfModification;
 class BRepTools_GTrsfModification : public BRepTools_Modification {
 	public:
@@ -1450,6 +1505,11 @@ class Handle_BRepTools_GTrsfModification : public Handle_BRepTools_Modification 
     }
 };
 
+%extend BRepTools_GTrsfModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_NurbsConvertModification;
 class BRepTools_NurbsConvertModification : public BRepTools_Modification {
 	public:
@@ -1600,6 +1660,11 @@ class Handle_BRepTools_NurbsConvertModification : public Handle_BRepTools_Modifi
     }
 };
 
+%extend BRepTools_NurbsConvertModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTools_TrsfModification;
 class BRepTools_TrsfModification : public BRepTools_Modification {
 	public:
@@ -1758,3 +1823,8 @@ class Handle_BRepTools_TrsfModification : public Handle_BRepTools_Modification {
     }
 };
 
+%extend BRepTools_TrsfModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BRepTopAdaptor.i
+++ b/src/SWIG_files/wrapper/BRepTopAdaptor.i
@@ -87,6 +87,11 @@ class BRepTopAdaptor_DataMapIteratorOfMapOfShapeTool : public TCollection_BasicM
 };
 
 
+%extend BRepTopAdaptor_DataMapIteratorOfMapOfShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_DataMapNodeOfMapOfShapeTool;
 class BRepTopAdaptor_DataMapNodeOfMapOfShapeTool : public TCollection_MapNode {
 	public:
@@ -157,6 +162,11 @@ class Handle_BRepTopAdaptor_DataMapNodeOfMapOfShapeTool : public Handle_TCollect
     }
 };
 
+%extend BRepTopAdaptor_DataMapNodeOfMapOfShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_FClass2d;
 class BRepTopAdaptor_FClass2d {
 	public:
@@ -211,6 +221,11 @@ class BRepTopAdaptor_FClass2d {
 };
 
 
+%extend BRepTopAdaptor_FClass2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_HVertex;
 class BRepTopAdaptor_HVertex : public Adaptor3d_HVertex {
 	public:
@@ -307,6 +322,11 @@ class Handle_BRepTopAdaptor_HVertex : public Handle_Adaptor3d_HVertex {
     }
 };
 
+%extend BRepTopAdaptor_HVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_MapOfShapeTool;
 class BRepTopAdaptor_MapOfShapeTool : public TCollection_BasicMap {
 	public:
@@ -385,6 +405,11 @@ class BRepTopAdaptor_MapOfShapeTool : public TCollection_BasicMap {
 };
 
 
+%extend BRepTopAdaptor_MapOfShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_Tool;
 class BRepTopAdaptor_Tool {
 	public:
@@ -445,6 +470,11 @@ class BRepTopAdaptor_Tool {
 };
 
 
+%extend BRepTopAdaptor_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BRepTopAdaptor_TopolTool;
 class BRepTopAdaptor_TopolTool : public Adaptor3d_TopolTool {
 	public:
@@ -667,3 +697,8 @@ class Handle_BRepTopAdaptor_TopolTool : public Handle_Adaptor3d_TopolTool {
     }
 };
 
+%extend BRepTopAdaptor_TopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BSplCLib.i
+++ b/src/SWIG_files/wrapper/BSplCLib.i
@@ -2933,3 +2933,8 @@ class BSplCLib {
 };
 
 
+%extend BSplCLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BSplSLib.i
+++ b/src/SWIG_files/wrapper/BSplSLib.i
@@ -1030,3 +1030,8 @@ class BSplSLib {
 };
 
 
+%extend BSplSLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BiTgte.i
+++ b/src/SWIG_files/wrapper/BiTgte.i
@@ -291,6 +291,11 @@ class BiTgte_Blend {
 };
 
 
+%extend BiTgte_Blend {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_CurveOnEdge;
 class BiTgte_CurveOnEdge : public Adaptor3d_Curve {
 	public:
@@ -499,6 +504,11 @@ class BiTgte_CurveOnEdge : public Adaptor3d_Curve {
 };
 
 
+%extend BiTgte_CurveOnEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_CurveOnVertex;
 class BiTgte_CurveOnVertex : public Adaptor3d_Curve {
 	public:
@@ -707,6 +717,11 @@ class BiTgte_CurveOnVertex : public Adaptor3d_Curve {
 };
 
 
+%extend BiTgte_CurveOnVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_DataMapIteratorOfDataMapOfShapeBox;
 class BiTgte_DataMapIteratorOfDataMapOfShapeBox : public TCollection_BasicMapIterator {
 	public:
@@ -737,6 +752,11 @@ class BiTgte_DataMapIteratorOfDataMapOfShapeBox : public TCollection_BasicMapIte
 };
 
 
+%extend BiTgte_DataMapIteratorOfDataMapOfShapeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_DataMapNodeOfDataMapOfShapeBox;
 class BiTgte_DataMapNodeOfDataMapOfShapeBox : public TCollection_MapNode {
 	public:
@@ -807,6 +827,11 @@ class Handle_BiTgte_DataMapNodeOfDataMapOfShapeBox : public Handle_TCollection_M
     }
 };
 
+%extend BiTgte_DataMapNodeOfDataMapOfShapeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_DataMapOfShapeBox;
 class BiTgte_DataMapOfShapeBox : public TCollection_BasicMap {
 	public:
@@ -885,6 +910,11 @@ class BiTgte_DataMapOfShapeBox : public TCollection_BasicMap {
 };
 
 
+%extend BiTgte_DataMapOfShapeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_HCurveOnEdge;
 class BiTgte_HCurveOnEdge : public Adaptor3d_HCurve {
 	public:
@@ -965,6 +995,11 @@ class Handle_BiTgte_HCurveOnEdge : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend BiTgte_HCurveOnEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BiTgte_HCurveOnVertex;
 class BiTgte_HCurveOnVertex : public Adaptor3d_HCurve {
 	public:
@@ -1045,3 +1080,8 @@ class Handle_BiTgte_HCurveOnVertex : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend BiTgte_HCurveOnVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Bisector.i
+++ b/src/SWIG_files/wrapper/Bisector.i
@@ -70,6 +70,11 @@ class Bisector {
 };
 
 
+%extend Bisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_Bisec;
 class Bisector_Bisec {
 	public:
@@ -180,6 +185,11 @@ class Bisector_Bisec {
 };
 
 
+%extend Bisector_Bisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_Curve;
 class Bisector_Curve : public Geom2d_Curve {
 	public:
@@ -268,6 +278,11 @@ class Handle_Bisector_Curve : public Handle_Geom2d_Curve {
     }
 };
 
+%extend Bisector_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_FunctionH;
 class Bisector_FunctionH : public math_FunctionWithDerivative {
 	public:
@@ -314,6 +329,11 @@ class Bisector_FunctionH : public math_FunctionWithDerivative {
 };
 
 
+%extend Bisector_FunctionH {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_FunctionInter;
 class Bisector_FunctionInter : public math_FunctionWithDerivative {
 	public:
@@ -374,6 +394,11 @@ class Bisector_FunctionInter : public math_FunctionWithDerivative {
 };
 
 
+%extend Bisector_FunctionInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_Inter;
 class Bisector_Inter : public IntRes2d_Intersection {
 	public:
@@ -424,6 +449,11 @@ class Bisector_Inter : public IntRes2d_Intersection {
 };
 
 
+%extend Bisector_Inter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_PointOnBis;
 class Bisector_PointOnBis {
 	public:
@@ -512,6 +542,11 @@ class Bisector_PointOnBis {
 };
 
 
+%extend Bisector_PointOnBis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_PolyBis;
 class Bisector_PolyBis {
 	public:
@@ -562,6 +597,11 @@ class Bisector_PolyBis {
 };
 
 
+%extend Bisector_PolyBis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_BisecAna;
 class Bisector_BisecAna : public Bisector_Curve {
 	public:
@@ -886,6 +926,11 @@ class Handle_Bisector_BisecAna : public Handle_Bisector_Curve {
     }
 };
 
+%extend Bisector_BisecAna {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_BisecCC;
 class Bisector_BisecCC : public Bisector_Curve {
 	public:
@@ -1192,6 +1237,11 @@ class Handle_Bisector_BisecCC : public Handle_Bisector_Curve {
     }
 };
 
+%extend Bisector_BisecCC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bisector_BisecPC;
 class Bisector_BisecPC : public Bisector_Curve {
 	public:
@@ -1486,3 +1536,8 @@ class Handle_Bisector_BisecPC : public Handle_Bisector_Curve {
     }
 };
 
+%extend Bisector_BisecPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Blend.i
+++ b/src/SWIG_files/wrapper/Blend.i
@@ -346,6 +346,11 @@ class Blend_AppFunction : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Blend_AppFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_CurvPointFuncInv;
 class Blend_CurvPointFuncInv : public math_FunctionSetWithDerivatives {
 	public:
@@ -434,6 +439,11 @@ class Blend_CurvPointFuncInv : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Blend_CurvPointFuncInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_FuncInv;
 class Blend_FuncInv : public math_FunctionSetWithDerivatives {
 	public:
@@ -524,6 +534,11 @@ class Blend_FuncInv : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Blend_FuncInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_Point;
 class Blend_Point {
 	public:
@@ -1052,6 +1067,11 @@ class Blend_Point {
 };
 
 
+%extend Blend_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_SequenceNodeOfSequenceOfPoint;
 class Blend_SequenceNodeOfSequenceOfPoint : public TCollection_SeqNode {
 	public:
@@ -1118,6 +1138,11 @@ class Handle_Blend_SequenceNodeOfSequenceOfPoint : public Handle_TCollection_Seq
     }
 };
 
+%extend Blend_SequenceNodeOfSequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_SequenceOfPoint;
 class Blend_SequenceOfPoint : public TCollection_BaseSequence {
 	public:
@@ -1256,6 +1281,11 @@ class Blend_SequenceOfPoint : public TCollection_BaseSequence {
 };
 
 
+%extend Blend_SequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_SurfCurvFuncInv;
 class Blend_SurfCurvFuncInv : public math_FunctionSetWithDerivatives {
 	public:
@@ -1344,6 +1374,11 @@ class Blend_SurfCurvFuncInv : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Blend_SurfCurvFuncInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_SurfPointFuncInv;
 class Blend_SurfPointFuncInv : public math_FunctionSetWithDerivatives {
 	public:
@@ -1432,6 +1467,11 @@ class Blend_SurfPointFuncInv : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Blend_SurfPointFuncInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_CSFunction;
 class Blend_CSFunction : public Blend_AppFunction {
 	public:
@@ -1708,6 +1748,11 @@ class Blend_CSFunction : public Blend_AppFunction {
 };
 
 
+%extend Blend_CSFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_Function;
 class Blend_Function : public Blend_AppFunction {
 	public:
@@ -1988,6 +2033,11 @@ class Blend_Function : public Blend_AppFunction {
 };
 
 
+%extend Blend_Function {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_RstRstFunction;
 class Blend_RstRstFunction : public Blend_AppFunction {
 	public:
@@ -2322,6 +2372,11 @@ class Blend_RstRstFunction : public Blend_AppFunction {
 };
 
 
+%extend Blend_RstRstFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Blend_SurfRstFunction;
 class Blend_SurfRstFunction : public Blend_AppFunction {
 	public:
@@ -2646,3 +2701,8 @@ class Blend_SurfRstFunction : public Blend_AppFunction {
 };
 
 
+%extend Blend_SurfRstFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BlendFunc.i
+++ b/src/SWIG_files/wrapper/BlendFunc.i
@@ -131,6 +131,11 @@ class BlendFunc {
 };
 
 
+%extend BlendFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_CSCircular;
 class BlendFunc_CSCircular : public Blend_CSFunction {
 	public:
@@ -479,6 +484,11 @@ class BlendFunc_CSCircular : public Blend_CSFunction {
 };
 
 
+%extend BlendFunc_CSCircular {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_CSConstRad;
 class BlendFunc_CSConstRad : public Blend_CSFunction {
 	public:
@@ -819,6 +829,11 @@ class BlendFunc_CSConstRad : public Blend_CSFunction {
 };
 
 
+%extend BlendFunc_CSConstRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_ChAsym;
 class BlendFunc_ChAsym : public Blend_Function {
 	public:
@@ -1169,6 +1184,11 @@ class BlendFunc_ChAsym : public Blend_Function {
 };
 
 
+%extend BlendFunc_ChAsym {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_ChAsymInv;
 class BlendFunc_ChAsymInv : public Blend_FuncInv {
 	public:
@@ -1277,6 +1297,11 @@ class BlendFunc_ChAsymInv : public Blend_FuncInv {
 };
 
 
+%extend BlendFunc_ChAsymInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_ChamfInv;
 class BlendFunc_ChamfInv : public Blend_FuncInv {
 	public:
@@ -1373,6 +1398,11 @@ class BlendFunc_ChamfInv : public Blend_FuncInv {
 };
 
 
+%extend BlendFunc_ChamfInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_Chamfer;
 class BlendFunc_Chamfer : public Blend_Function {
 	public:
@@ -1703,6 +1733,11 @@ class BlendFunc_Chamfer : public Blend_Function {
 };
 
 
+%extend BlendFunc_Chamfer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_ConstRad;
 class BlendFunc_ConstRad : public Blend_Function {
 	public:
@@ -2053,6 +2088,11 @@ class BlendFunc_ConstRad : public Blend_Function {
 };
 
 
+%extend BlendFunc_ConstRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_ConstRadInv;
 class BlendFunc_ConstRadInv : public Blend_FuncInv {
 	public:
@@ -2147,6 +2187,11 @@ class BlendFunc_ConstRadInv : public Blend_FuncInv {
 };
 
 
+%extend BlendFunc_ConstRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_Corde;
 class BlendFunc_Corde {
 	public:
@@ -2247,6 +2292,11 @@ class BlendFunc_Corde {
 };
 
 
+%extend BlendFunc_Corde {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_EvolRad;
 class BlendFunc_EvolRad : public Blend_Function {
 	public:
@@ -2589,6 +2639,11 @@ class BlendFunc_EvolRad : public Blend_Function {
 };
 
 
+%extend BlendFunc_EvolRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_EvolRadInv;
 class BlendFunc_EvolRadInv : public Blend_FuncInv {
 	public:
@@ -2683,6 +2738,11 @@ class BlendFunc_EvolRadInv : public Blend_FuncInv {
 };
 
 
+%extend BlendFunc_EvolRadInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_Ruled;
 class BlendFunc_Ruled : public Blend_Function {
 	public:
@@ -3003,6 +3063,11 @@ class BlendFunc_Ruled : public Blend_Function {
 };
 
 
+%extend BlendFunc_Ruled {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_RuledInv;
 class BlendFunc_RuledInv : public Blend_FuncInv {
 	public:
@@ -3089,6 +3154,11 @@ class BlendFunc_RuledInv : public Blend_FuncInv {
 };
 
 
+%extend BlendFunc_RuledInv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor BlendFunc_Tensor;
 class BlendFunc_Tensor {
 	public:
@@ -3145,3 +3215,8 @@ class BlendFunc_Tensor {
 };
 
 
+%extend BlendFunc_Tensor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Bnd.i
+++ b/src/SWIG_files/wrapper/Bnd.i
@@ -138,6 +138,11 @@ class Bnd_Array1OfBox {
 };
 
 
+%extend Bnd_Array1OfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_Array1OfBox2d;
 class Bnd_Array1OfBox2d {
 	public:
@@ -220,6 +225,11 @@ class Bnd_Array1OfBox2d {
 };
 
 
+%extend Bnd_Array1OfBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_Array1OfSphere;
 class Bnd_Array1OfSphere {
 	public:
@@ -302,6 +312,11 @@ class Bnd_Array1OfSphere {
 };
 
 
+%extend Bnd_Array1OfSphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_B2d;
 class Bnd_B2d {
 	public:
@@ -446,6 +461,11 @@ class Bnd_B2d {
 };
 
 
+%extend Bnd_B2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_B2f;
 class Bnd_B2f {
 	public:
@@ -590,6 +610,11 @@ class Bnd_B2f {
 };
 
 
+%extend Bnd_B2f {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_B3d;
 class Bnd_B3d {
 	public:
@@ -736,6 +761,11 @@ class Bnd_B3d {
 };
 
 
+%extend Bnd_B3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_B3f;
 class Bnd_B3f {
 	public:
@@ -882,6 +912,11 @@ class Bnd_B3f {
 };
 
 
+%extend Bnd_B3f {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_BoundSortBox;
 class Bnd_BoundSortBox {
 	public:
@@ -956,6 +991,11 @@ class Bnd_BoundSortBox {
 };
 
 
+%extend Bnd_BoundSortBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_BoundSortBox2d;
 class Bnd_BoundSortBox2d {
 	public:
@@ -1018,6 +1058,11 @@ class Bnd_BoundSortBox2d {
 };
 
 
+%extend Bnd_BoundSortBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_Box;
 class Bnd_Box {
 	public:
@@ -1384,6 +1429,11 @@ class Bnd_Box {
 };
 
 
+%extend Bnd_Box {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_Box2d;
 class Bnd_Box2d {
 	public:
@@ -1636,6 +1686,11 @@ class Bnd_Box2d {
 };
 
 
+%extend Bnd_Box2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_HArray1OfBox;
 class Bnd_HArray1OfBox : public MMgt_TShared {
 	public:
@@ -1752,6 +1807,11 @@ class Handle_Bnd_HArray1OfBox : public Handle_MMgt_TShared {
     }
 };
 
+%extend Bnd_HArray1OfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_HArray1OfBox2d;
 class Bnd_HArray1OfBox2d : public MMgt_TShared {
 	public:
@@ -1868,6 +1928,11 @@ class Handle_Bnd_HArray1OfBox2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Bnd_HArray1OfBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_HArray1OfSphere;
 class Bnd_HArray1OfSphere : public MMgt_TShared {
 	public:
@@ -1984,6 +2049,11 @@ class Handle_Bnd_HArray1OfSphere : public Handle_MMgt_TShared {
     }
 };
 
+%extend Bnd_HArray1OfSphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_SeqOfBox;
 class Bnd_SeqOfBox : public TCollection_BaseSequence {
 	public:
@@ -2122,6 +2192,11 @@ class Bnd_SeqOfBox : public TCollection_BaseSequence {
 };
 
 
+%extend Bnd_SeqOfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_SequenceNodeOfSeqOfBox;
 class Bnd_SequenceNodeOfSeqOfBox : public TCollection_SeqNode {
 	public:
@@ -2188,6 +2263,11 @@ class Handle_Bnd_SequenceNodeOfSeqOfBox : public Handle_TCollection_SeqNode {
     }
 };
 
+%extend Bnd_SequenceNodeOfSeqOfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Bnd_Sphere;
 class Bnd_Sphere {
 	public:
@@ -2324,3 +2404,8 @@ class Bnd_Sphere {
 };
 
 
+%extend Bnd_Sphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/BndLib.i
+++ b/src/SWIG_files/wrapper/BndLib.i
@@ -388,6 +388,11 @@ class BndLib {
 };
 
 
+%extend BndLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BndLib_Add2dCurve {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -449,6 +454,11 @@ class BndLib_Add2dCurve {
 };
 
 
+%extend BndLib_Add2dCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BndLib_Add3dCurve {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -482,6 +492,11 @@ class BndLib_Add3dCurve {
 };
 
 
+%extend BndLib_Add3dCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class BndLib_AddSurface {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -519,3 +534,8 @@ class BndLib_AddSurface {
 };
 
 
+%extend BndLib_AddSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/CPnts.i
+++ b/src/SWIG_files/wrapper/CPnts.i
@@ -362,6 +362,11 @@ class CPnts_AbscissaPoint {
 };
 
 
+%extend CPnts_AbscissaPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor CPnts_MyGaussFunction;
 class CPnts_MyGaussFunction : public math_Function {
 	public:
@@ -390,6 +395,11 @@ class CPnts_MyGaussFunction : public math_Function {
 };
 
 
+%extend CPnts_MyGaussFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor CPnts_MyRootFunction;
 class CPnts_MyRootFunction : public math_FunctionWithDerivative {
 	public:
@@ -464,6 +474,11 @@ class CPnts_MyRootFunction : public math_FunctionWithDerivative {
 };
 
 
+%extend CPnts_MyRootFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor CPnts_UniformDeflection;
 class CPnts_UniformDeflection {
 	public:
@@ -634,3 +649,8 @@ class CPnts_UniformDeflection {
 };
 
 
+%extend CPnts_UniformDeflection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/CSLib.i
+++ b/src/SWIG_files/wrapper/CSLib.i
@@ -214,6 +214,11 @@ class CSLib {
 };
 
 
+%extend CSLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor CSLib_Class2d;
 class CSLib_Class2d {
 	public:
@@ -284,6 +289,11 @@ class CSLib_Class2d {
 };
 
 
+%extend CSLib_Class2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor CSLib_NormalPolyDef;
 class CSLib_NormalPolyDef : public math_FunctionWithDerivative {
 	public:
@@ -330,3 +340,8 @@ class CSLib_NormalPolyDef : public math_FunctionWithDerivative {
 };
 
 
+%extend CSLib_NormalPolyDef {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ChFi2d.i
+++ b/src/SWIG_files/wrapper/ChFi2d.i
@@ -79,6 +79,11 @@ class ChFi2d {
 };
 
 
+%extend ChFi2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi2d_AnaFilletAlgo;
 class ChFi2d_AnaFilletAlgo {
 	public:
@@ -153,6 +158,11 @@ class ChFi2d_AnaFilletAlgo {
 };
 
 
+%extend ChFi2d_AnaFilletAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi2d_Builder;
 class ChFi2d_Builder {
 	public:
@@ -337,6 +347,11 @@ class ChFi2d_Builder {
 };
 
 
+%extend ChFi2d_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi2d_ChamferAPI;
 class ChFi2d_ChamferAPI {
 	public:
@@ -403,6 +418,11 @@ class ChFi2d_ChamferAPI {
 };
 
 
+%extend ChFi2d_ChamferAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi2d_FilletAPI;
 class ChFi2d_FilletAPI {
 	public:
@@ -489,6 +509,11 @@ class ChFi2d_FilletAPI {
 };
 
 
+%extend ChFi2d_FilletAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi2d_FilletAlgo;
 class ChFi2d_FilletAlgo {
 	public:
@@ -575,3 +600,8 @@ class ChFi2d_FilletAlgo {
 };
 
 
+%extend ChFi2d_FilletAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ChFi3d.i
+++ b/src/SWIG_files/wrapper/ChFi3d.i
@@ -128,6 +128,11 @@ class ChFi3d {
 };
 
 
+%extend ChFi3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi3d_Builder;
 class ChFi3d_Builder {
 	public:
@@ -398,6 +403,11 @@ class ChFi3d_Builder {
 };
 
 
+%extend ChFi3d_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi3d_SearchSing;
 class ChFi3d_SearchSing : public math_FunctionWithDerivative {
 	public:
@@ -444,6 +454,11 @@ class ChFi3d_SearchSing : public math_FunctionWithDerivative {
 };
 
 
+%extend ChFi3d_SearchSing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi3d_ChBuilder;
 class ChFi3d_ChBuilder : public ChFi3d_Builder {
 	public:
@@ -1024,6 +1039,11 @@ class ChFi3d_ChBuilder : public ChFi3d_Builder {
 };
 
 
+%extend ChFi3d_ChBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFi3d_FilBuilder;
 class ChFi3d_FilBuilder : public ChFi3d_Builder {
 	public:
@@ -1240,3 +1260,8 @@ class ChFi3d_FilBuilder : public ChFi3d_Builder {
 };
 
 
+%extend ChFi3d_FilBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ChFiDS.i
+++ b/src/SWIG_files/wrapper/ChFiDS.i
@@ -130,6 +130,11 @@ class ChFiDS_CircSection {
 };
 
 
+%extend ChFiDS_CircSection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_CommonPoint;
 class ChFiDS_CommonPoint {
 	public:
@@ -268,6 +273,11 @@ class ChFiDS_CommonPoint {
 };
 
 
+%extend ChFiDS_CommonPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ElSpine;
 class ChFiDS_ElSpine : public Adaptor3d_Curve {
 	public:
@@ -490,6 +500,11 @@ class ChFiDS_ElSpine : public Adaptor3d_Curve {
 };
 
 
+%extend ChFiDS_ElSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_FaceInterference;
 class ChFiDS_FaceInterference {
 	public:
@@ -582,6 +597,11 @@ class ChFiDS_FaceInterference {
 };
 
 
+%extend ChFiDS_FaceInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_HData;
 class ChFiDS_HData : public MMgt_TShared {
 	public:
@@ -766,6 +786,11 @@ class Handle_ChFiDS_HData : public Handle_MMgt_TShared {
     }
 };
 
+%extend ChFiDS_HData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_HElSpine;
 class ChFiDS_HElSpine : public Adaptor3d_HCurve {
 	public:
@@ -846,6 +871,11 @@ class Handle_ChFiDS_HElSpine : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend ChFiDS_HElSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_IndexedDataMapNodeOfIndexedDataMapOfVertexListOfStripe;
 class ChFiDS_IndexedDataMapNodeOfIndexedDataMapOfVertexListOfStripe : public TCollection_MapNode {
 	public:
@@ -937,6 +967,11 @@ class Handle_ChFiDS_IndexedDataMapNodeOfIndexedDataMapOfVertexListOfStripe : pub
     }
 };
 
+%extend ChFiDS_IndexedDataMapNodeOfIndexedDataMapOfVertexListOfStripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_IndexedDataMapOfVertexListOfStripe;
 class ChFiDS_IndexedDataMapOfVertexListOfStripe : public TCollection_BasicMap {
 	public:
@@ -1047,6 +1082,11 @@ class ChFiDS_IndexedDataMapOfVertexListOfStripe : public TCollection_BasicMap {
 };
 
 
+%extend ChFiDS_IndexedDataMapOfVertexListOfStripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListIteratorOfListOfHElSpine;
 class ChFiDS_ListIteratorOfListOfHElSpine {
 	public:
@@ -1081,6 +1121,11 @@ class ChFiDS_ListIteratorOfListOfHElSpine {
 };
 
 
+%extend ChFiDS_ListIteratorOfListOfHElSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListIteratorOfListOfStripe;
 class ChFiDS_ListIteratorOfListOfStripe {
 	public:
@@ -1115,6 +1160,11 @@ class ChFiDS_ListIteratorOfListOfStripe {
 };
 
 
+%extend ChFiDS_ListIteratorOfListOfStripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListIteratorOfRegularities;
 class ChFiDS_ListIteratorOfRegularities {
 	public:
@@ -1149,6 +1199,11 @@ class ChFiDS_ListIteratorOfRegularities {
 };
 
 
+%extend ChFiDS_ListIteratorOfRegularities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListNodeOfListOfHElSpine;
 class ChFiDS_ListNodeOfListOfHElSpine : public TCollection_MapNode {
 	public:
@@ -1213,6 +1268,11 @@ class Handle_ChFiDS_ListNodeOfListOfHElSpine : public Handle_TCollection_MapNode
     }
 };
 
+%extend ChFiDS_ListNodeOfListOfHElSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListNodeOfListOfStripe;
 class ChFiDS_ListNodeOfListOfStripe : public TCollection_MapNode {
 	public:
@@ -1277,6 +1337,11 @@ class Handle_ChFiDS_ListNodeOfListOfStripe : public Handle_TCollection_MapNode {
     }
 };
 
+%extend ChFiDS_ListNodeOfListOfStripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListNodeOfRegularities;
 class ChFiDS_ListNodeOfRegularities : public TCollection_MapNode {
 	public:
@@ -1341,6 +1406,11 @@ class Handle_ChFiDS_ListNodeOfRegularities : public Handle_TCollection_MapNode {
     }
 };
 
+%extend ChFiDS_ListNodeOfRegularities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListOfHElSpine;
 class ChFiDS_ListOfHElSpine {
 	public:
@@ -1471,6 +1541,11 @@ class ChFiDS_ListOfHElSpine {
 };
 
 
+%extend ChFiDS_ListOfHElSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ListOfStripe;
 class ChFiDS_ListOfStripe {
 	public:
@@ -1601,6 +1676,11 @@ class ChFiDS_ListOfStripe {
 };
 
 
+%extend ChFiDS_ListOfStripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_Map;
 class ChFiDS_Map {
 	public:
@@ -1643,6 +1723,11 @@ class ChFiDS_Map {
 };
 
 
+%extend ChFiDS_Map {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_Regul;
 class ChFiDS_Regul {
 	public:
@@ -1695,6 +1780,11 @@ class ChFiDS_Regul {
 };
 
 
+%extend ChFiDS_Regul {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_Regularities;
 class ChFiDS_Regularities {
 	public:
@@ -1825,6 +1915,11 @@ class ChFiDS_Regularities {
 };
 
 
+%extend ChFiDS_Regularities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SecArray1;
 class ChFiDS_SecArray1 {
 	public:
@@ -1907,6 +2002,11 @@ class ChFiDS_SecArray1 {
 };
 
 
+%extend ChFiDS_SecArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SecHArray1;
 class ChFiDS_SecHArray1 : public MMgt_TShared {
 	public:
@@ -2023,6 +2123,11 @@ class Handle_ChFiDS_SecHArray1 : public Handle_MMgt_TShared {
     }
 };
 
+%extend ChFiDS_SecHArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SequenceNodeOfSequenceOfSpine;
 class ChFiDS_SequenceNodeOfSequenceOfSpine : public TCollection_SeqNode {
 	public:
@@ -2089,6 +2194,11 @@ class Handle_ChFiDS_SequenceNodeOfSequenceOfSpine : public Handle_TCollection_Se
     }
 };
 
+%extend ChFiDS_SequenceNodeOfSequenceOfSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SequenceNodeOfSequenceOfSurfData;
 class ChFiDS_SequenceNodeOfSequenceOfSurfData : public TCollection_SeqNode {
 	public:
@@ -2155,6 +2265,11 @@ class Handle_ChFiDS_SequenceNodeOfSequenceOfSurfData : public Handle_TCollection
     }
 };
 
+%extend ChFiDS_SequenceNodeOfSequenceOfSurfData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SequenceOfSpine;
 class ChFiDS_SequenceOfSpine : public TCollection_BaseSequence {
 	public:
@@ -2293,6 +2408,11 @@ class ChFiDS_SequenceOfSpine : public TCollection_BaseSequence {
 };
 
 
+%extend ChFiDS_SequenceOfSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SequenceOfSurfData;
 class ChFiDS_SequenceOfSurfData : public TCollection_BaseSequence {
 	public:
@@ -2431,6 +2551,11 @@ class ChFiDS_SequenceOfSurfData : public TCollection_BaseSequence {
 };
 
 
+%extend ChFiDS_SequenceOfSurfData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_Spine;
 class ChFiDS_Spine : public MMgt_TShared {
 	public:
@@ -2869,6 +2994,11 @@ class Handle_ChFiDS_Spine : public Handle_MMgt_TShared {
     }
 };
 
+%extend ChFiDS_Spine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_Stripe;
 class ChFiDS_Stripe : public MMgt_TShared {
 	public:
@@ -3225,6 +3355,11 @@ class Handle_ChFiDS_Stripe : public Handle_MMgt_TShared {
     }
 };
 
+%extend ChFiDS_Stripe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_StripeArray1;
 class ChFiDS_StripeArray1 {
 	public:
@@ -3307,6 +3442,11 @@ class ChFiDS_StripeArray1 {
 };
 
 
+%extend ChFiDS_StripeArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_StripeMap;
 class ChFiDS_StripeMap {
 	public:
@@ -3351,6 +3491,11 @@ class ChFiDS_StripeMap {
 };
 
 
+%extend ChFiDS_StripeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_SurfData;
 class ChFiDS_SurfData : public MMgt_TShared {
 	public:
@@ -3683,6 +3828,11 @@ class Handle_ChFiDS_SurfData : public Handle_MMgt_TShared {
     }
 };
 
+%extend ChFiDS_SurfData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_ChamfSpine;
 class ChFiDS_ChamfSpine : public ChFiDS_Spine {
 	public:
@@ -3799,6 +3949,11 @@ class Handle_ChFiDS_ChamfSpine : public Handle_ChFiDS_Spine {
     }
 };
 
+%extend ChFiDS_ChamfSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiDS_FilSpine;
 class ChFiDS_FilSpine : public ChFiDS_Spine {
 	public:
@@ -3993,3 +4148,8 @@ class Handle_ChFiDS_FilSpine : public Handle_ChFiDS_Spine {
     }
 };
 
+%extend ChFiDS_FilSpine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ChFiKPart.i
+++ b/src/SWIG_files/wrapper/ChFiKPart.i
@@ -173,6 +173,11 @@ class ChFiKPart_ComputeData {
 };
 
 
+%extend ChFiKPart_ComputeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiKPart_DataMapIteratorOfRstMap;
 class ChFiKPart_DataMapIteratorOfRstMap : public TCollection_BasicMapIterator {
 	public:
@@ -203,6 +208,11 @@ class ChFiKPart_DataMapIteratorOfRstMap : public TCollection_BasicMapIterator {
 };
 
 
+%extend ChFiKPart_DataMapIteratorOfRstMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiKPart_DataMapNodeOfRstMap;
 class ChFiKPart_DataMapNodeOfRstMap : public TCollection_MapNode {
 	public:
@@ -282,6 +292,11 @@ class Handle_ChFiKPart_DataMapNodeOfRstMap : public Handle_TCollection_MapNode {
     }
 };
 
+%extend ChFiKPart_DataMapNodeOfRstMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ChFiKPart_RstMap;
 class ChFiKPart_RstMap : public TCollection_BasicMap {
 	public:
@@ -360,3 +375,8 @@ class ChFiKPart_RstMap : public TCollection_BasicMap {
 };
 
 
+%extend ChFiKPart_RstMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Contap.i
+++ b/src/SWIG_files/wrapper/Contap.i
@@ -164,6 +164,11 @@ class Contap_ArcFunction : public math_FunctionWithDerivative {
 };
 
 
+%extend Contap_ArcFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_ContAna;
 class Contap_ContAna {
 	public:
@@ -276,6 +281,11 @@ class Contap_ContAna {
 };
 
 
+%extend Contap_ContAna {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_Contour;
 class Contap_Contour {
 	public:
@@ -438,6 +448,11 @@ class Contap_Contour {
 };
 
 
+%extend Contap_Contour {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Contap_HContTool {
 	public:
 		%feature("compactdefaultargs") NbSamplesU;
@@ -629,6 +644,11 @@ class Contap_HContTool {
 };
 
 
+%extend Contap_HContTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Contap_HCurve2dTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -844,6 +864,11 @@ class Contap_HCurve2dTool {
 };
 
 
+%extend Contap_HCurve2dTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_Line;
 class Contap_Line {
 	public:
@@ -954,6 +979,11 @@ class Contap_Line {
 };
 
 
+%extend Contap_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_Point;
 class Contap_Point {
 	public:
@@ -1104,6 +1134,11 @@ class Contap_Point {
 };
 
 
+%extend Contap_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceNodeOfSequenceOfIWLineOfTheIWalking;
 class Contap_SequenceNodeOfSequenceOfIWLineOfTheIWalking : public TCollection_SeqNode {
 	public:
@@ -1170,6 +1205,11 @@ class Handle_Contap_SequenceNodeOfSequenceOfIWLineOfTheIWalking : public Handle_
     }
 };
 
+%extend Contap_SequenceNodeOfSequenceOfIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceNodeOfSequenceOfPathPointOfTheSearch;
 class Contap_SequenceNodeOfSequenceOfPathPointOfTheSearch : public TCollection_SeqNode {
 	public:
@@ -1236,6 +1276,11 @@ class Handle_Contap_SequenceNodeOfSequenceOfPathPointOfTheSearch : public Handle
     }
 };
 
+%extend Contap_SequenceNodeOfSequenceOfPathPointOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceNodeOfSequenceOfSegmentOfTheSearch;
 class Contap_SequenceNodeOfSequenceOfSegmentOfTheSearch : public TCollection_SeqNode {
 	public:
@@ -1302,6 +1347,11 @@ class Handle_Contap_SequenceNodeOfSequenceOfSegmentOfTheSearch : public Handle_T
     }
 };
 
+%extend Contap_SequenceNodeOfSequenceOfSegmentOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceNodeOfTheSequenceOfLine;
 class Contap_SequenceNodeOfTheSequenceOfLine : public TCollection_SeqNode {
 	public:
@@ -1368,6 +1418,11 @@ class Handle_Contap_SequenceNodeOfTheSequenceOfLine : public Handle_TCollection_
     }
 };
 
+%extend Contap_SequenceNodeOfTheSequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceNodeOfTheSequenceOfPoint;
 class Contap_SequenceNodeOfTheSequenceOfPoint : public TCollection_SeqNode {
 	public:
@@ -1434,6 +1489,11 @@ class Handle_Contap_SequenceNodeOfTheSequenceOfPoint : public Handle_TCollection
     }
 };
 
+%extend Contap_SequenceNodeOfTheSequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceOfIWLineOfTheIWalking;
 class Contap_SequenceOfIWLineOfTheIWalking : public TCollection_BaseSequence {
 	public:
@@ -1572,6 +1632,11 @@ class Contap_SequenceOfIWLineOfTheIWalking : public TCollection_BaseSequence {
 };
 
 
+%extend Contap_SequenceOfIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceOfPathPointOfTheSearch;
 class Contap_SequenceOfPathPointOfTheSearch : public TCollection_BaseSequence {
 	public:
@@ -1710,6 +1775,11 @@ class Contap_SequenceOfPathPointOfTheSearch : public TCollection_BaseSequence {
 };
 
 
+%extend Contap_SequenceOfPathPointOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SequenceOfSegmentOfTheSearch;
 class Contap_SequenceOfSegmentOfTheSearch : public TCollection_BaseSequence {
 	public:
@@ -1848,6 +1918,11 @@ class Contap_SequenceOfSegmentOfTheSearch : public TCollection_BaseSequence {
 };
 
 
+%extend Contap_SequenceOfSegmentOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_SurfFunction;
 class Contap_SurfFunction : public math_FunctionSetWithDerivatives {
 	public:
@@ -1990,6 +2065,11 @@ class Contap_SurfFunction : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Contap_SurfFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Contap_SurfProps {
 	public:
 		%feature("compactdefaultargs") Normale;
@@ -2051,6 +2131,11 @@ class Contap_SurfProps {
 };
 
 
+%extend Contap_SurfProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheHSequenceOfPoint;
 class Contap_TheHSequenceOfPoint : public MMgt_TShared {
 	public:
@@ -2235,6 +2320,11 @@ class Handle_Contap_TheHSequenceOfPoint : public Handle_MMgt_TShared {
     }
 };
 
+%extend Contap_TheHSequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheIWLineOfTheIWalking;
 class Contap_TheIWLineOfTheIWalking : public MMgt_TShared {
 	public:
@@ -2451,6 +2541,11 @@ class Handle_Contap_TheIWLineOfTheIWalking : public Handle_MMgt_TShared {
     }
 };
 
+%extend Contap_TheIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheIWalking;
 class Contap_TheIWalking {
 	public:
@@ -2527,6 +2622,11 @@ class Contap_TheIWalking {
 };
 
 
+%extend Contap_TheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_ThePathPointOfTheSearch;
 class Contap_ThePathPointOfTheSearch {
 	public:
@@ -2613,6 +2713,11 @@ class Contap_ThePathPointOfTheSearch {
 };
 
 
+%extend Contap_ThePathPointOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheSearch;
 class Contap_TheSearch {
 	public:
@@ -2665,6 +2770,11 @@ class Contap_TheSearch {
 };
 
 
+%extend Contap_TheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheSearchInside;
 class Contap_TheSearchInside {
 	public:
@@ -2725,6 +2835,11 @@ class Contap_TheSearchInside {
 };
 
 
+%extend Contap_TheSearchInside {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheSegmentOfTheSearch;
 class Contap_TheSegmentOfTheSearch {
 	public:
@@ -2769,6 +2884,11 @@ class Contap_TheSegmentOfTheSearch {
 };
 
 
+%extend Contap_TheSegmentOfTheSearch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheSequenceOfLine;
 class Contap_TheSequenceOfLine : public TCollection_BaseSequence {
 	public:
@@ -2907,6 +3027,11 @@ class Contap_TheSequenceOfLine : public TCollection_BaseSequence {
 };
 
 
+%extend Contap_TheSequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Contap_TheSequenceOfPoint;
 class Contap_TheSequenceOfPoint : public TCollection_BaseSequence {
 	public:
@@ -3045,3 +3170,8 @@ class Contap_TheSequenceOfPoint : public TCollection_BaseSequence {
 };
 
 
+%extend Contap_TheSequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Convert.i
+++ b/src/SWIG_files/wrapper/Convert.i
@@ -133,6 +133,11 @@ class Convert_CompBezierCurves2dToBSplineCurve2d {
 };
 
 
+%extend Convert_CompBezierCurves2dToBSplineCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_CompBezierCurvesToBSplineCurve;
 class Convert_CompBezierCurvesToBSplineCurve {
 	public:
@@ -197,6 +202,11 @@ class Convert_CompBezierCurvesToBSplineCurve {
 };
 
 
+%extend Convert_CompBezierCurvesToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_CompPolynomialToPoles;
 class Convert_CompPolynomialToPoles {
 	public:
@@ -309,6 +319,11 @@ class Convert_CompPolynomialToPoles {
 };
 
 
+%extend Convert_CompPolynomialToPoles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_ConicToBSplineCurve;
 class Convert_ConicToBSplineCurve {
 	public:
@@ -411,6 +426,11 @@ class Convert_ConicToBSplineCurve {
 };
 
 
+%extend Convert_ConicToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_ElementarySurfaceToBSplineSurface;
 class Convert_ElementarySurfaceToBSplineSurface {
 	public:
@@ -509,6 +529,11 @@ class Convert_ElementarySurfaceToBSplineSurface {
 };
 
 
+%extend Convert_ElementarySurfaceToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_GridPolynomialToPoles;
 class Convert_GridPolynomialToPoles {
 	public:
@@ -645,6 +670,11 @@ class Convert_GridPolynomialToPoles {
 };
 
 
+%extend Convert_GridPolynomialToPoles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_SequenceNodeOfSequenceOfArray1OfPoles;
 class Convert_SequenceNodeOfSequenceOfArray1OfPoles : public TCollection_SeqNode {
 	public:
@@ -711,6 +741,11 @@ class Handle_Convert_SequenceNodeOfSequenceOfArray1OfPoles : public Handle_TColl
     }
 };
 
+%extend Convert_SequenceNodeOfSequenceOfArray1OfPoles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_SequenceOfArray1OfPoles;
 class Convert_SequenceOfArray1OfPoles : public TCollection_BaseSequence {
 	public:
@@ -849,6 +884,11 @@ class Convert_SequenceOfArray1OfPoles : public TCollection_BaseSequence {
 };
 
 
+%extend Convert_SequenceOfArray1OfPoles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_CircleToBSplineCurve;
 class Convert_CircleToBSplineCurve : public Convert_ConicToBSplineCurve {
 	public:
@@ -879,6 +919,11 @@ class Convert_CircleToBSplineCurve : public Convert_ConicToBSplineCurve {
 };
 
 
+%extend Convert_CircleToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_ConeToBSplineSurface;
 class Convert_ConeToBSplineSurface : public Convert_ElementarySurfaceToBSplineSurface {
 	public:
@@ -913,6 +958,11 @@ class Convert_ConeToBSplineSurface : public Convert_ElementarySurfaceToBSplineSu
 };
 
 
+%extend Convert_ConeToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_CylinderToBSplineSurface;
 class Convert_CylinderToBSplineSurface : public Convert_ElementarySurfaceToBSplineSurface {
 	public:
@@ -947,6 +997,11 @@ class Convert_CylinderToBSplineSurface : public Convert_ElementarySurfaceToBSpli
 };
 
 
+%extend Convert_CylinderToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_EllipseToBSplineCurve;
 class Convert_EllipseToBSplineCurve : public Convert_ConicToBSplineCurve {
 	public:
@@ -977,6 +1032,11 @@ class Convert_EllipseToBSplineCurve : public Convert_ConicToBSplineCurve {
 };
 
 
+%extend Convert_EllipseToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_HyperbolaToBSplineCurve;
 class Convert_HyperbolaToBSplineCurve : public Convert_ConicToBSplineCurve {
 	public:
@@ -995,6 +1055,11 @@ class Convert_HyperbolaToBSplineCurve : public Convert_ConicToBSplineCurve {
 };
 
 
+%extend Convert_HyperbolaToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_ParabolaToBSplineCurve;
 class Convert_ParabolaToBSplineCurve : public Convert_ConicToBSplineCurve {
 	public:
@@ -1013,6 +1078,11 @@ class Convert_ParabolaToBSplineCurve : public Convert_ConicToBSplineCurve {
 };
 
 
+%extend Convert_ParabolaToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_SphereToBSplineSurface;
 class Convert_SphereToBSplineSurface : public Convert_ElementarySurfaceToBSplineSurface {
 	public:
@@ -1057,6 +1127,11 @@ class Convert_SphereToBSplineSurface : public Convert_ElementarySurfaceToBSpline
 };
 
 
+%extend Convert_SphereToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Convert_TorusToBSplineSurface;
 class Convert_TorusToBSplineSurface : public Convert_ElementarySurfaceToBSplineSurface {
 	public:
@@ -1101,3 +1176,8 @@ class Convert_TorusToBSplineSurface : public Convert_ElementarySurfaceToBSplineS
 };
 
 
+%extend Convert_TorusToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Dico.i
+++ b/src/SWIG_files/wrapper/Dico.i
@@ -246,6 +246,11 @@ class Handle_Dico_DictionaryOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend Dico_DictionaryOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Dico_DictionaryOfTransient;
 class Dico_DictionaryOfTransient : public MMgt_TShared {
 	public:
@@ -436,6 +441,11 @@ class Handle_Dico_DictionaryOfTransient : public Handle_MMgt_TShared {
     }
 };
 
+%extend Dico_DictionaryOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Dico_IteratorOfDictionaryOfInteger;
 class Dico_IteratorOfDictionaryOfInteger {
 	public:
@@ -484,6 +494,11 @@ class Dico_IteratorOfDictionaryOfInteger {
 };
 
 
+%extend Dico_IteratorOfDictionaryOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Dico_IteratorOfDictionaryOfTransient;
 class Dico_IteratorOfDictionaryOfTransient {
 	public:
@@ -532,6 +547,11 @@ class Dico_IteratorOfDictionaryOfTransient {
 };
 
 
+%extend Dico_IteratorOfDictionaryOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Dico_StackItemOfDictionaryOfInteger;
 class Dico_StackItemOfDictionaryOfInteger : public MMgt_TShared {
 	public:
@@ -608,6 +628,11 @@ class Handle_Dico_StackItemOfDictionaryOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend Dico_StackItemOfDictionaryOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Dico_StackItemOfDictionaryOfTransient;
 class Dico_StackItemOfDictionaryOfTransient : public MMgt_TShared {
 	public:
@@ -684,3 +709,8 @@ class Handle_Dico_StackItemOfDictionaryOfTransient : public Handle_MMgt_TShared 
     }
 };
 
+%extend Dico_StackItemOfDictionaryOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Draft.i
+++ b/src/SWIG_files/wrapper/Draft.i
@@ -79,6 +79,11 @@ class Draft {
 };
 
 
+%extend Draft {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapIteratorOfDataMapOfEdgeEdgeInfo;
 class Draft_DataMapIteratorOfDataMapOfEdgeEdgeInfo : public TCollection_BasicMapIterator {
 	public:
@@ -109,6 +114,11 @@ class Draft_DataMapIteratorOfDataMapOfEdgeEdgeInfo : public TCollection_BasicMap
 };
 
 
+%extend Draft_DataMapIteratorOfDataMapOfEdgeEdgeInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapIteratorOfDataMapOfFaceFaceInfo;
 class Draft_DataMapIteratorOfDataMapOfFaceFaceInfo : public TCollection_BasicMapIterator {
 	public:
@@ -139,6 +149,11 @@ class Draft_DataMapIteratorOfDataMapOfFaceFaceInfo : public TCollection_BasicMap
 };
 
 
+%extend Draft_DataMapIteratorOfDataMapOfFaceFaceInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapIteratorOfDataMapOfVertexVertexInfo;
 class Draft_DataMapIteratorOfDataMapOfVertexVertexInfo : public TCollection_BasicMapIterator {
 	public:
@@ -169,6 +184,11 @@ class Draft_DataMapIteratorOfDataMapOfVertexVertexInfo : public TCollection_Basi
 };
 
 
+%extend Draft_DataMapIteratorOfDataMapOfVertexVertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapNodeOfDataMapOfEdgeEdgeInfo;
 class Draft_DataMapNodeOfDataMapOfEdgeEdgeInfo : public TCollection_MapNode {
 	public:
@@ -239,6 +259,11 @@ class Handle_Draft_DataMapNodeOfDataMapOfEdgeEdgeInfo : public Handle_TCollectio
     }
 };
 
+%extend Draft_DataMapNodeOfDataMapOfEdgeEdgeInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapNodeOfDataMapOfFaceFaceInfo;
 class Draft_DataMapNodeOfDataMapOfFaceFaceInfo : public TCollection_MapNode {
 	public:
@@ -309,6 +334,11 @@ class Handle_Draft_DataMapNodeOfDataMapOfFaceFaceInfo : public Handle_TCollectio
     }
 };
 
+%extend Draft_DataMapNodeOfDataMapOfFaceFaceInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapNodeOfDataMapOfVertexVertexInfo;
 class Draft_DataMapNodeOfDataMapOfVertexVertexInfo : public TCollection_MapNode {
 	public:
@@ -379,6 +409,11 @@ class Handle_Draft_DataMapNodeOfDataMapOfVertexVertexInfo : public Handle_TColle
     }
 };
 
+%extend Draft_DataMapNodeOfDataMapOfVertexVertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapOfEdgeEdgeInfo;
 class Draft_DataMapOfEdgeEdgeInfo : public TCollection_BasicMap {
 	public:
@@ -457,6 +492,11 @@ class Draft_DataMapOfEdgeEdgeInfo : public TCollection_BasicMap {
 };
 
 
+%extend Draft_DataMapOfEdgeEdgeInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapOfFaceFaceInfo;
 class Draft_DataMapOfFaceFaceInfo : public TCollection_BasicMap {
 	public:
@@ -535,6 +575,11 @@ class Draft_DataMapOfFaceFaceInfo : public TCollection_BasicMap {
 };
 
 
+%extend Draft_DataMapOfFaceFaceInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_DataMapOfVertexVertexInfo;
 class Draft_DataMapOfVertexVertexInfo : public TCollection_BasicMap {
 	public:
@@ -613,6 +658,11 @@ class Draft_DataMapOfVertexVertexInfo : public TCollection_BasicMap {
 };
 
 
+%extend Draft_DataMapOfVertexVertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_EdgeInfo;
 class Draft_EdgeInfo {
 	public:
@@ -709,6 +759,11 @@ class Draft_EdgeInfo {
 };
 
 
+%extend Draft_EdgeInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_FaceInfo;
 class Draft_FaceInfo {
 	public:
@@ -771,6 +826,11 @@ class Draft_FaceInfo {
 };
 
 
+%extend Draft_FaceInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_Modification;
 class Draft_Modification : public BRepTools_Modification {
 	public:
@@ -997,6 +1057,11 @@ class Handle_Draft_Modification : public Handle_BRepTools_Modification {
     }
 };
 
+%extend Draft_Modification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Draft_VertexInfo;
 class Draft_VertexInfo {
 	public:
@@ -1049,3 +1114,8 @@ class Draft_VertexInfo {
 };
 
 
+%extend Draft_VertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ElCLib.i
+++ b/src/SWIG_files/wrapper/ElCLib.i
@@ -1522,3 +1522,8 @@ class ElCLib {
 };
 
 
+%extend ElCLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ElSLib.i
+++ b/src/SWIG_files/wrapper/ElSLib.i
@@ -1362,3 +1362,8 @@ class ElSLib {
 };
 
 
+%extend ElSLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Expr.i
+++ b/src/SWIG_files/wrapper/Expr.i
@@ -86,6 +86,11 @@ class Expr {
 };
 
 
+%extend Expr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Array1OfGeneralExpression;
 class Expr_Array1OfGeneralExpression {
 	public:
@@ -168,6 +173,11 @@ class Expr_Array1OfGeneralExpression {
 };
 
 
+%extend Expr_Array1OfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Array1OfNamedUnknown;
 class Expr_Array1OfNamedUnknown {
 	public:
@@ -250,6 +260,11 @@ class Expr_Array1OfNamedUnknown {
 };
 
 
+%extend Expr_Array1OfNamedUnknown {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Array1OfSingleRelation;
 class Expr_Array1OfSingleRelation {
 	public:
@@ -332,6 +347,11 @@ class Expr_Array1OfSingleRelation {
 };
 
 
+%extend Expr_Array1OfSingleRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_GeneralExpression;
 class Expr_GeneralExpression : public MMgt_TShared {
 	public:
@@ -500,6 +520,11 @@ class Handle_Expr_GeneralExpression : public Handle_MMgt_TShared {
     }
 };
 
+%extend Expr_GeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_GeneralFunction;
 class Expr_GeneralFunction : public MMgt_TShared {
 	public:
@@ -620,6 +645,11 @@ class Handle_Expr_GeneralFunction : public Handle_MMgt_TShared {
     }
 };
 
+%extend Expr_GeneralFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_GeneralRelation;
 class Expr_GeneralRelation : public MMgt_TShared {
 	public:
@@ -746,6 +776,11 @@ class Handle_Expr_GeneralRelation : public Handle_MMgt_TShared {
     }
 };
 
+%extend Expr_GeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_IndexedMapNodeOfMapOfNamedUnknown;
 class Expr_IndexedMapNodeOfMapOfNamedUnknown : public TCollection_MapNode {
 	public:
@@ -831,6 +866,11 @@ class Handle_Expr_IndexedMapNodeOfMapOfNamedUnknown : public Handle_TCollection_
     }
 };
 
+%extend Expr_IndexedMapNodeOfMapOfNamedUnknown {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_MapOfNamedUnknown;
 class Expr_MapOfNamedUnknown : public TCollection_BasicMap {
 	public:
@@ -907,6 +947,11 @@ class Expr_MapOfNamedUnknown : public TCollection_BasicMap {
 };
 
 
+%extend Expr_MapOfNamedUnknown {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_RUIterator;
 class Expr_RUIterator {
 	public:
@@ -937,6 +982,11 @@ class Expr_RUIterator {
 };
 
 
+%extend Expr_RUIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_RelationIterator;
 class Expr_RelationIterator {
 	public:
@@ -965,6 +1015,11 @@ class Expr_RelationIterator {
 };
 
 
+%extend Expr_RelationIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SequenceNodeOfSequenceOfGeneralExpression;
 class Expr_SequenceNodeOfSequenceOfGeneralExpression : public TCollection_SeqNode {
 	public:
@@ -1031,6 +1086,11 @@ class Handle_Expr_SequenceNodeOfSequenceOfGeneralExpression : public Handle_TCol
     }
 };
 
+%extend Expr_SequenceNodeOfSequenceOfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SequenceNodeOfSequenceOfGeneralRelation;
 class Expr_SequenceNodeOfSequenceOfGeneralRelation : public TCollection_SeqNode {
 	public:
@@ -1097,6 +1157,11 @@ class Handle_Expr_SequenceNodeOfSequenceOfGeneralRelation : public Handle_TColle
     }
 };
 
+%extend Expr_SequenceNodeOfSequenceOfGeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SequenceOfGeneralExpression;
 class Expr_SequenceOfGeneralExpression : public TCollection_BaseSequence {
 	public:
@@ -1235,6 +1300,11 @@ class Expr_SequenceOfGeneralExpression : public TCollection_BaseSequence {
 };
 
 
+%extend Expr_SequenceOfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SequenceOfGeneralRelation;
 class Expr_SequenceOfGeneralRelation : public TCollection_BaseSequence {
 	public:
@@ -1373,6 +1443,11 @@ class Expr_SequenceOfGeneralRelation : public TCollection_BaseSequence {
 };
 
 
+%extend Expr_SequenceOfGeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_UnknownIterator;
 class Expr_UnknownIterator {
 	public:
@@ -1397,6 +1472,11 @@ class Expr_UnknownIterator {
 };
 
 
+%extend Expr_UnknownIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_BinaryExpression;
 class Expr_BinaryExpression : public Expr_GeneralExpression {
 	public:
@@ -1517,6 +1597,11 @@ class Handle_Expr_BinaryExpression : public Handle_Expr_GeneralExpression {
     }
 };
 
+%extend Expr_BinaryExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_FunctionDerivative;
 class Expr_FunctionDerivative : public Expr_GeneralFunction {
 	public:
@@ -1675,6 +1760,11 @@ class Handle_Expr_FunctionDerivative : public Handle_Expr_GeneralFunction {
     }
 };
 
+%extend Expr_FunctionDerivative {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_NamedExpression;
 class Expr_NamedExpression : public Expr_GeneralExpression {
 	public:
@@ -1757,6 +1847,11 @@ class Handle_Expr_NamedExpression : public Handle_Expr_GeneralExpression {
     }
 };
 
+%extend Expr_NamedExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_NamedFunction;
 class Expr_NamedFunction : public Expr_GeneralFunction {
 	public:
@@ -1917,6 +2012,11 @@ class Handle_Expr_NamedFunction : public Handle_Expr_GeneralFunction {
     }
 };
 
+%extend Expr_NamedFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_NumericValue;
 class Expr_NumericValue : public Expr_GeneralExpression {
 	public:
@@ -2087,6 +2187,11 @@ class Handle_Expr_NumericValue : public Handle_Expr_GeneralExpression {
     }
 };
 
+%extend Expr_NumericValue {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_PolyExpression;
 class Expr_PolyExpression : public Expr_GeneralExpression {
 	public:
@@ -2207,6 +2312,11 @@ class Handle_Expr_PolyExpression : public Handle_Expr_GeneralExpression {
     }
 };
 
+%extend Expr_PolyExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SingleRelation;
 class Expr_SingleRelation : public Expr_GeneralRelation {
 	public:
@@ -2331,6 +2441,11 @@ class Handle_Expr_SingleRelation : public Handle_Expr_GeneralRelation {
     }
 };
 
+%extend Expr_SingleRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SystemRelation;
 class Expr_SystemRelation : public Expr_GeneralRelation {
 	public:
@@ -2477,6 +2592,11 @@ class Handle_Expr_SystemRelation : public Handle_Expr_GeneralRelation {
     }
 };
 
+%extend Expr_SystemRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_UnaryExpression;
 class Expr_UnaryExpression : public Expr_GeneralExpression {
 	public:
@@ -2587,6 +2707,11 @@ class Handle_Expr_UnaryExpression : public Handle_Expr_GeneralExpression {
     }
 };
 
+%extend Expr_UnaryExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Absolute;
 class Expr_Absolute : public Expr_UnaryExpression {
 	public:
@@ -2695,6 +2820,11 @@ class Handle_Expr_Absolute : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Absolute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArcCosine;
 class Expr_ArcCosine : public Expr_UnaryExpression {
 	public:
@@ -2803,6 +2933,11 @@ class Handle_Expr_ArcCosine : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArcCosine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArcSine;
 class Expr_ArcSine : public Expr_UnaryExpression {
 	public:
@@ -2911,6 +3046,11 @@ class Handle_Expr_ArcSine : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArcSine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArcTangent;
 class Expr_ArcTangent : public Expr_UnaryExpression {
 	public:
@@ -3019,6 +3159,11 @@ class Handle_Expr_ArcTangent : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArcTangent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArgCosh;
 class Expr_ArgCosh : public Expr_UnaryExpression {
 	public:
@@ -3127,6 +3272,11 @@ class Handle_Expr_ArgCosh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArgCosh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArgSinh;
 class Expr_ArgSinh : public Expr_UnaryExpression {
 	public:
@@ -3235,6 +3385,11 @@ class Handle_Expr_ArgSinh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArgSinh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_ArgTanh;
 class Expr_ArgTanh : public Expr_UnaryExpression {
 	public:
@@ -3343,6 +3498,11 @@ class Handle_Expr_ArgTanh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_ArgTanh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_BinaryFunction;
 class Expr_BinaryFunction : public Expr_BinaryExpression {
 	public:
@@ -3461,6 +3621,11 @@ class Handle_Expr_BinaryFunction : public Handle_Expr_BinaryExpression {
     }
 };
 
+%extend Expr_BinaryFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Cosh;
 class Expr_Cosh : public Expr_UnaryExpression {
 	public:
@@ -3569,6 +3734,11 @@ class Handle_Expr_Cosh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Cosh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Cosine;
 class Expr_Cosine : public Expr_UnaryExpression {
 	public:
@@ -3677,6 +3847,11 @@ class Handle_Expr_Cosine : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Cosine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Difference;
 class Expr_Difference : public Expr_BinaryExpression {
 	public:
@@ -3797,6 +3972,11 @@ class Handle_Expr_Difference : public Handle_Expr_BinaryExpression {
     }
 };
 
+%extend Expr_Difference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Different;
 class Expr_Different : public Expr_SingleRelation {
 	public:
@@ -3887,6 +4067,11 @@ class Handle_Expr_Different : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_Different {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Division;
 class Expr_Division : public Expr_BinaryExpression {
 	public:
@@ -3997,6 +4182,11 @@ class Handle_Expr_Division : public Handle_Expr_BinaryExpression {
     }
 };
 
+%extend Expr_Division {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Equal;
 class Expr_Equal : public Expr_SingleRelation {
 	public:
@@ -4087,6 +4277,11 @@ class Handle_Expr_Equal : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_Equal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Exponential;
 class Expr_Exponential : public Expr_UnaryExpression {
 	public:
@@ -4195,6 +4390,11 @@ class Handle_Expr_Exponential : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Exponential {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Exponentiate;
 class Expr_Exponentiate : public Expr_BinaryExpression {
 	public:
@@ -4305,6 +4505,11 @@ class Handle_Expr_Exponentiate : public Handle_Expr_BinaryExpression {
     }
 };
 
+%extend Expr_Exponentiate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_GreaterThan;
 class Expr_GreaterThan : public Expr_SingleRelation {
 	public:
@@ -4395,6 +4600,11 @@ class Handle_Expr_GreaterThan : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_GreaterThan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_GreaterThanOrEqual;
 class Expr_GreaterThanOrEqual : public Expr_SingleRelation {
 	public:
@@ -4485,6 +4695,11 @@ class Handle_Expr_GreaterThanOrEqual : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_GreaterThanOrEqual {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_LessThan;
 class Expr_LessThan : public Expr_SingleRelation {
 	public:
@@ -4575,6 +4790,11 @@ class Handle_Expr_LessThan : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_LessThan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_LessThanOrEqual;
 class Expr_LessThanOrEqual : public Expr_SingleRelation {
 	public:
@@ -4665,6 +4885,11 @@ class Handle_Expr_LessThanOrEqual : public Handle_Expr_SingleRelation {
     }
 };
 
+%extend Expr_LessThanOrEqual {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_LogOf10;
 class Expr_LogOf10 : public Expr_UnaryExpression {
 	public:
@@ -4773,6 +4998,11 @@ class Handle_Expr_LogOf10 : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_LogOf10 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_LogOfe;
 class Expr_LogOfe : public Expr_UnaryExpression {
 	public:
@@ -4881,6 +5111,11 @@ class Handle_Expr_LogOfe : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_LogOfe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_NamedConstant;
 class Expr_NamedConstant : public Expr_NamedExpression {
 	public:
@@ -5035,6 +5270,11 @@ class Handle_Expr_NamedConstant : public Handle_Expr_NamedExpression {
     }
 };
 
+%extend Expr_NamedConstant {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_NamedUnknown;
 class Expr_NamedUnknown : public Expr_NamedExpression {
 	public:
@@ -5197,6 +5437,11 @@ class Handle_Expr_NamedUnknown : public Handle_Expr_NamedExpression {
     }
 };
 
+%extend Expr_NamedUnknown {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_PolyFunction;
 class Expr_PolyFunction : public Expr_PolyExpression {
 	public:
@@ -5313,6 +5558,11 @@ class Handle_Expr_PolyFunction : public Handle_Expr_PolyExpression {
     }
 };
 
+%extend Expr_PolyFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Product;
 class Expr_Product : public Expr_PolyExpression {
 	public:
@@ -5431,6 +5681,11 @@ class Handle_Expr_Product : public Handle_Expr_PolyExpression {
     }
 };
 
+%extend Expr_Product {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Sine;
 class Expr_Sine : public Expr_UnaryExpression {
 	public:
@@ -5539,6 +5794,11 @@ class Handle_Expr_Sine : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Sine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Sinh;
 class Expr_Sinh : public Expr_UnaryExpression {
 	public:
@@ -5647,6 +5907,11 @@ class Handle_Expr_Sinh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Sinh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Square;
 class Expr_Square : public Expr_UnaryExpression {
 	public:
@@ -5755,6 +6020,11 @@ class Handle_Expr_Square : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Square {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_SquareRoot;
 class Expr_SquareRoot : public Expr_UnaryExpression {
 	public:
@@ -5863,6 +6133,11 @@ class Handle_Expr_SquareRoot : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_SquareRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Sum;
 class Expr_Sum : public Expr_PolyExpression {
 	public:
@@ -5991,6 +6266,11 @@ class Handle_Expr_Sum : public Handle_Expr_PolyExpression {
     }
 };
 
+%extend Expr_Sum {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Tangent;
 class Expr_Tangent : public Expr_UnaryExpression {
 	public:
@@ -6099,6 +6379,11 @@ class Handle_Expr_Tangent : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Tangent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_Tanh;
 class Expr_Tanh : public Expr_UnaryExpression {
 	public:
@@ -6207,6 +6492,11 @@ class Handle_Expr_Tanh : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_Tanh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_UnaryFunction;
 class Expr_UnaryFunction : public Expr_UnaryExpression {
 	public:
@@ -6323,6 +6613,11 @@ class Handle_Expr_UnaryFunction : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_UnaryFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Expr_UnaryMinus;
 class Expr_UnaryMinus : public Expr_UnaryExpression {
 	public:
@@ -6441,3 +6736,8 @@ class Handle_Expr_UnaryMinus : public Handle_Expr_UnaryExpression {
     }
 };
 
+%extend Expr_UnaryMinus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ExprIntrp.i
+++ b/src/SWIG_files/wrapper/ExprIntrp.i
@@ -63,6 +63,11 @@ class ExprIntrp {
 };
 
 
+%extend ExprIntrp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_Analysis;
 class ExprIntrp_Analysis {
 	public:
@@ -165,6 +170,11 @@ class ExprIntrp_Analysis {
 };
 
 
+%extend ExprIntrp_Analysis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_Generator;
 class ExprIntrp_Generator : public MMgt_TShared {
 	public:
@@ -253,6 +263,11 @@ class Handle_ExprIntrp_Generator : public Handle_MMgt_TShared {
     }
 };
 
+%extend ExprIntrp_Generator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListIteratorOfStackOfGeneralExpression;
 class ExprIntrp_ListIteratorOfStackOfGeneralExpression {
 	public:
@@ -287,6 +302,11 @@ class ExprIntrp_ListIteratorOfStackOfGeneralExpression {
 };
 
 
+%extend ExprIntrp_ListIteratorOfStackOfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListIteratorOfStackOfGeneralFunction;
 class ExprIntrp_ListIteratorOfStackOfGeneralFunction {
 	public:
@@ -321,6 +341,11 @@ class ExprIntrp_ListIteratorOfStackOfGeneralFunction {
 };
 
 
+%extend ExprIntrp_ListIteratorOfStackOfGeneralFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListIteratorOfStackOfGeneralRelation;
 class ExprIntrp_ListIteratorOfStackOfGeneralRelation {
 	public:
@@ -355,6 +380,11 @@ class ExprIntrp_ListIteratorOfStackOfGeneralRelation {
 };
 
 
+%extend ExprIntrp_ListIteratorOfStackOfGeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListNodeOfStackOfGeneralExpression;
 class ExprIntrp_ListNodeOfStackOfGeneralExpression : public TCollection_MapNode {
 	public:
@@ -419,6 +449,11 @@ class Handle_ExprIntrp_ListNodeOfStackOfGeneralExpression : public Handle_TColle
     }
 };
 
+%extend ExprIntrp_ListNodeOfStackOfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListNodeOfStackOfGeneralFunction;
 class ExprIntrp_ListNodeOfStackOfGeneralFunction : public TCollection_MapNode {
 	public:
@@ -483,6 +518,11 @@ class Handle_ExprIntrp_ListNodeOfStackOfGeneralFunction : public Handle_TCollect
     }
 };
 
+%extend ExprIntrp_ListNodeOfStackOfGeneralFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_ListNodeOfStackOfGeneralRelation;
 class ExprIntrp_ListNodeOfStackOfGeneralRelation : public TCollection_MapNode {
 	public:
@@ -547,6 +587,11 @@ class Handle_ExprIntrp_ListNodeOfStackOfGeneralRelation : public Handle_TCollect
     }
 };
 
+%extend ExprIntrp_ListNodeOfStackOfGeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_SequenceNodeOfSequenceOfNamedExpression;
 class ExprIntrp_SequenceNodeOfSequenceOfNamedExpression : public TCollection_SeqNode {
 	public:
@@ -613,6 +658,11 @@ class Handle_ExprIntrp_SequenceNodeOfSequenceOfNamedExpression : public Handle_T
     }
 };
 
+%extend ExprIntrp_SequenceNodeOfSequenceOfNamedExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_SequenceNodeOfSequenceOfNamedFunction;
 class ExprIntrp_SequenceNodeOfSequenceOfNamedFunction : public TCollection_SeqNode {
 	public:
@@ -679,6 +729,11 @@ class Handle_ExprIntrp_SequenceNodeOfSequenceOfNamedFunction : public Handle_TCo
     }
 };
 
+%extend ExprIntrp_SequenceNodeOfSequenceOfNamedFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_SequenceOfNamedExpression;
 class ExprIntrp_SequenceOfNamedExpression : public TCollection_BaseSequence {
 	public:
@@ -817,6 +872,11 @@ class ExprIntrp_SequenceOfNamedExpression : public TCollection_BaseSequence {
 };
 
 
+%extend ExprIntrp_SequenceOfNamedExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_SequenceOfNamedFunction;
 class ExprIntrp_SequenceOfNamedFunction : public TCollection_BaseSequence {
 	public:
@@ -955,6 +1015,11 @@ class ExprIntrp_SequenceOfNamedFunction : public TCollection_BaseSequence {
 };
 
 
+%extend ExprIntrp_SequenceOfNamedFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_StackOfGeneralExpression;
 class ExprIntrp_StackOfGeneralExpression {
 	public:
@@ -1085,6 +1150,11 @@ class ExprIntrp_StackOfGeneralExpression {
 };
 
 
+%extend ExprIntrp_StackOfGeneralExpression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_StackOfGeneralFunction;
 class ExprIntrp_StackOfGeneralFunction {
 	public:
@@ -1215,6 +1285,11 @@ class ExprIntrp_StackOfGeneralFunction {
 };
 
 
+%extend ExprIntrp_StackOfGeneralFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_StackOfGeneralRelation;
 class ExprIntrp_StackOfGeneralRelation {
 	public:
@@ -1345,6 +1420,11 @@ class ExprIntrp_StackOfGeneralRelation {
 };
 
 
+%extend ExprIntrp_StackOfGeneralRelation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_GenExp;
 class ExprIntrp_GenExp : public ExprIntrp_Generator {
 	public:
@@ -1421,6 +1501,11 @@ class Handle_ExprIntrp_GenExp : public Handle_ExprIntrp_Generator {
     }
 };
 
+%extend ExprIntrp_GenExp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_GenFct;
 class ExprIntrp_GenFct : public ExprIntrp_Generator {
 	public:
@@ -1487,6 +1572,11 @@ class Handle_ExprIntrp_GenFct : public Handle_ExprIntrp_Generator {
     }
 };
 
+%extend ExprIntrp_GenFct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ExprIntrp_GenRel;
 class ExprIntrp_GenRel : public ExprIntrp_Generator {
 	public:
@@ -1563,3 +1653,8 @@ class Handle_ExprIntrp_GenRel : public Handle_ExprIntrp_Generator {
     }
 };
 
+%extend ExprIntrp_GenRel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Extrema.i
+++ b/src/SWIG_files/wrapper/Extrema.i
@@ -159,6 +159,11 @@ class Extrema_Array1OfPOnCurv {
 };
 
 
+%extend Extrema_Array1OfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array1OfPOnCurv2d;
 class Extrema_Array1OfPOnCurv2d {
 	public:
@@ -241,6 +246,11 @@ class Extrema_Array1OfPOnCurv2d {
 };
 
 
+%extend Extrema_Array1OfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array1OfPOnSurf;
 class Extrema_Array1OfPOnSurf {
 	public:
@@ -323,6 +333,11 @@ class Extrema_Array1OfPOnSurf {
 };
 
 
+%extend Extrema_Array1OfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array2OfPOnCurv;
 class Extrema_Array2OfPOnCurv {
 	public:
@@ -427,6 +442,11 @@ class Extrema_Array2OfPOnCurv {
 };
 
 
+%extend Extrema_Array2OfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array2OfPOnCurv2d;
 class Extrema_Array2OfPOnCurv2d {
 	public:
@@ -531,6 +551,11 @@ class Extrema_Array2OfPOnCurv2d {
 };
 
 
+%extend Extrema_Array2OfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array2OfPOnSurf;
 class Extrema_Array2OfPOnSurf {
 	public:
@@ -635,6 +660,11 @@ class Extrema_Array2OfPOnSurf {
 };
 
 
+%extend Extrema_Array2OfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_Array2OfPOnSurfParams;
 class Extrema_Array2OfPOnSurfParams {
 	public:
@@ -739,6 +769,11 @@ class Extrema_Array2OfPOnSurfParams {
 };
 
 
+%extend Extrema_Array2OfPOnSurfParams {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_CCLocFOfLocECC;
 class Extrema_CCLocFOfLocECC : public math_FunctionSetWithDerivatives {
 	public:
@@ -857,6 +892,11 @@ class Extrema_CCLocFOfLocECC : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Extrema_CCLocFOfLocECC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_CCLocFOfLocECC2d;
 class Extrema_CCLocFOfLocECC2d : public math_FunctionSetWithDerivatives {
 	public:
@@ -975,6 +1015,11 @@ class Extrema_CCLocFOfLocECC2d : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Extrema_CCLocFOfLocECC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Extrema_Curve2dTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -1204,6 +1249,11 @@ class Extrema_Curve2dTool {
 };
 
 
+%extend Extrema_Curve2dTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Extrema_CurveTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -1411,6 +1461,11 @@ class Extrema_CurveTool {
 };
 
 
+%extend Extrema_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ECC;
 class Extrema_ECC {
 	public:
@@ -1495,6 +1550,11 @@ class Extrema_ECC {
 };
 
 
+%extend Extrema_ECC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ECC2d;
 class Extrema_ECC2d {
 	public:
@@ -1579,6 +1639,11 @@ class Extrema_ECC2d {
 };
 
 
+%extend Extrema_ECC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ELCC;
 class Extrema_ELCC {
 	public:
@@ -1663,6 +1728,11 @@ class Extrema_ELCC {
 };
 
 
+%extend Extrema_ELCC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ELCC2d;
 class Extrema_ELCC2d {
 	public:
@@ -1747,6 +1817,11 @@ class Extrema_ELCC2d {
 };
 
 
+%extend Extrema_ELCC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ELPCOfLocateExtPC;
 class Extrema_ELPCOfLocateExtPC {
 	public:
@@ -1837,6 +1912,11 @@ class Extrema_ELPCOfLocateExtPC {
 };
 
 
+%extend Extrema_ELPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ELPCOfLocateExtPC2d;
 class Extrema_ELPCOfLocateExtPC2d {
 	public:
@@ -1927,6 +2007,11 @@ class Extrema_ELPCOfLocateExtPC2d {
 };
 
 
+%extend Extrema_ELPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_EPCOfELPCOfLocateExtPC;
 class Extrema_EPCOfELPCOfLocateExtPC {
 	public:
@@ -2049,6 +2134,11 @@ class Extrema_EPCOfELPCOfLocateExtPC {
 };
 
 
+%extend Extrema_EPCOfELPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_EPCOfELPCOfLocateExtPC2d;
 class Extrema_EPCOfELPCOfLocateExtPC2d {
 	public:
@@ -2171,6 +2261,11 @@ class Extrema_EPCOfELPCOfLocateExtPC2d {
 };
 
 
+%extend Extrema_EPCOfELPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_EPCOfExtPC;
 class Extrema_EPCOfExtPC {
 	public:
@@ -2293,6 +2388,11 @@ class Extrema_EPCOfExtPC {
 };
 
 
+%extend Extrema_EPCOfExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_EPCOfExtPC2d;
 class Extrema_EPCOfExtPC2d {
 	public:
@@ -2415,6 +2515,11 @@ class Extrema_EPCOfExtPC2d {
 };
 
 
+%extend Extrema_EPCOfExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtCC;
 class Extrema_ExtCC {
 	public:
@@ -2567,6 +2672,11 @@ class Extrema_ExtCC {
 };
 
 
+%extend Extrema_ExtCC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtCC2d;
 class Extrema_ExtCC2d {
 	public:
@@ -2699,6 +2809,11 @@ class Extrema_ExtCC2d {
 };
 
 
+%extend Extrema_ExtCC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtCS;
 class Extrema_ExtCS {
 	public:
@@ -2819,6 +2934,11 @@ class Extrema_ExtCS {
 };
 
 
+%extend Extrema_ExtCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtElC;
 class Extrema_ExtElC {
 	public:
@@ -3021,6 +3141,11 @@ class Extrema_ExtElC {
 };
 
 
+%extend Extrema_ExtElC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtElC2d;
 class Extrema_ExtElC2d {
 	public:
@@ -3223,6 +3348,11 @@ class Extrema_ExtElC2d {
 };
 
 
+%extend Extrema_ExtElC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtElCS;
 class Extrema_ExtElCS {
 	public:
@@ -3469,6 +3599,11 @@ class Extrema_ExtElCS {
 };
 
 
+%extend Extrema_ExtElCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtElSS;
 class Extrema_ExtElSS {
 	public:
@@ -3625,6 +3760,11 @@ class Extrema_ExtElSS {
 };
 
 
+%extend Extrema_ExtElSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPC;
 class Extrema_ExtPC {
 	public:
@@ -3715,6 +3855,11 @@ class Extrema_ExtPC {
 };
 
 
+%extend Extrema_ExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPC2d;
 class Extrema_ExtPC2d {
 	public:
@@ -3805,6 +3950,11 @@ class Extrema_ExtPC2d {
 };
 
 
+%extend Extrema_ExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPElC;
 class Extrema_ExtPElC {
 	public:
@@ -4001,6 +4151,11 @@ class Extrema_ExtPElC {
 };
 
 
+%extend Extrema_ExtPElC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPElC2d;
 class Extrema_ExtPElC2d {
 	public:
@@ -4197,6 +4352,11 @@ class Extrema_ExtPElC2d {
 };
 
 
+%extend Extrema_ExtPElC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPElS;
 class Extrema_ExtPElS {
 	public:
@@ -4345,6 +4505,11 @@ class Extrema_ExtPElS {
 };
 
 
+%extend Extrema_ExtPElS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPExtS;
 class Extrema_ExtPExtS : public Standard_Transient {
 	public:
@@ -4491,6 +4656,11 @@ class Handle_Extrema_ExtPExtS : public Handle_Standard_Transient {
     }
 };
 
+%extend Extrema_ExtPExtS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPRevS;
 class Extrema_ExtPRevS : public Standard_Transient {
 	public:
@@ -4635,6 +4805,11 @@ class Handle_Extrema_ExtPRevS : public Handle_Standard_Transient {
     }
 };
 
+%extend Extrema_ExtPRevS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtPS;
 class Extrema_ExtPS {
 	public:
@@ -4779,6 +4954,11 @@ class Extrema_ExtPS {
 };
 
 
+%extend Extrema_ExtPS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_ExtSS;
 class Extrema_ExtSS {
 	public:
@@ -4907,6 +5087,11 @@ class Extrema_ExtSS {
 };
 
 
+%extend Extrema_ExtSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_FuncExtCS;
 class Extrema_FuncExtCS : public math_FunctionSetWithDerivatives {
 	public:
@@ -5011,6 +5196,11 @@ class Extrema_FuncExtCS : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Extrema_FuncExtCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_FuncExtPS;
 class Extrema_FuncExtPS : public math_FunctionSetWithDerivatives {
 	public:
@@ -5113,6 +5303,11 @@ class Extrema_FuncExtPS : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Extrema_FuncExtPS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_FuncExtSS;
 class Extrema_FuncExtSS : public math_FunctionSetWithDerivatives {
 	public:
@@ -5217,6 +5412,11 @@ class Extrema_FuncExtSS : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Extrema_FuncExtSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenExtCS;
 class Extrema_GenExtCS {
 	public:
@@ -5375,6 +5575,11 @@ class Extrema_GenExtCS {
 };
 
 
+%extend Extrema_GenExtCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenExtPS;
 class Extrema_GenExtPS {
 	public:
@@ -5521,6 +5726,11 @@ class Extrema_GenExtPS {
 };
 
 
+%extend Extrema_GenExtPS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenExtSS;
 class Extrema_GenExtSS {
 	public:
@@ -5679,6 +5889,11 @@ class Extrema_GenExtSS {
 };
 
 
+%extend Extrema_GenExtSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenLocateExtCS;
 class Extrema_GenLocateExtCS {
 	public:
@@ -5751,6 +5966,11 @@ class Extrema_GenLocateExtCS {
 };
 
 
+%extend Extrema_GenLocateExtCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenLocateExtPS;
 class Extrema_GenLocateExtPS {
 	public:
@@ -5797,6 +6017,11 @@ class Extrema_GenLocateExtPS {
 };
 
 
+%extend Extrema_GenLocateExtPS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GenLocateExtSS;
 class Extrema_GenLocateExtSS {
 	public:
@@ -5873,6 +6098,11 @@ class Extrema_GenLocateExtSS {
 };
 
 
+%extend Extrema_GenLocateExtSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GlobOptFuncCCC0;
 class Extrema_GlobOptFuncCCC0 : public math_MultipleVarFunction {
 	public:
@@ -5907,6 +6137,11 @@ class Extrema_GlobOptFuncCCC0 : public math_MultipleVarFunction {
 };
 
 
+%extend Extrema_GlobOptFuncCCC0 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GlobOptFuncCCC1;
 class Extrema_GlobOptFuncCCC1 : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -5959,6 +6194,11 @@ class Extrema_GlobOptFuncCCC1 : public math_MultipleVarFunctionWithGradient {
 };
 
 
+%extend Extrema_GlobOptFuncCCC1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GlobOptFuncCCC2;
 class Extrema_GlobOptFuncCCC2 : public math_MultipleVarFunctionWithHessian {
 	public:
@@ -6023,6 +6263,11 @@ class Extrema_GlobOptFuncCCC2 : public math_MultipleVarFunctionWithHessian {
 };
 
 
+%extend Extrema_GlobOptFuncCCC2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_GlobOptFuncCS;
 class Extrema_GlobOptFuncCS : public math_MultipleVarFunctionWithHessian {
 	public:
@@ -6081,6 +6326,11 @@ class Extrema_GlobOptFuncCS : public math_MultipleVarFunctionWithHessian {
 };
 
 
+%extend Extrema_GlobOptFuncCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray1OfPOnCurv;
 class Extrema_HArray1OfPOnCurv : public MMgt_TShared {
 	public:
@@ -6197,6 +6447,11 @@ class Handle_Extrema_HArray1OfPOnCurv : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray1OfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray1OfPOnCurv2d;
 class Extrema_HArray1OfPOnCurv2d : public MMgt_TShared {
 	public:
@@ -6313,6 +6568,11 @@ class Handle_Extrema_HArray1OfPOnCurv2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray1OfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray1OfPOnSurf;
 class Extrema_HArray1OfPOnSurf : public MMgt_TShared {
 	public:
@@ -6429,6 +6689,11 @@ class Handle_Extrema_HArray1OfPOnSurf : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray1OfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray2OfPOnCurv;
 class Extrema_HArray2OfPOnCurv : public MMgt_TShared {
 	public:
@@ -6571,6 +6836,11 @@ class Handle_Extrema_HArray2OfPOnCurv : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray2OfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray2OfPOnCurv2d;
 class Extrema_HArray2OfPOnCurv2d : public MMgt_TShared {
 	public:
@@ -6713,6 +6983,11 @@ class Handle_Extrema_HArray2OfPOnCurv2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray2OfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray2OfPOnSurf;
 class Extrema_HArray2OfPOnSurf : public MMgt_TShared {
 	public:
@@ -6855,6 +7130,11 @@ class Handle_Extrema_HArray2OfPOnSurf : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray2OfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_HArray2OfPOnSurfParams;
 class Extrema_HArray2OfPOnSurfParams : public MMgt_TShared {
 	public:
@@ -6997,6 +7277,11 @@ class Handle_Extrema_HArray2OfPOnSurfParams : public Handle_MMgt_TShared {
     }
 };
 
+%extend Extrema_HArray2OfPOnSurfParams {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocECC;
 class Extrema_LocECC {
 	public:
@@ -7035,6 +7320,11 @@ class Extrema_LocECC {
 };
 
 
+%extend Extrema_LocECC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocECC2d;
 class Extrema_LocECC2d {
 	public:
@@ -7073,6 +7363,11 @@ class Extrema_LocECC2d {
 };
 
 
+%extend Extrema_LocECC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocEPCOfLocateExtPC;
 class Extrema_LocEPCOfLocateExtPC {
 	public:
@@ -7147,6 +7442,11 @@ class Extrema_LocEPCOfLocateExtPC {
 };
 
 
+%extend Extrema_LocEPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocEPCOfLocateExtPC2d;
 class Extrema_LocEPCOfLocateExtPC2d {
 	public:
@@ -7221,6 +7521,11 @@ class Extrema_LocEPCOfLocateExtPC2d {
 };
 
 
+%extend Extrema_LocEPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocateExtCC;
 class Extrema_LocateExtCC {
 	public:
@@ -7263,6 +7568,11 @@ class Extrema_LocateExtCC {
 };
 
 
+%extend Extrema_LocateExtCC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocateExtCC2d;
 class Extrema_LocateExtCC2d {
 	public:
@@ -7305,6 +7615,11 @@ class Extrema_LocateExtCC2d {
 };
 
 
+%extend Extrema_LocateExtCC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocateExtPC;
 class Extrema_LocateExtPC {
 	public:
@@ -7379,6 +7694,11 @@ class Extrema_LocateExtPC {
 };
 
 
+%extend Extrema_LocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_LocateExtPC2d;
 class Extrema_LocateExtPC2d {
 	public:
@@ -7453,6 +7773,11 @@ class Extrema_LocateExtPC2d {
 };
 
 
+%extend Extrema_LocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCFOfEPCOfELPCOfLocateExtPC;
 class Extrema_PCFOfEPCOfELPCOfLocateExtPC : public math_FunctionWithDerivative {
 	public:
@@ -7547,6 +7872,11 @@ class Extrema_PCFOfEPCOfELPCOfLocateExtPC : public math_FunctionWithDerivative {
 };
 
 
+%extend Extrema_PCFOfEPCOfELPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCFOfEPCOfELPCOfLocateExtPC2d;
 class Extrema_PCFOfEPCOfELPCOfLocateExtPC2d : public math_FunctionWithDerivative {
 	public:
@@ -7641,6 +7971,11 @@ class Extrema_PCFOfEPCOfELPCOfLocateExtPC2d : public math_FunctionWithDerivative
 };
 
 
+%extend Extrema_PCFOfEPCOfELPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCFOfEPCOfExtPC;
 class Extrema_PCFOfEPCOfExtPC : public math_FunctionWithDerivative {
 	public:
@@ -7735,6 +8070,11 @@ class Extrema_PCFOfEPCOfExtPC : public math_FunctionWithDerivative {
 };
 
 
+%extend Extrema_PCFOfEPCOfExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCFOfEPCOfExtPC2d;
 class Extrema_PCFOfEPCOfExtPC2d : public math_FunctionWithDerivative {
 	public:
@@ -7829,6 +8169,11 @@ class Extrema_PCFOfEPCOfExtPC2d : public math_FunctionWithDerivative {
 };
 
 
+%extend Extrema_PCFOfEPCOfExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCLocFOfLocEPCOfLocateExtPC;
 class Extrema_PCLocFOfLocEPCOfLocateExtPC : public math_FunctionWithDerivative {
 	public:
@@ -7923,6 +8268,11 @@ class Extrema_PCLocFOfLocEPCOfLocateExtPC : public math_FunctionWithDerivative {
 };
 
 
+%extend Extrema_PCLocFOfLocEPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_PCLocFOfLocEPCOfLocateExtPC2d;
 class Extrema_PCLocFOfLocEPCOfLocateExtPC2d : public math_FunctionWithDerivative {
 	public:
@@ -8017,6 +8367,11 @@ class Extrema_PCLocFOfLocEPCOfLocateExtPC2d : public math_FunctionWithDerivative
 };
 
 
+%extend Extrema_PCLocFOfLocEPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_POnCurv;
 class Extrema_POnCurv {
 	public:
@@ -8065,6 +8420,11 @@ class Extrema_POnCurv {
 };
 
 
+%extend Extrema_POnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_POnCurv2d;
 class Extrema_POnCurv2d {
 	public:
@@ -8113,6 +8473,11 @@ class Extrema_POnCurv2d {
 };
 
 
+%extend Extrema_POnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_POnSurf;
 class Extrema_POnSurf {
 	public:
@@ -8153,6 +8518,11 @@ class Extrema_POnSurf {
 };
 
 
+%extend Extrema_POnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC;
 class Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC : public TCollection_BaseSequence {
 	public:
@@ -8291,6 +8661,11 @@ class Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC : public TCollection_BaseSequen
 };
 
 
+%extend Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d;
 class Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d : public TCollection_BaseSequence {
 	public:
@@ -8429,6 +8804,11 @@ class Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d : public TCollection_BaseSequ
 };
 
 
+%extend Extrema_SeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCFOfEPCOfExtPC;
 class Extrema_SeqPCOfPCFOfEPCOfExtPC : public TCollection_BaseSequence {
 	public:
@@ -8567,6 +8947,11 @@ class Extrema_SeqPCOfPCFOfEPCOfExtPC : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SeqPCOfPCFOfEPCOfExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCFOfEPCOfExtPC2d;
 class Extrema_SeqPCOfPCFOfEPCOfExtPC2d : public TCollection_BaseSequence {
 	public:
@@ -8705,6 +9090,11 @@ class Extrema_SeqPCOfPCFOfEPCOfExtPC2d : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SeqPCOfPCFOfEPCOfExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC;
 class Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC : public TCollection_BaseSequence {
 	public:
@@ -8843,6 +9233,11 @@ class Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC : public TCollection_BaseSequen
 };
 
 
+%extend Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC2d;
 class Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC2d : public TCollection_BaseSequence {
 	public:
@@ -8981,6 +9376,11 @@ class Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC2d : public TCollection_BaseSequ
 };
 
 
+%extend Extrema_SeqPCOfPCLocFOfLocEPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPOnCOfCCLocFOfLocECC;
 class Extrema_SeqPOnCOfCCLocFOfLocECC : public TCollection_BaseSequence {
 	public:
@@ -9119,6 +9519,11 @@ class Extrema_SeqPOnCOfCCLocFOfLocECC : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SeqPOnCOfCCLocFOfLocECC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SeqPOnCOfCCLocFOfLocECC2d;
 class Extrema_SeqPOnCOfCCLocFOfLocECC2d : public TCollection_BaseSequence {
 	public:
@@ -9257,6 +9662,11 @@ class Extrema_SeqPOnCOfCCLocFOfLocECC2d : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SeqPOnCOfCCLocFOfLocECC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC;
 class Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC : public TCollection_SeqNode {
 	public:
@@ -9323,6 +9733,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC : public H
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d;
 class Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d : public TCollection_SeqNode {
 	public:
@@ -9389,6 +9804,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d : public
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfELPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC;
 class Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC : public TCollection_SeqNode {
 	public:
@@ -9455,6 +9875,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC : public Handle_TColle
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC2d;
 class Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC2d : public TCollection_SeqNode {
 	public:
@@ -9521,6 +9946,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC2d : public Handle_TCol
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCFOfEPCOfExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC;
 class Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC : public TCollection_SeqNode {
 	public:
@@ -9587,6 +10017,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC : public H
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC2d;
 class Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC2d : public TCollection_SeqNode {
 	public:
@@ -9653,6 +10088,11 @@ class Handle_Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC2d : public
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPCOfPCLocFOfLocEPCOfLocateExtPC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC;
 class Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC : public TCollection_SeqNode {
 	public:
@@ -9719,6 +10159,11 @@ class Handle_Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC : public Handle_TColl
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC2d;
 class Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC2d : public TCollection_SeqNode {
 	public:
@@ -9785,6 +10230,11 @@ class Handle_Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC2d : public Handle_TCo
     }
 };
 
+%extend Extrema_SequenceNodeOfSeqPOnCOfCCLocFOfLocECC2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSequenceOfPOnCurv;
 class Extrema_SequenceNodeOfSequenceOfPOnCurv : public TCollection_SeqNode {
 	public:
@@ -9851,6 +10301,11 @@ class Handle_Extrema_SequenceNodeOfSequenceOfPOnCurv : public Handle_TCollection
     }
 };
 
+%extend Extrema_SequenceNodeOfSequenceOfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSequenceOfPOnCurv2d;
 class Extrema_SequenceNodeOfSequenceOfPOnCurv2d : public TCollection_SeqNode {
 	public:
@@ -9917,6 +10372,11 @@ class Handle_Extrema_SequenceNodeOfSequenceOfPOnCurv2d : public Handle_TCollecti
     }
 };
 
+%extend Extrema_SequenceNodeOfSequenceOfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceNodeOfSequenceOfPOnSurf;
 class Extrema_SequenceNodeOfSequenceOfPOnSurf : public TCollection_SeqNode {
 	public:
@@ -9983,6 +10443,11 @@ class Handle_Extrema_SequenceNodeOfSequenceOfPOnSurf : public Handle_TCollection
     }
 };
 
+%extend Extrema_SequenceNodeOfSequenceOfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceOfPOnCurv;
 class Extrema_SequenceOfPOnCurv : public TCollection_BaseSequence {
 	public:
@@ -10121,6 +10586,11 @@ class Extrema_SequenceOfPOnCurv : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SequenceOfPOnCurv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceOfPOnCurv2d;
 class Extrema_SequenceOfPOnCurv2d : public TCollection_BaseSequence {
 	public:
@@ -10259,6 +10729,11 @@ class Extrema_SequenceOfPOnCurv2d : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SequenceOfPOnCurv2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_SequenceOfPOnSurf;
 class Extrema_SequenceOfPOnSurf : public TCollection_BaseSequence {
 	public:
@@ -10397,6 +10872,11 @@ class Extrema_SequenceOfPOnSurf : public TCollection_BaseSequence {
 };
 
 
+%extend Extrema_SequenceOfPOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Extrema_POnSurfParams;
 class Extrema_POnSurfParams : public Extrema_POnSurf {
 	public:
@@ -10469,3 +10949,8 @@ class Extrema_POnSurfParams : public Extrema_POnSurf {
 };
 
 
+%extend Extrema_POnSurfParams {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/FEmTool.i
+++ b/src/SWIG_files/wrapper/FEmTool.i
@@ -156,6 +156,11 @@ class FEmTool_Assembly {
 };
 
 
+%extend FEmTool_Assembly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_AssemblyTable;
 class FEmTool_AssemblyTable {
 	public:
@@ -260,6 +265,11 @@ class FEmTool_AssemblyTable {
 };
 
 
+%extend FEmTool_AssemblyTable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_Curve;
 class FEmTool_Curve : public MMgt_TShared {
 	public:
@@ -424,6 +434,11 @@ class Handle_FEmTool_Curve : public Handle_MMgt_TShared {
     }
 };
 
+%extend FEmTool_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ElementaryCriterion;
 class FEmTool_ElementaryCriterion : public MMgt_TShared {
 	public:
@@ -528,6 +543,11 @@ class Handle_FEmTool_ElementaryCriterion : public Handle_MMgt_TShared {
     }
 };
 
+%extend FEmTool_ElementaryCriterion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ElementsOfRefMatrix;
 class FEmTool_ElementsOfRefMatrix : public math_FunctionSet {
 	public:
@@ -564,6 +584,11 @@ class FEmTool_ElementsOfRefMatrix : public math_FunctionSet {
 };
 
 
+%extend FEmTool_ElementsOfRefMatrix {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_HAssemblyTable;
 class FEmTool_HAssemblyTable : public MMgt_TShared {
 	public:
@@ -706,6 +731,11 @@ class Handle_FEmTool_HAssemblyTable : public Handle_MMgt_TShared {
     }
 };
 
+%extend FEmTool_HAssemblyTable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ListIteratorOfListOfVectors;
 class FEmTool_ListIteratorOfListOfVectors {
 	public:
@@ -740,6 +770,11 @@ class FEmTool_ListIteratorOfListOfVectors {
 };
 
 
+%extend FEmTool_ListIteratorOfListOfVectors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ListNodeOfListOfVectors;
 class FEmTool_ListNodeOfListOfVectors : public TCollection_MapNode {
 	public:
@@ -804,6 +839,11 @@ class Handle_FEmTool_ListNodeOfListOfVectors : public Handle_TCollection_MapNode
     }
 };
 
+%extend FEmTool_ListNodeOfListOfVectors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ListOfVectors;
 class FEmTool_ListOfVectors {
 	public:
@@ -934,6 +974,11 @@ class FEmTool_ListOfVectors {
 };
 
 
+%extend FEmTool_ListOfVectors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_SeqOfLinConstr;
 class FEmTool_SeqOfLinConstr : public TCollection_BaseSequence {
 	public:
@@ -1072,6 +1117,11 @@ class FEmTool_SeqOfLinConstr : public TCollection_BaseSequence {
 };
 
 
+%extend FEmTool_SeqOfLinConstr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_SequenceNodeOfSeqOfLinConstr;
 class FEmTool_SequenceNodeOfSeqOfLinConstr : public TCollection_SeqNode {
 	public:
@@ -1138,6 +1188,11 @@ class Handle_FEmTool_SequenceNodeOfSeqOfLinConstr : public Handle_TCollection_Se
     }
 };
 
+%extend FEmTool_SequenceNodeOfSeqOfLinConstr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_SparseMatrix;
 class FEmTool_SparseMatrix : public MMgt_TShared {
 	public:
@@ -1266,6 +1321,11 @@ class Handle_FEmTool_SparseMatrix : public Handle_MMgt_TShared {
     }
 };
 
+%extend FEmTool_SparseMatrix {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_LinearFlexion;
 class FEmTool_LinearFlexion : public FEmTool_ElementaryCriterion {
 	public:
@@ -1352,6 +1412,11 @@ class Handle_FEmTool_LinearFlexion : public Handle_FEmTool_ElementaryCriterion {
     }
 };
 
+%extend FEmTool_LinearFlexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_LinearJerk;
 class FEmTool_LinearJerk : public FEmTool_ElementaryCriterion {
 	public:
@@ -1438,6 +1503,11 @@ class Handle_FEmTool_LinearJerk : public Handle_FEmTool_ElementaryCriterion {
     }
 };
 
+%extend FEmTool_LinearJerk {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_LinearTension;
 class FEmTool_LinearTension : public FEmTool_ElementaryCriterion {
 	public:
@@ -1524,6 +1594,11 @@ class Handle_FEmTool_LinearTension : public Handle_FEmTool_ElementaryCriterion {
     }
 };
 
+%extend FEmTool_LinearTension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FEmTool_ProfileMatrix;
 class FEmTool_ProfileMatrix : public FEmTool_SparseMatrix {
 	public:
@@ -1674,3 +1749,8 @@ class Handle_FEmTool_ProfileMatrix : public Handle_FEmTool_SparseMatrix {
     }
 };
 
+%extend FEmTool_ProfileMatrix {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/FairCurve.i
+++ b/src/SWIG_files/wrapper/FairCurve.i
@@ -259,6 +259,11 @@ class FairCurve_Batten {
         };
 
 
+%extend FairCurve_Batten {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_BattenLaw;
 class FairCurve_BattenLaw : public math_Function {
 	public:
@@ -311,6 +316,11 @@ class FairCurve_BattenLaw : public math_Function {
 };
 
 
+%extend FairCurve_BattenLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_DistributionOfEnergy;
 class FairCurve_DistributionOfEnergy : public math_FunctionSet {
 	public:
@@ -335,6 +345,11 @@ class FairCurve_DistributionOfEnergy : public math_FunctionSet {
 };
 
 
+%extend FairCurve_DistributionOfEnergy {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_Energy;
 class FairCurve_Energy : public math_MultipleVarFunctionWithHessian {
 	public:
@@ -407,6 +422,11 @@ class FairCurve_Energy : public math_MultipleVarFunctionWithHessian {
 };
 
 
+%extend FairCurve_Energy {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_Newton;
 class FairCurve_Newton : public math_NewtonMinimum {
 	public:
@@ -457,6 +477,11 @@ class FairCurve_Newton : public math_NewtonMinimum {
 };
 
 
+%extend FairCurve_Newton {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_DistributionOfJerk;
 class FairCurve_DistributionOfJerk : public FairCurve_DistributionOfEnergy {
 	public:
@@ -489,6 +514,11 @@ class FairCurve_DistributionOfJerk : public FairCurve_DistributionOfEnergy {
 };
 
 
+%extend FairCurve_DistributionOfJerk {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_DistributionOfSagging;
 class FairCurve_DistributionOfSagging : public FairCurve_DistributionOfEnergy {
 	public:
@@ -521,6 +551,11 @@ class FairCurve_DistributionOfSagging : public FairCurve_DistributionOfEnergy {
 };
 
 
+%extend FairCurve_DistributionOfSagging {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_DistributionOfTension;
 class FairCurve_DistributionOfTension : public FairCurve_DistributionOfEnergy {
 	public:
@@ -565,6 +600,11 @@ class FairCurve_DistributionOfTension : public FairCurve_DistributionOfEnergy {
 };
 
 
+%extend FairCurve_DistributionOfTension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_EnergyOfBatten;
 class FairCurve_EnergyOfBatten : public FairCurve_Energy {
 	public:
@@ -617,6 +657,11 @@ class FairCurve_EnergyOfBatten : public FairCurve_Energy {
 };
 
 
+%extend FairCurve_EnergyOfBatten {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_EnergyOfMVC;
 class FairCurve_EnergyOfMVC : public FairCurve_Energy {
 	public:
@@ -675,6 +720,11 @@ class FairCurve_EnergyOfMVC : public FairCurve_Energy {
 };
 
 
+%extend FairCurve_EnergyOfMVC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FairCurve_MinimalVariation;
 class FairCurve_MinimalVariation : public FairCurve_Batten {
 	public:
@@ -759,3 +809,8 @@ class FairCurve_MinimalVariation : public FairCurve_Batten {
         };
 
 
+%extend FairCurve_MinimalVariation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/FilletSurf.i
+++ b/src/SWIG_files/wrapper/FilletSurf.i
@@ -245,6 +245,11 @@ class FilletSurf_Builder {
 };
 
 
+%extend FilletSurf_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor FilletSurf_InternalBuilder;
 class FilletSurf_InternalBuilder : public ChFi3d_FilBuilder {
 	public:
@@ -409,3 +414,8 @@ class FilletSurf_InternalBuilder : public ChFi3d_FilBuilder {
 };
 
 
+%extend FilletSurf_InternalBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GC.i
+++ b/src/SWIG_files/wrapper/GC.i
@@ -116,6 +116,11 @@ class GC_MakeMirror {
 };
 
 
+%extend GC_MakeMirror {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeRotation;
 class GC_MakeRotation {
 	public:
@@ -164,6 +169,11 @@ class GC_MakeRotation {
 };
 
 
+%extend GC_MakeRotation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeScale;
 class GC_MakeScale {
 	public:
@@ -190,6 +200,11 @@ class GC_MakeScale {
 };
 
 
+%extend GC_MakeScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeTranslation;
 class GC_MakeTranslation {
 	public:
@@ -224,6 +239,11 @@ class GC_MakeTranslation {
 };
 
 
+%extend GC_MakeTranslation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GC_Root {
 	public:
 		%feature("compactdefaultargs") IsDone;
@@ -241,6 +261,11 @@ class GC_Root {
 };
 
 
+%extend GC_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeArcOfCircle;
 class GC_MakeArcOfCircle : public GC_Root {
 	public:
@@ -323,6 +348,11 @@ class GC_MakeArcOfCircle : public GC_Root {
 };
 
 
+%extend GC_MakeArcOfCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeArcOfEllipse;
 class GC_MakeArcOfEllipse : public GC_Root {
 	public:
@@ -381,6 +411,11 @@ class GC_MakeArcOfEllipse : public GC_Root {
 };
 
 
+%extend GC_MakeArcOfEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeArcOfHyperbola;
 class GC_MakeArcOfHyperbola : public GC_Root {
 	public:
@@ -439,6 +474,11 @@ class GC_MakeArcOfHyperbola : public GC_Root {
 };
 
 
+%extend GC_MakeArcOfHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeArcOfParabola;
 class GC_MakeArcOfParabola : public GC_Root {
 	public:
@@ -497,6 +537,11 @@ class GC_MakeArcOfParabola : public GC_Root {
 };
 
 
+%extend GC_MakeArcOfParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeCircle;
 class GC_MakeCircle : public GC_Root {
 	public:
@@ -597,6 +642,11 @@ class GC_MakeCircle : public GC_Root {
 };
 
 
+%extend GC_MakeCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeConicalSurface;
 class GC_MakeConicalSurface : public GC_Root {
 	public:
@@ -705,6 +755,11 @@ class GC_MakeConicalSurface : public GC_Root {
 };
 
 
+%extend GC_MakeConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeCylindricalSurface;
 class GC_MakeCylindricalSurface : public GC_Root {
 	public:
@@ -789,6 +844,11 @@ class GC_MakeCylindricalSurface : public GC_Root {
 };
 
 
+%extend GC_MakeCylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeEllipse;
 class GC_MakeEllipse : public GC_Root {
 	public:
@@ -837,6 +897,11 @@ class GC_MakeEllipse : public GC_Root {
 };
 
 
+%extend GC_MakeEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeHyperbola;
 class GC_MakeHyperbola : public GC_Root {
 	public:
@@ -885,6 +950,11 @@ class GC_MakeHyperbola : public GC_Root {
 };
 
 
+%extend GC_MakeHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeLine;
 class GC_MakeLine : public GC_Root {
 	public:
@@ -947,6 +1017,11 @@ class GC_MakeLine : public GC_Root {
 };
 
 
+%extend GC_MakeLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakePlane;
 class GC_MakePlane : public GC_Root {
 	public:
@@ -1043,6 +1118,11 @@ class GC_MakePlane : public GC_Root {
 };
 
 
+%extend GC_MakePlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeSegment;
 class GC_MakeSegment : public GC_Root {
 	public:
@@ -1105,6 +1185,11 @@ class GC_MakeSegment : public GC_Root {
 };
 
 
+%extend GC_MakeSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeTrimmedCone;
 class GC_MakeTrimmedCone : public GC_Root {
 	public:
@@ -1149,6 +1234,11 @@ class GC_MakeTrimmedCone : public GC_Root {
 };
 
 
+%extend GC_MakeTrimmedCone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GC_MakeTrimmedCylinder;
 class GC_MakeTrimmedCylinder : public GC_Root {
 	public:
@@ -1223,3 +1313,8 @@ class GC_MakeTrimmedCylinder : public GC_Root {
 };
 
 
+%extend GC_MakeTrimmedCylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GCE2d.i
+++ b/src/SWIG_files/wrapper/GCE2d.i
@@ -100,6 +100,11 @@ class GCE2d_MakeMirror {
 };
 
 
+%extend GCE2d_MakeMirror {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeRotation;
 class GCE2d_MakeRotation {
 	public:
@@ -126,6 +131,11 @@ class GCE2d_MakeRotation {
 };
 
 
+%extend GCE2d_MakeRotation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeScale;
 class GCE2d_MakeScale {
 	public:
@@ -152,6 +162,11 @@ class GCE2d_MakeScale {
 };
 
 
+%extend GCE2d_MakeScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeTranslation;
 class GCE2d_MakeTranslation {
 	public:
@@ -186,6 +201,11 @@ class GCE2d_MakeTranslation {
 };
 
 
+%extend GCE2d_MakeTranslation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GCE2d_Root {
 	public:
 		%feature("compactdefaultargs") IsDone;
@@ -203,6 +223,11 @@ class GCE2d_Root {
 };
 
 
+%extend GCE2d_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeArcOfCircle;
 class GCE2d_MakeArcOfCircle : public GCE2d_Root {
 	public:
@@ -285,6 +310,11 @@ class GCE2d_MakeArcOfCircle : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeArcOfCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeArcOfEllipse;
 class GCE2d_MakeArcOfEllipse : public GCE2d_Root {
 	public:
@@ -343,6 +373,11 @@ class GCE2d_MakeArcOfEllipse : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeArcOfEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeArcOfHyperbola;
 class GCE2d_MakeArcOfHyperbola : public GCE2d_Root {
 	public:
@@ -401,6 +436,11 @@ class GCE2d_MakeArcOfHyperbola : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeArcOfHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeArcOfParabola;
 class GCE2d_MakeArcOfParabola : public GCE2d_Root {
 	public:
@@ -459,6 +499,11 @@ class GCE2d_MakeArcOfParabola : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeArcOfParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeCircle;
 class GCE2d_MakeCircle : public GCE2d_Root {
 	public:
@@ -561,6 +606,11 @@ class GCE2d_MakeCircle : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeEllipse;
 class GCE2d_MakeEllipse : public GCE2d_Root {
 	public:
@@ -623,6 +673,11 @@ class GCE2d_MakeEllipse : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeHyperbola;
 class GCE2d_MakeHyperbola : public GCE2d_Root {
 	public:
@@ -685,6 +740,11 @@ class GCE2d_MakeHyperbola : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeLine;
 class GCE2d_MakeLine : public GCE2d_Root {
 	public:
@@ -757,6 +817,11 @@ class GCE2d_MakeLine : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeParabola;
 class GCE2d_MakeParabola : public GCE2d_Root {
 	public:
@@ -835,6 +900,11 @@ class GCE2d_MakeParabola : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCE2d_MakeSegment;
 class GCE2d_MakeSegment : public GCE2d_Root {
 	public:
@@ -909,3 +979,8 @@ class GCE2d_MakeSegment : public GCE2d_Root {
 };
 
 
+%extend GCE2d_MakeSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GCPnts.i
+++ b/src/SWIG_files/wrapper/GCPnts.i
@@ -290,6 +290,11 @@ class GCPnts_AbscissaPoint {
 };
 
 
+%extend GCPnts_AbscissaPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCPnts_QuasiUniformAbscissa;
 class GCPnts_QuasiUniformAbscissa {
 	public:
@@ -418,6 +423,11 @@ class GCPnts_QuasiUniformAbscissa {
 };
 
 
+%extend GCPnts_QuasiUniformAbscissa {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCPnts_QuasiUniformDeflection;
 class GCPnts_QuasiUniformDeflection {
 	public:
@@ -576,6 +586,11 @@ class GCPnts_QuasiUniformDeflection {
 };
 
 
+%extend GCPnts_QuasiUniformDeflection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCPnts_TangentialDeflection;
 class GCPnts_TangentialDeflection {
 	public:
@@ -742,6 +757,11 @@ class GCPnts_TangentialDeflection {
 };
 
 
+%extend GCPnts_TangentialDeflection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCPnts_UniformAbscissa;
 class GCPnts_UniformAbscissa {
 	public:
@@ -1000,6 +1020,11 @@ class GCPnts_UniformAbscissa {
 };
 
 
+%extend GCPnts_UniformAbscissa {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GCPnts_UniformDeflection;
 class GCPnts_UniformDeflection {
 	public:
@@ -1158,3 +1183,8 @@ class GCPnts_UniformDeflection {
 };
 
 
+%extend GCPnts_UniformDeflection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GProp.i
+++ b/src/SWIG_files/wrapper/GProp.i
@@ -98,6 +98,11 @@ class GProp {
 };
 
 
+%extend GProp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_GProps;
 class GProp_GProps {
 	public:
@@ -180,6 +185,11 @@ class GProp_GProps {
 };
 
 
+%extend GProp_GProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_PEquation;
 class GProp_PEquation {
 	public:
@@ -252,6 +262,11 @@ class GProp_PEquation {
 };
 
 
+%extend GProp_PEquation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_PrincipalProps;
 class GProp_PrincipalProps {
 	public:
@@ -334,6 +349,11 @@ class GProp_PrincipalProps {
 };
 
 
+%extend GProp_PrincipalProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_CelGProps;
 class GProp_CelGProps : public GProp_GProps {
 	public:
@@ -402,6 +422,11 @@ class GProp_CelGProps : public GProp_GProps {
 };
 
 
+%extend GProp_CelGProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_PGProps;
 class GProp_PGProps : public GProp_GProps {
 	public:
@@ -512,6 +537,11 @@ class GProp_PGProps : public GProp_GProps {
 };
 
 
+%extend GProp_PGProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_SelGProps;
 class GProp_SelGProps : public GProp_GProps {
 	public:
@@ -648,6 +678,11 @@ class GProp_SelGProps : public GProp_GProps {
 };
 
 
+%extend GProp_SelGProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GProp_VelGProps;
 class GProp_VelGProps : public GProp_GProps {
 	public:
@@ -784,3 +819,8 @@ class GProp_VelGProps : public GProp_GProps {
 };
 
 
+%extend GProp_VelGProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GccAna.i
+++ b/src/SWIG_files/wrapper/GccAna.i
@@ -318,6 +318,11 @@ class GccAna_Circ2d2TanOn {
 };
 
 
+%extend GccAna_Circ2d2TanOn {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Circ2d2TanRad;
 class GccAna_Circ2d2TanRad {
 	public:
@@ -484,6 +489,11 @@ class GccAna_Circ2d2TanRad {
 };
 
 
+%extend GccAna_Circ2d2TanRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Circ2d3Tan;
 class GccAna_Circ2d3Tan {
 	public:
@@ -730,6 +740,11 @@ class GccAna_Circ2d3Tan {
 };
 
 
+%extend GccAna_Circ2d3Tan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Circ2dBisec;
 class GccAna_Circ2dBisec {
 	public:
@@ -766,6 +781,11 @@ class GccAna_Circ2dBisec {
 };
 
 
+%extend GccAna_Circ2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Circ2dTanCen;
 class GccAna_Circ2dTanCen {
 	public:
@@ -856,6 +876,11 @@ class GccAna_Circ2dTanCen {
 };
 
 
+%extend GccAna_Circ2dTanCen {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Circ2dTanOnRad;
 class GccAna_Circ2dTanOnRad {
 	public:
@@ -1010,6 +1035,11 @@ class GccAna_Circ2dTanOnRad {
 };
 
 
+%extend GccAna_Circ2dTanOnRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_CircLin2dBisec;
 class GccAna_CircLin2dBisec {
 	public:
@@ -1046,6 +1076,11 @@ class GccAna_CircLin2dBisec {
 };
 
 
+%extend GccAna_CircLin2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_CircPnt2dBisec;
 class GccAna_CircPnt2dBisec {
 	public:
@@ -1094,6 +1129,11 @@ class GccAna_CircPnt2dBisec {
 };
 
 
+%extend GccAna_CircPnt2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Lin2d2Tan;
 class GccAna_Lin2d2Tan {
 	public:
@@ -1196,6 +1236,11 @@ class GccAna_Lin2d2Tan {
 };
 
 
+%extend GccAna_Lin2d2Tan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Lin2dBisec;
 class GccAna_Lin2dBisec {
 	public:
@@ -1260,6 +1305,11 @@ class GccAna_Lin2dBisec {
 };
 
 
+%extend GccAna_Lin2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Lin2dTanObl;
 class GccAna_Lin2dTanObl {
 	public:
@@ -1348,6 +1398,11 @@ class GccAna_Lin2dTanObl {
 };
 
 
+%extend GccAna_Lin2dTanObl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Lin2dTanPar;
 class GccAna_Lin2dTanPar {
 	public:
@@ -1418,6 +1473,11 @@ class GccAna_Lin2dTanPar {
 };
 
 
+%extend GccAna_Lin2dTanPar {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Lin2dTanPer;
 class GccAna_Lin2dTanPer {
 	public:
@@ -1522,6 +1582,11 @@ class GccAna_Lin2dTanPer {
 };
 
 
+%extend GccAna_Lin2dTanPer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_LinPnt2dBisec;
 class GccAna_LinPnt2dBisec {
 	public:
@@ -1550,6 +1615,11 @@ class GccAna_LinPnt2dBisec {
 };
 
 
+%extend GccAna_LinPnt2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccAna_Pnt2dBisec;
 class GccAna_Pnt2dBisec {
 	public:
@@ -1584,3 +1654,8 @@ class GccAna_Pnt2dBisec {
 };
 
 
+%extend GccAna_Pnt2dBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GccEnt.i
+++ b/src/SWIG_files/wrapper/GccEnt.i
@@ -126,6 +126,11 @@ class GccEnt {
 };
 
 
+%extend GccEnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccEnt_Array1OfPosition;
 class GccEnt_Array1OfPosition {
 	public:
@@ -208,6 +213,11 @@ class GccEnt_Array1OfPosition {
 };
 
 
+%extend GccEnt_Array1OfPosition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccEnt_QualifiedCirc;
 class GccEnt_QualifiedCirc {
 	public:
@@ -278,6 +288,11 @@ class GccEnt_QualifiedCirc {
 };
 
 
+%extend GccEnt_QualifiedCirc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccEnt_QualifiedLin;
 class GccEnt_QualifiedLin {
 	public:
@@ -342,3 +357,8 @@ class GccEnt_QualifiedLin {
 };
 
 
+%extend GccEnt_QualifiedLin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GccInt.i
+++ b/src/SWIG_files/wrapper/GccInt.i
@@ -159,6 +159,11 @@ class Handle_GccInt_Bisec : public Handle_MMgt_TShared {
     }
 };
 
+%extend GccInt_Bisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BCirc;
 class GccInt_BCirc : public GccInt_Bisec {
 	public:
@@ -231,6 +236,11 @@ class Handle_GccInt_BCirc : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BCirc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BElips;
 class GccInt_BElips : public GccInt_Bisec {
 	public:
@@ -303,6 +313,11 @@ class Handle_GccInt_BElips : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BElips {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BHyper;
 class GccInt_BHyper : public GccInt_Bisec {
 	public:
@@ -375,6 +390,11 @@ class Handle_GccInt_BHyper : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BHyper {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BLine;
 class GccInt_BLine : public GccInt_Bisec {
 	public:
@@ -447,6 +467,11 @@ class Handle_GccInt_BLine : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BParab;
 class GccInt_BParab : public GccInt_Bisec {
 	public:
@@ -519,6 +544,11 @@ class Handle_GccInt_BParab : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BParab {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GccInt_BPoint;
 class GccInt_BPoint : public GccInt_Bisec {
 	public:
@@ -591,3 +621,8 @@ class Handle_GccInt_BPoint : public Handle_GccInt_Bisec {
     }
 };
 
+%extend GccInt_BPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom.i
+++ b/src/SWIG_files/wrapper/Geom.i
@@ -238,6 +238,11 @@ class Handle_Geom_Geometry : public Handle_MMgt_TShared {
     }
 };
 
+%extend Geom_Geometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_HSequenceOfBSplineSurface;
 class Geom_HSequenceOfBSplineSurface : public MMgt_TShared {
 	public:
@@ -422,6 +427,11 @@ class Handle_Geom_HSequenceOfBSplineSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend Geom_HSequenceOfBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_OsculatingSurface;
 class Geom_OsculatingSurface {
 	public:
@@ -486,6 +496,11 @@ class Geom_OsculatingSurface {
 };
 
 
+%extend Geom_OsculatingSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SequenceNodeOfSequenceOfBSplineSurface;
 class Geom_SequenceNodeOfSequenceOfBSplineSurface : public TCollection_SeqNode {
 	public:
@@ -552,6 +567,11 @@ class Handle_Geom_SequenceNodeOfSequenceOfBSplineSurface : public Handle_TCollec
     }
 };
 
+%extend Geom_SequenceNodeOfSequenceOfBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SequenceOfBSplineSurface;
 class Geom_SequenceOfBSplineSurface : public TCollection_BaseSequence {
 	public:
@@ -690,6 +710,11 @@ class Geom_SequenceOfBSplineSurface : public TCollection_BaseSequence {
 };
 
 
+%extend Geom_SequenceOfBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Transformation;
 class Geom_Transformation : public MMgt_TShared {
 	public:
@@ -948,6 +973,11 @@ class Handle_Geom_Transformation : public Handle_MMgt_TShared {
     }
 };
 
+%extend Geom_Transformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_AxisPlacement;
 class Geom_AxisPlacement : public Geom_Geometry {
 	public:
@@ -1050,6 +1080,11 @@ class Handle_Geom_AxisPlacement : public Handle_Geom_Geometry {
     }
 };
 
+%extend Geom_AxisPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Curve;
 class Geom_Curve : public Geom_Geometry {
 	public:
@@ -1254,6 +1289,11 @@ class Handle_Geom_Curve : public Handle_Geom_Geometry {
     }
 };
 
+%extend Geom_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Point;
 class Geom_Point : public Geom_Geometry {
 	public:
@@ -1358,6 +1398,11 @@ class Handle_Geom_Point : public Handle_Geom_Geometry {
     }
 };
 
+%extend Geom_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Surface;
 class Geom_Surface : public Geom_Geometry {
 	public:
@@ -1662,6 +1707,11 @@ class Handle_Geom_Surface : public Handle_Geom_Geometry {
     }
 };
 
+%extend Geom_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Vector;
 class Geom_Vector : public Geom_Geometry {
 	public:
@@ -1846,6 +1896,11 @@ class Handle_Geom_Vector : public Handle_Geom_Geometry {
     }
 };
 
+%extend Geom_Vector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Axis1Placement;
 class Geom_Axis1Placement : public Geom_AxisPlacement {
 	public:
@@ -1956,6 +2011,11 @@ class Handle_Geom_Axis1Placement : public Handle_Geom_AxisPlacement {
     }
 };
 
+%extend Geom_Axis1Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Axis2Placement;
 class Geom_Axis2Placement : public Geom_AxisPlacement {
 	public:
@@ -2092,6 +2152,11 @@ class Handle_Geom_Axis2Placement : public Handle_Geom_AxisPlacement {
     }
 };
 
+%extend Geom_Axis2Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BoundedCurve;
 class Geom_BoundedCurve : public Geom_Curve {
 	public:
@@ -2156,6 +2221,11 @@ class Handle_Geom_BoundedCurve : public Handle_Geom_Curve {
     }
 };
 
+%extend Geom_BoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BoundedSurface;
 class Geom_BoundedSurface : public Geom_Surface {
 	public:
@@ -2208,6 +2278,11 @@ class Handle_Geom_BoundedSurface : public Handle_Geom_Surface {
     }
 };
 
+%extend Geom_BoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_CartesianPoint;
 class Geom_CartesianPoint : public Geom_Point {
 	public:
@@ -2374,6 +2449,11 @@ class Handle_Geom_CartesianPoint : public Handle_Geom_Point {
     }
 };
 
+%extend Geom_CartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Conic;
 class Geom_Conic : public Geom_Curve {
 	public:
@@ -2514,6 +2594,11 @@ class Handle_Geom_Conic : public Handle_Geom_Curve {
     }
 };
 
+%extend Geom_Conic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Direction;
 class Geom_Direction : public Geom_Vector {
 	public:
@@ -2698,6 +2783,11 @@ class Handle_Geom_Direction : public Handle_Geom_Vector {
     }
 };
 
+%extend Geom_Direction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_ElementarySurface;
 class Geom_ElementarySurface : public Geom_Surface {
 	public:
@@ -2842,6 +2932,11 @@ class Handle_Geom_ElementarySurface : public Handle_Geom_Surface {
     }
 };
 
+%extend Geom_ElementarySurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Line;
 class Geom_Line : public Geom_Curve {
 	public:
@@ -3110,6 +3205,11 @@ class Handle_Geom_Line : public Handle_Geom_Curve {
     }
 };
 
+%extend Geom_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_OffsetCurve;
 class Geom_OffsetCurve : public Geom_Curve {
 	public:
@@ -3432,6 +3532,11 @@ class Handle_Geom_OffsetCurve : public Handle_Geom_Curve {
     }
 };
 
+%extend Geom_OffsetCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_OffsetSurface;
 class Geom_OffsetSurface : public Geom_Surface {
 	public:
@@ -3992,6 +4097,11 @@ class Handle_Geom_OffsetSurface : public Handle_Geom_Surface {
     }
 };
 
+%extend Geom_OffsetSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SweptSurface;
 class Geom_SweptSurface : public Geom_Surface {
 	public:
@@ -4062,6 +4172,11 @@ class Handle_Geom_SweptSurface : public Handle_Geom_Surface {
     }
 };
 
+%extend Geom_SweptSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_VectorWithMagnitude;
 class Geom_VectorWithMagnitude : public Geom_Vector {
 	public:
@@ -4326,6 +4441,11 @@ class Handle_Geom_VectorWithMagnitude : public Handle_Geom_Vector {
     }
 };
 
+%extend Geom_VectorWithMagnitude {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BSplineCurve;
 class Geom_BSplineCurve : public Geom_BoundedCurve {
 	public:
@@ -5034,6 +5154,11 @@ class Handle_Geom_BSplineCurve : public Handle_Geom_BoundedCurve {
     }
 };
 
+%extend Geom_BSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BSplineSurface;
 class Geom_BSplineSurface : public Geom_BoundedSurface {
 	public:
@@ -6200,6 +6325,11 @@ class Handle_Geom_BSplineSurface : public Handle_Geom_BoundedSurface {
     }
 };
 
+%extend Geom_BSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BezierCurve;
 class Geom_BezierCurve : public Geom_BoundedCurve {
 	public:
@@ -6572,6 +6702,11 @@ class Handle_Geom_BezierCurve : public Handle_Geom_BoundedCurve {
     }
 };
 
+%extend Geom_BezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_BezierSurface;
 class Geom_BezierSurface : public Geom_BoundedSurface {
 	public:
@@ -7174,6 +7309,11 @@ class Handle_Geom_BezierSurface : public Handle_Geom_BoundedSurface {
     }
 };
 
+%extend Geom_BezierSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Circle;
 class Geom_Circle : public Geom_Conic {
 	public:
@@ -7386,6 +7526,11 @@ class Handle_Geom_Circle : public Handle_Geom_Conic {
     }
 };
 
+%extend Geom_Circle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_ConicalSurface;
 class Geom_ConicalSurface : public Geom_ElementarySurface {
 	public:
@@ -7736,6 +7881,11 @@ class Handle_Geom_ConicalSurface : public Handle_Geom_ElementarySurface {
     }
 };
 
+%extend Geom_ConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_CylindricalSurface;
 class Geom_CylindricalSurface : public Geom_ElementarySurface {
 	public:
@@ -8058,6 +8208,11 @@ class Handle_Geom_CylindricalSurface : public Handle_Geom_ElementarySurface {
     }
 };
 
+%extend Geom_CylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Ellipse;
 class Geom_Ellipse : public Geom_Conic {
 	public:
@@ -8320,6 +8475,11 @@ class Handle_Geom_Ellipse : public Handle_Geom_Conic {
     }
 };
 
+%extend Geom_Ellipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Hyperbola;
 class Geom_Hyperbola : public Geom_Conic {
 	public:
@@ -8614,6 +8774,11 @@ class Handle_Geom_Hyperbola : public Handle_Geom_Conic {
     }
 };
 
+%extend Geom_Hyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Parabola;
 class Geom_Parabola : public Geom_Conic {
 	public:
@@ -8872,6 +9037,11 @@ class Handle_Geom_Parabola : public Handle_Geom_Conic {
     }
 };
 
+%extend Geom_Parabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_Plane;
 class Geom_Plane : public Geom_ElementarySurface {
 	public:
@@ -9202,6 +9372,11 @@ class Handle_Geom_Plane : public Handle_Geom_ElementarySurface {
     }
 };
 
+%extend Geom_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_RectangularTrimmedSurface;
 class Geom_RectangularTrimmedSurface : public Geom_BoundedSurface {
 	public:
@@ -9572,6 +9747,11 @@ class Handle_Geom_RectangularTrimmedSurface : public Handle_Geom_BoundedSurface 
     }
 };
 
+%extend Geom_RectangularTrimmedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SphericalSurface;
 class Geom_SphericalSurface : public Geom_ElementarySurface {
 	public:
@@ -9886,6 +10066,11 @@ class Handle_Geom_SphericalSurface : public Handle_Geom_ElementarySurface {
     }
 };
 
+%extend Geom_SphericalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SurfaceOfLinearExtrusion;
 class Geom_SurfaceOfLinearExtrusion : public Geom_SweptSurface {
 	public:
@@ -10286,6 +10471,11 @@ class Handle_Geom_SurfaceOfLinearExtrusion : public Handle_Geom_SweptSurface {
     }
 };
 
+%extend Geom_SurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_SurfaceOfRevolution;
 class Geom_SurfaceOfRevolution : public Geom_SweptSurface {
 	public:
@@ -10718,6 +10908,11 @@ class Handle_Geom_SurfaceOfRevolution : public Handle_Geom_SweptSurface {
     }
 };
 
+%extend Geom_SurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_ToroidalSurface;
 class Geom_ToroidalSurface : public Geom_ElementarySurface {
 	public:
@@ -11030,6 +11225,11 @@ class Handle_Geom_ToroidalSurface : public Handle_Geom_ElementarySurface {
     }
 };
 
+%extend Geom_ToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom_TrimmedCurve;
 class Geom_TrimmedCurve : public Geom_BoundedCurve {
 	public:
@@ -11278,3 +11478,8 @@ class Handle_Geom_TrimmedCurve : public Handle_Geom_BoundedCurve {
     }
 };
 
+%extend Geom_TrimmedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2d.i
+++ b/src/SWIG_files/wrapper/Geom2d.i
@@ -222,6 +222,11 @@ class Handle_Geom2d_Geometry : public Handle_MMgt_TShared {
     }
 };
 
+%extend Geom2d_Geometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Transformation;
 class Geom2d_Transformation : public MMgt_TShared {
 	public:
@@ -482,6 +487,11 @@ class Handle_Geom2d_Transformation : public Handle_MMgt_TShared {
     }
 };
 
+%extend Geom2d_Transformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_AxisPlacement;
 class Geom2d_AxisPlacement : public Geom2d_Geometry {
 	public:
@@ -626,6 +636,11 @@ class Handle_Geom2d_AxisPlacement : public Handle_Geom2d_Geometry {
     }
 };
 
+%extend Geom2d_AxisPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Curve;
 class Geom2d_Curve : public Geom2d_Geometry {
 	public:
@@ -830,6 +845,11 @@ class Handle_Geom2d_Curve : public Handle_Geom2d_Geometry {
     }
 };
 
+%extend Geom2d_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Point;
 class Geom2d_Point : public Geom2d_Geometry {
 	public:
@@ -926,6 +946,11 @@ class Handle_Geom2d_Point : public Handle_Geom2d_Geometry {
     }
 };
 
+%extend Geom2d_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Vector;
 class Geom2d_Vector : public Geom2d_Geometry {
 	public:
@@ -1054,6 +1079,11 @@ class Handle_Geom2d_Vector : public Handle_Geom2d_Geometry {
     }
 };
 
+%extend Geom2d_Vector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_BoundedCurve;
 class Geom2d_BoundedCurve : public Geom2d_Curve {
 	public:
@@ -1118,6 +1148,11 @@ class Handle_Geom2d_BoundedCurve : public Handle_Geom2d_Curve {
     }
 };
 
+%extend Geom2d_BoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_CartesianPoint;
 class Geom2d_CartesianPoint : public Geom2d_Point {
 	public:
@@ -1258,6 +1293,11 @@ class Handle_Geom2d_CartesianPoint : public Handle_Geom2d_Point {
     }
 };
 
+%extend Geom2d_CartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Conic;
 class Geom2d_Conic : public Geom2d_Curve {
 	public:
@@ -1398,6 +1438,11 @@ class Handle_Geom2d_Conic : public Handle_Geom2d_Curve {
     }
 };
 
+%extend Geom2d_Conic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Direction;
 class Geom2d_Direction : public Geom2d_Vector {
 	public:
@@ -1548,6 +1593,11 @@ class Handle_Geom2d_Direction : public Handle_Geom2d_Vector {
     }
 };
 
+%extend Geom2d_Direction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Line;
 class Geom2d_Line : public Geom2d_Curve {
 	public:
@@ -1834,6 +1884,11 @@ class Handle_Geom2d_Line : public Handle_Geom2d_Curve {
     }
 };
 
+%extend Geom2d_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_OffsetCurve;
 class Geom2d_OffsetCurve : public Geom2d_Curve {
 	public:
@@ -2128,6 +2183,11 @@ class Handle_Geom2d_OffsetCurve : public Handle_Geom2d_Curve {
     }
 };
 
+%extend Geom2d_OffsetCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_VectorWithMagnitude;
 class Geom2d_VectorWithMagnitude : public Geom2d_Vector {
 	public:
@@ -2398,6 +2458,11 @@ class Handle_Geom2d_VectorWithMagnitude : public Handle_Geom2d_Vector {
     }
 };
 
+%extend Geom2d_VectorWithMagnitude {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_BSplineCurve;
 class Geom2d_BSplineCurve : public Geom2d_BoundedCurve {
 	public:
@@ -3110,6 +3175,11 @@ class Handle_Geom2d_BSplineCurve : public Handle_Geom2d_BoundedCurve {
     }
 };
 
+%extend Geom2d_BSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_BezierCurve;
 class Geom2d_BezierCurve : public Geom2d_BoundedCurve {
 	public:
@@ -3460,6 +3530,11 @@ class Handle_Geom2d_BezierCurve : public Handle_Geom2d_BoundedCurve {
     }
 };
 
+%extend Geom2d_BezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Circle;
 class Geom2d_Circle : public Geom2d_Conic {
 	public:
@@ -3682,6 +3757,11 @@ class Handle_Geom2d_Circle : public Handle_Geom2d_Conic {
     }
 };
 
+%extend Geom2d_Circle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Ellipse;
 class Geom2d_Ellipse : public Geom2d_Conic {
 	public:
@@ -3958,6 +4038,11 @@ class Handle_Geom2d_Ellipse : public Handle_Geom2d_Conic {
     }
 };
 
+%extend Geom2d_Ellipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Hyperbola;
 class Geom2d_Hyperbola : public Geom2d_Conic {
 	public:
@@ -4266,6 +4351,11 @@ class Handle_Geom2d_Hyperbola : public Handle_Geom2d_Conic {
     }
 };
 
+%extend Geom2d_Hyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_Parabola;
 class Geom2d_Parabola : public Geom2d_Conic {
 	public:
@@ -4536,6 +4626,11 @@ class Handle_Geom2d_Parabola : public Handle_Geom2d_Conic {
     }
 };
 
+%extend Geom2d_Parabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2d_TrimmedCurve;
 class Geom2d_TrimmedCurve : public Geom2d_BoundedCurve {
 	public:
@@ -4784,3 +4879,8 @@ class Handle_Geom2d_TrimmedCurve : public Handle_Geom2d_BoundedCurve {
     }
 };
 
+%extend Geom2d_TrimmedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dAPI.i
+++ b/src/SWIG_files/wrapper/Geom2dAPI.i
@@ -156,6 +156,11 @@ class Geom2dAPI_ExtremaCurveCurve {
 };
 
 
+%extend Geom2dAPI_ExtremaCurveCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAPI_InterCurveCurve;
 class Geom2dAPI_InterCurveCurve {
 	public:
@@ -260,6 +265,11 @@ class Geom2dAPI_InterCurveCurve {
 };
 
 
+%extend Geom2dAPI_InterCurveCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAPI_Interpolate;
 class Geom2dAPI_Interpolate {
 	public:
@@ -330,6 +340,11 @@ class Geom2dAPI_Interpolate {
 };
 
 
+%extend Geom2dAPI_Interpolate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAPI_PointsToBSpline;
 class Geom2dAPI_PointsToBSpline {
 	public:
@@ -536,6 +551,11 @@ class Geom2dAPI_PointsToBSpline {
 };
 
 
+%extend Geom2dAPI_PointsToBSpline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAPI_ProjectPointOnCurve;
 class Geom2dAPI_ProjectPointOnCurve {
 	public:
@@ -672,3 +692,8 @@ class Geom2dAPI_ProjectPointOnCurve {
 };
 
 
+%extend Geom2dAPI_ProjectPointOnCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dAdaptor.i
+++ b/src/SWIG_files/wrapper/Geom2dAdaptor.i
@@ -70,6 +70,11 @@ class Geom2dAdaptor {
 };
 
 
+%extend Geom2dAdaptor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAdaptor_Curve;
 class Geom2dAdaptor_Curve : public Adaptor2d_Curve2d {
 	public:
@@ -304,6 +309,11 @@ class Geom2dAdaptor_Curve : public Adaptor2d_Curve2d {
 };
 
 
+%extend Geom2dAdaptor_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAdaptor_GHCurve;
 class Geom2dAdaptor_GHCurve : public Adaptor2d_HCurve2d {
 	public:
@@ -380,6 +390,11 @@ class Handle_Geom2dAdaptor_GHCurve : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend Geom2dAdaptor_GHCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dAdaptor_HCurve;
 class Geom2dAdaptor_HCurve : public Geom2dAdaptor_GHCurve {
 	public:
@@ -460,3 +475,8 @@ class Handle_Geom2dAdaptor_HCurve : public Handle_Geom2dAdaptor_GHCurve {
     }
 };
 
+%extend Geom2dAdaptor_HCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dConvert.i
+++ b/src/SWIG_files/wrapper/Geom2dConvert.i
@@ -192,6 +192,11 @@ class Geom2dConvert {
 };
 
 
+%extend Geom2dConvert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dConvert_ApproxCurve;
 class Geom2dConvert_ApproxCurve {
 	public:
@@ -246,6 +251,11 @@ class Geom2dConvert_ApproxCurve {
         };
 
 
+%extend Geom2dConvert_ApproxCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dConvert_BSplineCurveKnotSplitting;
 class Geom2dConvert_BSplineCurveKnotSplitting {
 	public:
@@ -284,6 +294,11 @@ class Geom2dConvert_BSplineCurveKnotSplitting {
 };
 
 
+%extend Geom2dConvert_BSplineCurveKnotSplitting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dConvert_BSplineCurveToBezierCurve;
 class Geom2dConvert_BSplineCurveToBezierCurve {
 	public:
@@ -342,6 +357,11 @@ class Geom2dConvert_BSplineCurveToBezierCurve {
 };
 
 
+%extend Geom2dConvert_BSplineCurveToBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dConvert_CompCurveToBSplineCurve;
 class Geom2dConvert_CompCurveToBSplineCurve {
 	public:
@@ -388,3 +408,8 @@ class Geom2dConvert_CompCurveToBSplineCurve {
 };
 
 
+%extend Geom2dConvert_CompCurveToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dGcc.i
+++ b/src/SWIG_files/wrapper/Geom2dGcc.i
@@ -123,6 +123,11 @@ class Geom2dGcc {
 };
 
 
+%extend Geom2dGcc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d2TanOn;
 class Geom2dGcc_Circ2d2TanOn {
 	public:
@@ -281,6 +286,11 @@ class Geom2dGcc_Circ2d2TanOn {
 };
 
 
+%extend Geom2dGcc_Circ2d2TanOn {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d2TanOnGeo;
 class Geom2dGcc_Circ2d2TanOnGeo {
 	public:
@@ -459,6 +469,11 @@ class Geom2dGcc_Circ2d2TanOnGeo {
 };
 
 
+%extend Geom2dGcc_Circ2d2TanOnGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d2TanOnIter;
 class Geom2dGcc_Circ2d2TanOnIter {
 	public:
@@ -765,6 +780,11 @@ class Geom2dGcc_Circ2d2TanOnIter {
 };
 
 
+%extend Geom2dGcc_Circ2d2TanOnIter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d2TanRad;
 class Geom2dGcc_Circ2d2TanRad {
 	public:
@@ -897,6 +917,11 @@ class Geom2dGcc_Circ2d2TanRad {
 };
 
 
+%extend Geom2dGcc_Circ2d2TanRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d2TanRadGeo;
 class Geom2dGcc_Circ2d2TanRadGeo {
 	public:
@@ -1035,6 +1060,11 @@ class Geom2dGcc_Circ2d2TanRadGeo {
 };
 
 
+%extend Geom2dGcc_Circ2d2TanRadGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d3Tan;
 class Geom2dGcc_Circ2d3Tan {
 	public:
@@ -1221,6 +1251,11 @@ class Geom2dGcc_Circ2d3Tan {
 };
 
 
+%extend Geom2dGcc_Circ2d3Tan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2d3TanIter;
 class Geom2dGcc_Circ2d3TanIter {
 	public:
@@ -1493,6 +1528,11 @@ class Geom2dGcc_Circ2d3TanIter {
 };
 
 
+%extend Geom2dGcc_Circ2d3TanIter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2dTanCen;
 class Geom2dGcc_Circ2dTanCen {
 	public:
@@ -1563,6 +1603,11 @@ class Geom2dGcc_Circ2dTanCen {
 };
 
 
+%extend Geom2dGcc_Circ2dTanCen {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2dTanCenGeo;
 class Geom2dGcc_Circ2dTanCenGeo {
 	public:
@@ -1623,6 +1668,11 @@ class Geom2dGcc_Circ2dTanCenGeo {
 };
 
 
+%extend Geom2dGcc_Circ2dTanCenGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2dTanOnRad;
 class Geom2dGcc_Circ2dTanOnRad {
 	public:
@@ -1733,6 +1783,11 @@ class Geom2dGcc_Circ2dTanOnRad {
 };
 
 
+%extend Geom2dGcc_Circ2dTanOnRad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Circ2dTanOnRadGeo;
 class Geom2dGcc_Circ2dTanOnRadGeo {
 	public:
@@ -1885,6 +1940,11 @@ class Geom2dGcc_Circ2dTanOnRadGeo {
 };
 
 
+%extend Geom2dGcc_Circ2dTanOnRadGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dGcc_CurveTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -1966,6 +2026,11 @@ class Geom2dGcc_CurveTool {
 };
 
 
+%extend Geom2dGcc_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dGcc_CurveToolGeo {
 	public:
 		%feature("compactdefaultargs") TheType;
@@ -2115,6 +2180,11 @@ class Geom2dGcc_CurveToolGeo {
 };
 
 
+%extend Geom2dGcc_CurveToolGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_FunctionTanCirCu;
 class Geom2dGcc_FunctionTanCirCu : public math_FunctionWithDerivative {
 	public:
@@ -2161,6 +2231,11 @@ class Geom2dGcc_FunctionTanCirCu : public math_FunctionWithDerivative {
 };
 
 
+%extend Geom2dGcc_FunctionTanCirCu {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_FunctionTanCuCu;
 class Geom2dGcc_FunctionTanCuCu : public math_FunctionSetWithDerivatives {
 	public:
@@ -2245,6 +2320,11 @@ class Geom2dGcc_FunctionTanCuCu : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Geom2dGcc_FunctionTanCuCu {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_FunctionTanCuCuOnCu;
 class Geom2dGcc_FunctionTanCuCuOnCu : public math_FunctionSetWithDerivatives {
 	public:
@@ -2463,6 +2543,11 @@ class Geom2dGcc_FunctionTanCuCuOnCu : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend Geom2dGcc_FunctionTanCuCuOnCu {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_FunctionTanCuPnt;
 class Geom2dGcc_FunctionTanCuPnt : public math_FunctionWithDerivative {
 	public:
@@ -2509,6 +2594,11 @@ class Geom2dGcc_FunctionTanCuPnt : public math_FunctionWithDerivative {
 };
 
 
+%extend Geom2dGcc_FunctionTanCuPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_FunctionTanObl;
 class Geom2dGcc_FunctionTanObl : public math_FunctionWithDerivative {
 	public:
@@ -2555,6 +2645,11 @@ class Geom2dGcc_FunctionTanObl : public math_FunctionWithDerivative {
 };
 
 
+%extend Geom2dGcc_FunctionTanObl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Lin2d2Tan;
 class Geom2dGcc_Lin2d2Tan {
 	public:
@@ -2675,6 +2770,11 @@ class Geom2dGcc_Lin2d2Tan {
 };
 
 
+%extend Geom2dGcc_Lin2d2Tan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Lin2d2TanIter;
 class Geom2dGcc_Lin2d2TanIter {
 	public:
@@ -2767,6 +2867,11 @@ class Geom2dGcc_Lin2d2TanIter {
 };
 
 
+%extend Geom2dGcc_Lin2d2TanIter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Lin2dTanObl;
 class Geom2dGcc_Lin2dTanObl {
 	public:
@@ -2861,6 +2966,11 @@ class Geom2dGcc_Lin2dTanObl {
 };
 
 
+%extend Geom2dGcc_Lin2dTanObl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_Lin2dTanOblIter;
 class Geom2dGcc_Lin2dTanOblIter {
 	public:
@@ -2923,6 +3033,11 @@ class Geom2dGcc_Lin2dTanOblIter {
 };
 
 
+%extend Geom2dGcc_Lin2dTanOblIter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_QCurve;
 class Geom2dGcc_QCurve {
 	public:
@@ -2969,6 +3084,11 @@ class Geom2dGcc_QCurve {
 };
 
 
+%extend Geom2dGcc_QCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dGcc_QualifiedCurve;
 class Geom2dGcc_QualifiedCurve {
 	public:
@@ -3021,3 +3141,8 @@ class Geom2dGcc_QualifiedCurve {
 };
 
 
+%extend Geom2dGcc_QualifiedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dHatch.i
+++ b/src/SWIG_files/wrapper/Geom2dHatch.i
@@ -110,6 +110,11 @@ class Geom2dHatch_Classifier {
 };
 
 
+%extend Geom2dHatch_Classifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_DataMapIteratorOfHatchings;
 class Geom2dHatch_DataMapIteratorOfHatchings : public TCollection_BasicMapIterator {
 	public:
@@ -140,6 +145,11 @@ class Geom2dHatch_DataMapIteratorOfHatchings : public TCollection_BasicMapIterat
 };
 
 
+%extend Geom2dHatch_DataMapIteratorOfHatchings {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_DataMapIteratorOfMapOfElements;
 class Geom2dHatch_DataMapIteratorOfMapOfElements : public TCollection_BasicMapIterator {
 	public:
@@ -170,6 +180,11 @@ class Geom2dHatch_DataMapIteratorOfMapOfElements : public TCollection_BasicMapIt
 };
 
 
+%extend Geom2dHatch_DataMapIteratorOfMapOfElements {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_DataMapNodeOfHatchings;
 class Geom2dHatch_DataMapNodeOfHatchings : public TCollection_MapNode {
 	public:
@@ -249,6 +264,11 @@ class Handle_Geom2dHatch_DataMapNodeOfHatchings : public Handle_TCollection_MapN
     }
 };
 
+%extend Geom2dHatch_DataMapNodeOfHatchings {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_DataMapNodeOfMapOfElements;
 class Geom2dHatch_DataMapNodeOfMapOfElements : public TCollection_MapNode {
 	public:
@@ -328,6 +348,11 @@ class Handle_Geom2dHatch_DataMapNodeOfMapOfElements : public Handle_TCollection_
     }
 };
 
+%extend Geom2dHatch_DataMapNodeOfMapOfElements {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Element;
 class Geom2dHatch_Element {
 	public:
@@ -382,6 +407,11 @@ class Geom2dHatch_Element {
 };
 
 
+%extend Geom2dHatch_Element {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Elements;
 class Geom2dHatch_Elements {
 	public:
@@ -508,6 +538,11 @@ class Geom2dHatch_Elements {
 };
 
 
+%extend Geom2dHatch_Elements {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_FClass2dOfClassifier;
 class Geom2dHatch_FClass2dOfClassifier {
 	public:
@@ -556,6 +591,11 @@ class Geom2dHatch_FClass2dOfClassifier {
 };
 
 
+%extend Geom2dHatch_FClass2dOfClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Hatcher;
 class Geom2dHatch_Hatcher {
 	public:
@@ -824,6 +864,11 @@ class Geom2dHatch_Hatcher {
 };
 
 
+%extend Geom2dHatch_Hatcher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Hatching;
 class Geom2dHatch_Hatching {
 	public:
@@ -998,6 +1043,11 @@ class Geom2dHatch_Hatching {
 };
 
 
+%extend Geom2dHatch_Hatching {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Hatchings;
 class Geom2dHatch_Hatchings : public TCollection_BasicMap {
 	public:
@@ -1076,6 +1126,11 @@ class Geom2dHatch_Hatchings : public TCollection_BasicMap {
 };
 
 
+%extend Geom2dHatch_Hatchings {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_Intersector;
 class Geom2dHatch_Intersector : public Geom2dInt_GInter {
 	public:
@@ -1164,6 +1219,11 @@ class Geom2dHatch_Intersector : public Geom2dInt_GInter {
 };
 
 
+%extend Geom2dHatch_Intersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dHatch_MapOfElements;
 class Geom2dHatch_MapOfElements : public TCollection_BasicMap {
 	public:
@@ -1242,3 +1302,8 @@ class Geom2dHatch_MapOfElements : public TCollection_BasicMap {
 };
 
 
+%extend Geom2dHatch_MapOfElements {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dInt.i
+++ b/src/SWIG_files/wrapper/Geom2dInt.i
@@ -120,6 +120,11 @@ class Geom2dInt_ExactIntersectionPointOfTheIntPCurvePCurveOfGInter {
 };
 
 
+%extend Geom2dInt_ExactIntersectionPointOfTheIntPCurvePCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_GInter;
 class Geom2dInt_GInter : public IntRes2d_Intersection {
 	public:
@@ -294,6 +299,11 @@ class Geom2dInt_GInter : public IntRes2d_Intersection {
 };
 
 
+%extend Geom2dInt_GInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dInt_Geom2dCurveTool {
 	public:
 		%feature("compactdefaultargs") GetType;
@@ -497,6 +507,11 @@ class Geom2dInt_Geom2dCurveTool {
 };
 
 
+%extend Geom2dInt_Geom2dCurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_IntConicCurveOfGInter;
 class Geom2dInt_IntConicCurveOfGInter : public IntRes2d_Intersection {
 	public:
@@ -667,6 +682,11 @@ class Geom2dInt_IntConicCurveOfGInter : public IntRes2d_Intersection {
 };
 
 
+%extend Geom2dInt_IntConicCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfGInter;
 class Geom2dInt_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfGInter : public math_FunctionWithDerivative {
 	public:
@@ -707,6 +727,11 @@ class Geom2dInt_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfGInter : public 
 };
 
 
+%extend Geom2dInt_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_PCLocFOfTheLocateExtPCOfTheProjPCurOfGInter;
 class Geom2dInt_PCLocFOfTheLocateExtPCOfTheProjPCurOfGInter : public math_FunctionWithDerivative {
 	public:
@@ -801,6 +826,11 @@ class Geom2dInt_PCLocFOfTheLocateExtPCOfTheProjPCurOfGInter : public math_Functi
 };
 
 
+%extend Geom2dInt_PCLocFOfTheLocateExtPCOfTheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter;
 class Geom2dInt_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter : public TCollection_BaseSequence {
 	public:
@@ -939,6 +969,11 @@ class Geom2dInt_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter : public TCol
 };
 
 
+%extend Geom2dInt_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter;
 class Geom2dInt_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter : public TCollection_SeqNode {
 	public:
@@ -1005,11 +1040,21 @@ class Handle_Geom2dInt_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurO
     }
 };
 
+%extend Geom2dInt_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dInt_TheCurveLocatorOfTheProjPCurOfGInter {
 	public:
 };
 
 
+%extend Geom2dInt_TheCurveLocatorOfTheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfGInter;
 class Geom2dInt_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfGInter : public math_FunctionSetWithDerivatives {
 	public:
@@ -1058,6 +1103,11 @@ class Geom2dInt_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfGInter : public math_
 };
 
 
+%extend Geom2dInt_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_TheIntConicCurveOfGInter;
 class Geom2dInt_TheIntConicCurveOfGInter : public IntRes2d_Intersection {
 	public:
@@ -1228,6 +1278,11 @@ class Geom2dInt_TheIntConicCurveOfGInter : public IntRes2d_Intersection {
 };
 
 
+%extend Geom2dInt_TheIntConicCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_TheIntPCurvePCurveOfGInter;
 class Geom2dInt_TheIntPCurvePCurveOfGInter : public IntRes2d_Intersection {
 	public:
@@ -1266,6 +1321,11 @@ class Geom2dInt_TheIntPCurvePCurveOfGInter : public IntRes2d_Intersection {
 };
 
 
+%extend Geom2dInt_TheIntPCurvePCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_TheIntersectorOfTheIntConicCurveOfGInter;
 class Geom2dInt_TheIntersectorOfTheIntConicCurveOfGInter : public IntRes2d_Intersection {
 	public:
@@ -1364,6 +1424,11 @@ class Geom2dInt_TheIntersectorOfTheIntConicCurveOfGInter : public IntRes2d_Inter
 };
 
 
+%extend Geom2dInt_TheIntersectorOfTheIntConicCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_TheLocateExtPCOfTheProjPCurOfGInter;
 class Geom2dInt_TheLocateExtPCOfTheProjPCurOfGInter {
 	public:
@@ -1438,6 +1503,11 @@ class Geom2dInt_TheLocateExtPCOfTheProjPCurOfGInter {
 };
 
 
+%extend Geom2dInt_TheLocateExtPCOfTheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dInt_ThePolygon2dOfTheIntPCurvePCurveOfGInter;
 class Geom2dInt_ThePolygon2dOfTheIntPCurvePCurveOfGInter : public Intf_Polygon2d {
 	public:
@@ -1548,6 +1618,11 @@ class Geom2dInt_ThePolygon2dOfTheIntPCurvePCurveOfGInter : public Intf_Polygon2d
 };
 
 
+%extend Geom2dInt_ThePolygon2dOfTheIntPCurvePCurveOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dInt_TheProjPCurOfGInter {
 	public:
 		%feature("compactdefaultargs") FindParameter;
@@ -1577,3 +1652,8 @@ class Geom2dInt_TheProjPCurOfGInter {
 };
 
 
+%extend Geom2dInt_TheProjPCurOfGInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Geom2dLProp.i
+++ b/src/SWIG_files/wrapper/Geom2dLProp.i
@@ -146,6 +146,11 @@ class Geom2dLProp_CLProps2d {
 };
 
 
+%extend Geom2dLProp_CLProps2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dLProp_CurAndInf2d;
 class Geom2dLProp_CurAndInf2d : public LProp_CurAndInf {
 	public:
@@ -188,6 +193,11 @@ class Geom2dLProp_CurAndInf2d : public LProp_CurAndInf {
 };
 
 
+%extend Geom2dLProp_CurAndInf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Geom2dLProp_Curve2dTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -277,6 +287,11 @@ class Geom2dLProp_Curve2dTool {
 };
 
 
+%extend Geom2dLProp_Curve2dTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dLProp_FuncCurExt;
 class Geom2dLProp_FuncCurExt : public math_FunctionWithDerivative {
 	public:
@@ -331,6 +346,11 @@ class Geom2dLProp_FuncCurExt : public math_FunctionWithDerivative {
 };
 
 
+%extend Geom2dLProp_FuncCurExt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dLProp_FuncCurNul;
 class Geom2dLProp_FuncCurNul : public math_FunctionWithDerivative {
 	public:
@@ -375,6 +395,11 @@ class Geom2dLProp_FuncCurNul : public math_FunctionWithDerivative {
 };
 
 
+%extend Geom2dLProp_FuncCurNul {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Geom2dLProp_NumericCurInf2d;
 class Geom2dLProp_NumericCurInf2d {
 	public:
@@ -439,3 +464,8 @@ class Geom2dLProp_NumericCurInf2d {
 };
 
 
+%extend Geom2dLProp_NumericCurInf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomAPI.i
+++ b/src/SWIG_files/wrapper/GeomAPI.i
@@ -82,6 +82,11 @@ class GeomAPI {
 };
 
 
+%extend GeomAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_ExtremaCurveCurve;
 class GeomAPI_ExtremaCurveCurve {
 	public:
@@ -254,6 +259,11 @@ class GeomAPI_ExtremaCurveCurve {
 };
 
 
+%extend GeomAPI_ExtremaCurveCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_ExtremaCurveSurface;
 class GeomAPI_ExtremaCurveSurface {
 	public:
@@ -412,6 +422,11 @@ class GeomAPI_ExtremaCurveSurface {
 };
 
 
+%extend GeomAPI_ExtremaCurveSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_ExtremaSurfaceSurface;
 class GeomAPI_ExtremaSurfaceSurface {
 	public:
@@ -582,6 +597,11 @@ class GeomAPI_ExtremaSurfaceSurface {
 };
 
 
+%extend GeomAPI_ExtremaSurfaceSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_IntCS;
 class GeomAPI_IntCS {
 	public:
@@ -678,6 +698,11 @@ class GeomAPI_IntCS {
 };
 
 
+%extend GeomAPI_IntCS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_IntSS;
 class GeomAPI_IntSS {
 	public:
@@ -734,6 +759,11 @@ class GeomAPI_IntSS {
 };
 
 
+%extend GeomAPI_IntSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_Interpolate;
 class GeomAPI_Interpolate {
 	public:
@@ -808,6 +838,11 @@ class GeomAPI_Interpolate {
 };
 
 
+%extend GeomAPI_Interpolate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_PointsToBSpline;
 class GeomAPI_PointsToBSpline {
 	public:
@@ -974,6 +1009,11 @@ class GeomAPI_PointsToBSpline {
 };
 
 
+%extend GeomAPI_PointsToBSpline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_PointsToBSplineSurface;
 class GeomAPI_PointsToBSplineSurface {
 	public:
@@ -1186,6 +1226,11 @@ class GeomAPI_PointsToBSplineSurface {
 };
 
 
+%extend GeomAPI_PointsToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_ProjectPointOnCurve;
 class GeomAPI_ProjectPointOnCurve {
 	public:
@@ -1342,6 +1387,11 @@ class GeomAPI_ProjectPointOnCurve {
 };
 
 
+%extend GeomAPI_ProjectPointOnCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAPI_ProjectPointOnSurf;
 class GeomAPI_ProjectPointOnSurf {
 	public:
@@ -1604,3 +1654,8 @@ class GeomAPI_ProjectPointOnSurf {
 };
 
 
+%extend GeomAPI_ProjectPointOnSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomAdaptor.i
+++ b/src/SWIG_files/wrapper/GeomAdaptor.i
@@ -78,6 +78,11 @@ class GeomAdaptor {
 };
 
 
+%extend GeomAdaptor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_Curve;
 class GeomAdaptor_Curve : public Adaptor3d_Curve {
 	public:
@@ -322,6 +327,11 @@ class GeomAdaptor_Curve : public Adaptor3d_Curve {
 };
 
 
+%extend GeomAdaptor_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_GHCurve;
 class GeomAdaptor_GHCurve : public Adaptor3d_HCurve {
 	public:
@@ -402,6 +412,11 @@ class Handle_GeomAdaptor_GHCurve : public Handle_Adaptor3d_HCurve {
     }
 };
 
+%extend GeomAdaptor_GHCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_GHSurface;
 class GeomAdaptor_GHSurface : public Adaptor3d_HSurface {
 	public:
@@ -478,6 +493,11 @@ class Handle_GeomAdaptor_GHSurface : public Handle_Adaptor3d_HSurface {
     }
 };
 
+%extend GeomAdaptor_GHSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_Surface;
 class GeomAdaptor_Surface : public Adaptor3d_Surface {
 	public:
@@ -862,6 +882,11 @@ class GeomAdaptor_Surface : public Adaptor3d_Surface {
 };
 
 
+%extend GeomAdaptor_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_HCurve;
 class GeomAdaptor_HCurve : public GeomAdaptor_GHCurve {
 	public:
@@ -942,6 +967,11 @@ class Handle_GeomAdaptor_HCurve : public Handle_GeomAdaptor_GHCurve {
     }
 };
 
+%extend GeomAdaptor_HCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomAdaptor_HSurface;
 class GeomAdaptor_HSurface : public GeomAdaptor_GHSurface {
 	public:
@@ -1030,3 +1060,8 @@ class Handle_GeomAdaptor_HSurface : public Handle_GeomAdaptor_GHSurface {
     }
 };
 
+%extend GeomAdaptor_HSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomConvert.i
+++ b/src/SWIG_files/wrapper/GeomConvert.i
@@ -278,6 +278,11 @@ class GeomConvert {
 };
 
 
+%extend GeomConvert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_ApproxCurve;
 class GeomConvert_ApproxCurve {
 	public:
@@ -332,6 +337,11 @@ class GeomConvert_ApproxCurve {
         };
 
 
+%extend GeomConvert_ApproxCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_ApproxSurface;
 class GeomConvert_ApproxSurface {
 	public:
@@ -392,6 +402,11 @@ class GeomConvert_ApproxSurface {
         };
 
 
+%extend GeomConvert_ApproxSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_BSplineCurveKnotSplitting;
 class GeomConvert_BSplineCurveKnotSplitting {
 	public:
@@ -430,6 +445,11 @@ class GeomConvert_BSplineCurveKnotSplitting {
 };
 
 
+%extend GeomConvert_BSplineCurveKnotSplitting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_BSplineCurveToBezierCurve;
 class GeomConvert_BSplineCurveToBezierCurve {
 	public:
@@ -488,6 +508,11 @@ class GeomConvert_BSplineCurveToBezierCurve {
 };
 
 
+%extend GeomConvert_BSplineCurveToBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_BSplineSurfaceKnotSplitting;
 class GeomConvert_BSplineSurfaceKnotSplitting {
 	public:
@@ -544,6 +569,11 @@ class GeomConvert_BSplineSurfaceKnotSplitting {
 };
 
 
+%extend GeomConvert_BSplineSurfaceKnotSplitting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_BSplineSurfaceToBezierSurface;
 class GeomConvert_BSplineSurfaceToBezierSurface {
 	public:
@@ -622,6 +652,11 @@ class GeomConvert_BSplineSurfaceToBezierSurface {
 };
 
 
+%extend GeomConvert_BSplineSurfaceToBezierSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_CompBezierSurfacesToBSplineSurface;
 class GeomConvert_CompBezierSurfacesToBSplineSurface {
 	public:
@@ -738,6 +773,11 @@ class GeomConvert_CompBezierSurfacesToBSplineSurface {
 };
 
 
+%extend GeomConvert_CompBezierSurfacesToBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomConvert_CompCurveToBSplineCurve;
 class GeomConvert_CompCurveToBSplineCurve {
 	public:
@@ -782,3 +822,8 @@ class GeomConvert_CompCurveToBSplineCurve {
 };
 
 
+%extend GeomConvert_CompCurveToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomFill.i
+++ b/src/SWIG_files/wrapper/GeomFill.i
@@ -287,6 +287,11 @@ class GeomFill {
 };
 
 
+%extend GeomFill {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_AppSurf;
 class GeomFill_AppSurf : public AppBlend_Approx {
 	public:
@@ -523,6 +528,11 @@ class GeomFill_AppSurf : public AppBlend_Approx {
 };
 
 
+%extend GeomFill_AppSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_AppSweep;
 class GeomFill_AppSweep : public AppBlend_Approx {
 	public:
@@ -759,6 +769,11 @@ class GeomFill_AppSweep : public AppBlend_Approx {
 };
 
 
+%extend GeomFill_AppSweep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Array1OfLocationLaw;
 class GeomFill_Array1OfLocationLaw {
 	public:
@@ -841,6 +856,11 @@ class GeomFill_Array1OfLocationLaw {
 };
 
 
+%extend GeomFill_Array1OfLocationLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Array1OfSectionLaw;
 class GeomFill_Array1OfSectionLaw {
 	public:
@@ -923,6 +943,11 @@ class GeomFill_Array1OfSectionLaw {
 };
 
 
+%extend GeomFill_Array1OfSectionLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_BSplineCurves;
 class GeomFill_BSplineCurves {
 	public:
@@ -1021,6 +1046,11 @@ class GeomFill_BSplineCurves {
 };
 
 
+%extend GeomFill_BSplineCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_BezierCurves;
 class GeomFill_BezierCurves {
 	public:
@@ -1123,6 +1153,11 @@ class GeomFill_BezierCurves {
 };
 
 
+%extend GeomFill_BezierCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Boundary;
 class GeomFill_Boundary : public MMgt_TShared {
 	public:
@@ -1269,6 +1304,11 @@ class Handle_GeomFill_Boundary : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_Boundary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_CircularBlendFunc;
 class GeomFill_CircularBlendFunc : public Approx_SweepFunction {
 	public:
@@ -1521,6 +1561,11 @@ class Handle_GeomFill_CircularBlendFunc : public Handle_Approx_SweepFunction {
     }
 };
 
+%extend GeomFill_CircularBlendFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_ConstrainedFilling;
 class GeomFill_ConstrainedFilling {
 	public:
@@ -1639,6 +1684,11 @@ class GeomFill_ConstrainedFilling {
 };
 
 
+%extend GeomFill_ConstrainedFilling {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_CoonsAlgPatch;
 class GeomFill_CoonsAlgPatch : public MMgt_TShared {
 	public:
@@ -1783,6 +1833,11 @@ class Handle_GeomFill_CoonsAlgPatch : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_CoonsAlgPatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_CornerState;
 class GeomFill_CornerState {
 	public:
@@ -1843,6 +1898,11 @@ class GeomFill_CornerState {
 };
 
 
+%extend GeomFill_CornerState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Filling;
 class GeomFill_Filling {
 	public:
@@ -1877,6 +1937,11 @@ class GeomFill_Filling {
 };
 
 
+%extend GeomFill_Filling {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_FunctionDraft;
 class GeomFill_FunctionDraft : public math_FunctionSetWithDerivatives {
 	public:
@@ -1993,6 +2058,11 @@ class GeomFill_FunctionDraft : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend GeomFill_FunctionDraft {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_FunctionGuide;
 class GeomFill_FunctionGuide : public math_FunctionSetWithDerivatives {
 	public:
@@ -2079,6 +2149,11 @@ class GeomFill_FunctionGuide : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend GeomFill_FunctionGuide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_HArray1OfLocationLaw;
 class GeomFill_HArray1OfLocationLaw : public MMgt_TShared {
 	public:
@@ -2195,6 +2270,11 @@ class Handle_GeomFill_HArray1OfLocationLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_HArray1OfLocationLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_HArray1OfSectionLaw;
 class GeomFill_HArray1OfSectionLaw : public MMgt_TShared {
 	public:
@@ -2311,6 +2391,11 @@ class Handle_GeomFill_HArray1OfSectionLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_HArray1OfSectionLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_HSequenceOfAx2;
 class GeomFill_HSequenceOfAx2 : public MMgt_TShared {
 	public:
@@ -2495,6 +2580,11 @@ class Handle_GeomFill_HSequenceOfAx2 : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_HSequenceOfAx2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Line;
 class GeomFill_Line : public MMgt_TShared {
 	public:
@@ -2567,6 +2657,11 @@ class Handle_GeomFill_Line : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_LocFunction;
 class GeomFill_LocFunction {
 	public:
@@ -2631,6 +2726,11 @@ class GeomFill_LocFunction {
 };
 
 
+%extend GeomFill_LocFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_LocationLaw;
 class GeomFill_LocationLaw : public MMgt_TShared {
 	public:
@@ -2917,6 +3017,11 @@ class Handle_GeomFill_LocationLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_LocationLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Pipe;
 class GeomFill_Pipe {
 	public:
@@ -3183,6 +3288,11 @@ class GeomFill_Pipe {
 };
 
 
+%extend GeomFill_Pipe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_PlanFunc;
 class GeomFill_PlanFunc : public math_FunctionWithDerivative {
 	public:
@@ -3275,6 +3385,11 @@ class GeomFill_PlanFunc : public math_FunctionWithDerivative {
 };
 
 
+%extend GeomFill_PlanFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_PolynomialConvertor;
 class GeomFill_PolynomialConvertor {
 	public:
@@ -3367,6 +3482,11 @@ class GeomFill_PolynomialConvertor {
 };
 
 
+%extend GeomFill_PolynomialConvertor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Profiler;
 class GeomFill_Profiler {
 	public:
@@ -3453,6 +3573,11 @@ class GeomFill_Profiler {
 };
 
 
+%extend GeomFill_Profiler {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_QuasiAngularConvertor;
 class GeomFill_QuasiAngularConvertor {
 	public:
@@ -3557,6 +3682,11 @@ class GeomFill_QuasiAngularConvertor {
 };
 
 
+%extend GeomFill_QuasiAngularConvertor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SectionLaw;
 class GeomFill_SectionLaw : public MMgt_TShared {
 	public:
@@ -3831,6 +3961,11 @@ class Handle_GeomFill_SectionLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_SectionLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SectionPlacement;
 class GeomFill_SectionPlacement {
 	public:
@@ -3919,6 +4054,11 @@ class GeomFill_SectionPlacement {
 };
 
 
+%extend GeomFill_SectionPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SequenceNodeOfSequenceOfAx2;
 class GeomFill_SequenceNodeOfSequenceOfAx2 : public TCollection_SeqNode {
 	public:
@@ -3985,6 +4125,11 @@ class Handle_GeomFill_SequenceNodeOfSequenceOfAx2 : public Handle_TCollection_Se
     }
 };
 
+%extend GeomFill_SequenceNodeOfSequenceOfAx2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SequenceNodeOfSequenceOfTrsf;
 class GeomFill_SequenceNodeOfSequenceOfTrsf : public TCollection_SeqNode {
 	public:
@@ -4051,6 +4196,11 @@ class Handle_GeomFill_SequenceNodeOfSequenceOfTrsf : public Handle_TCollection_S
     }
 };
 
+%extend GeomFill_SequenceNodeOfSequenceOfTrsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SequenceOfAx2;
 class GeomFill_SequenceOfAx2 : public TCollection_BaseSequence {
 	public:
@@ -4189,6 +4339,11 @@ class GeomFill_SequenceOfAx2 : public TCollection_BaseSequence {
 };
 
 
+%extend GeomFill_SequenceOfAx2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SequenceOfTrsf;
 class GeomFill_SequenceOfTrsf : public TCollection_BaseSequence {
 	public:
@@ -4327,6 +4482,11 @@ class GeomFill_SequenceOfTrsf : public TCollection_BaseSequence {
 };
 
 
+%extend GeomFill_SequenceOfTrsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SnglrFunc;
 class GeomFill_SnglrFunc : public Adaptor3d_Curve {
 	public:
@@ -4463,6 +4623,11 @@ class GeomFill_SnglrFunc : public Adaptor3d_Curve {
 };
 
 
+%extend GeomFill_SnglrFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Sweep;
 class GeomFill_Sweep {
 	public:
@@ -4603,6 +4768,11 @@ class GeomFill_Sweep {
 };
 
 
+%extend GeomFill_Sweep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SweepFunction;
 class GeomFill_SweepFunction : public Approx_SweepFunction {
 	public:
@@ -4867,6 +5037,11 @@ class Handle_GeomFill_SweepFunction : public Handle_Approx_SweepFunction {
     }
 };
 
+%extend GeomFill_SweepFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Tensor;
 class GeomFill_Tensor {
 	public:
@@ -4923,6 +5098,11 @@ class GeomFill_Tensor {
 };
 
 
+%extend GeomFill_Tensor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_TgtField;
 class GeomFill_TgtField : public MMgt_TShared {
 	public:
@@ -5013,6 +5193,11 @@ class Handle_GeomFill_TgtField : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_TgtField {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_TrihedronLaw;
 class GeomFill_TrihedronLaw : public MMgt_TShared {
 	public:
@@ -5203,6 +5388,11 @@ class Handle_GeomFill_TrihedronLaw : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomFill_TrihedronLaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_BoundWithSurf;
 class GeomFill_BoundWithSurf : public GeomFill_Boundary {
 	public:
@@ -5333,6 +5523,11 @@ class Handle_GeomFill_BoundWithSurf : public Handle_GeomFill_Boundary {
     }
 };
 
+%extend GeomFill_BoundWithSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_ConstantBiNormal;
 class GeomFill_ConstantBiNormal : public GeomFill_TrihedronLaw {
 	public:
@@ -5503,6 +5698,11 @@ class Handle_GeomFill_ConstantBiNormal : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_ConstantBiNormal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Coons;
 class GeomFill_Coons : public GeomFill_Filling {
 	public:
@@ -5577,6 +5777,11 @@ class GeomFill_Coons : public GeomFill_Filling {
 };
 
 
+%extend GeomFill_Coons {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_CorrectedFrenet;
 class GeomFill_CorrectedFrenet : public GeomFill_TrihedronLaw {
 	public:
@@ -5765,6 +5970,11 @@ class Handle_GeomFill_CorrectedFrenet : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_CorrectedFrenet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_CurveAndTrihedron;
 class GeomFill_CurveAndTrihedron : public GeomFill_LocationLaw {
 	public:
@@ -6003,6 +6213,11 @@ class Handle_GeomFill_CurveAndTrihedron : public Handle_GeomFill_LocationLaw {
     }
 };
 
+%extend GeomFill_CurveAndTrihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Curved;
 class GeomFill_Curved : public GeomFill_Filling {
 	public:
@@ -6169,6 +6384,11 @@ class GeomFill_Curved : public GeomFill_Filling {
 };
 
 
+%extend GeomFill_Curved {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Darboux;
 class GeomFill_Darboux : public GeomFill_TrihedronLaw {
 	public:
@@ -6331,6 +6551,11 @@ class Handle_GeomFill_Darboux : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_Darboux {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_DegeneratedBound;
 class GeomFill_DegeneratedBound : public GeomFill_Boundary {
 	public:
@@ -6443,6 +6668,11 @@ class Handle_GeomFill_DegeneratedBound : public Handle_GeomFill_Boundary {
     }
 };
 
+%extend GeomFill_DegeneratedBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_DiscreteTrihedron;
 class GeomFill_DiscreteTrihedron : public GeomFill_TrihedronLaw {
 	public:
@@ -6615,6 +6845,11 @@ class Handle_GeomFill_DiscreteTrihedron : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_DiscreteTrihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_DraftTrihedron;
 class GeomFill_DraftTrihedron : public GeomFill_TrihedronLaw {
 	public:
@@ -6785,6 +7020,11 @@ class Handle_GeomFill_DraftTrihedron : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_DraftTrihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_EvolvedSection;
 class GeomFill_EvolvedSection : public GeomFill_SectionLaw {
 	public:
@@ -7043,6 +7283,11 @@ class Handle_GeomFill_EvolvedSection : public Handle_GeomFill_SectionLaw {
     }
 };
 
+%extend GeomFill_EvolvedSection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Fixed;
 class GeomFill_Fixed : public GeomFill_TrihedronLaw {
 	public:
@@ -7203,6 +7448,11 @@ class Handle_GeomFill_Fixed : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_Fixed {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Frenet;
 class GeomFill_Frenet : public GeomFill_TrihedronLaw {
 	public:
@@ -7375,6 +7625,11 @@ class Handle_GeomFill_Frenet : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_Frenet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Generator;
 class GeomFill_Generator : public GeomFill_Profiler {
 	public:
@@ -7397,6 +7652,11 @@ class GeomFill_Generator : public GeomFill_Profiler {
 };
 
 
+%extend GeomFill_Generator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_LocationDraft;
 class GeomFill_LocationDraft : public GeomFill_LocationLaw {
 	public:
@@ -7689,6 +7949,11 @@ class Handle_GeomFill_LocationDraft : public Handle_GeomFill_LocationLaw {
     }
 };
 
+%extend GeomFill_LocationDraft {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_LocationGuide;
 class GeomFill_LocationGuide : public GeomFill_LocationLaw {
 	public:
@@ -8015,6 +8280,11 @@ class Handle_GeomFill_LocationGuide : public Handle_GeomFill_LocationLaw {
     }
 };
 
+%extend GeomFill_LocationGuide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SectionGenerator;
 class GeomFill_SectionGenerator : public GeomFill_Profiler {
 	public:
@@ -8095,6 +8365,11 @@ class GeomFill_SectionGenerator : public GeomFill_Profiler {
 };
 
 
+%extend GeomFill_SectionGenerator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_SimpleBound;
 class GeomFill_SimpleBound : public GeomFill_Boundary {
 	public:
@@ -8205,6 +8480,11 @@ class Handle_GeomFill_SimpleBound : public Handle_GeomFill_Boundary {
     }
 };
 
+%extend GeomFill_SimpleBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_Stretch;
 class GeomFill_Stretch : public GeomFill_Filling {
 	public:
@@ -8279,6 +8559,11 @@ class GeomFill_Stretch : public GeomFill_Filling {
 };
 
 
+%extend GeomFill_Stretch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_TgtOnCoons;
 class GeomFill_TgtOnCoons : public GeomFill_TgtField {
 	public:
@@ -8367,6 +8652,11 @@ class Handle_GeomFill_TgtOnCoons : public Handle_GeomFill_TgtField {
     }
 };
 
+%extend GeomFill_TgtOnCoons {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_TrihedronWithGuide;
 class GeomFill_TrihedronWithGuide : public GeomFill_TrihedronLaw {
 	public:
@@ -8437,6 +8727,11 @@ class Handle_GeomFill_TrihedronWithGuide : public Handle_GeomFill_TrihedronLaw {
     }
 };
 
+%extend GeomFill_TrihedronWithGuide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_UniformSection;
 class GeomFill_UniformSection : public GeomFill_SectionLaw {
 	public:
@@ -8697,6 +8992,11 @@ class Handle_GeomFill_UniformSection : public Handle_GeomFill_SectionLaw {
     }
 };
 
+%extend GeomFill_UniformSection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_GuideTrihedronAC;
 class GeomFill_GuideTrihedronAC : public GeomFill_TrihedronWithGuide {
 	public:
@@ -8883,6 +9183,11 @@ class Handle_GeomFill_GuideTrihedronAC : public Handle_GeomFill_TrihedronWithGui
     }
 };
 
+%extend GeomFill_GuideTrihedronAC {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomFill_GuideTrihedronPlan;
 class GeomFill_GuideTrihedronPlan : public GeomFill_TrihedronWithGuide {
 	public:
@@ -9075,3 +9380,8 @@ class Handle_GeomFill_GuideTrihedronPlan : public Handle_GeomFill_TrihedronWithG
     }
 };
 
+%extend GeomFill_GuideTrihedronPlan {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomInt.i
+++ b/src/SWIG_files/wrapper/GeomInt.i
@@ -82,6 +82,11 @@ class GeomInt {
 };
 
 
+%extend GeomInt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfWLApprox;
 class GeomInt_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfWLApprox : public math_BFGS {
 	public:
@@ -110,6 +115,11 @@ class GeomInt_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfWLApprox : publi
 };
 
 
+%extend GeomInt_BSpGradient_BFGSOfMyBSplGradientOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfWLApprox;
 class GeomInt_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfWLApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -230,6 +240,11 @@ class GeomInt_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfWLApprox : public 
 };
 
 
+%extend GeomInt_BSpParFunctionOfMyBSplGradientOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfWLApprox;
 class GeomInt_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfWLApprox {
 	public:
@@ -426,6 +441,11 @@ class GeomInt_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_BSpParLeastSquareOfMyBSplGradientOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfWLApprox;
 class GeomInt_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfWLApprox : public math_BFGS {
 	public:
@@ -454,6 +474,11 @@ class GeomInt_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfWLApprox : public
 };
 
 
+%extend GeomInt_Gradient_BFGSOfMyGradientOfTheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfWLApprox;
 class GeomInt_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfWLApprox : public math_BFGS {
 	public:
@@ -482,6 +507,11 @@ class GeomInt_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfWLApprox : public ma
 };
 
 
+%extend GeomInt_Gradient_BFGSOfMyGradientbisOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_IntSS;
 class GeomInt_IntSS {
 	public:
@@ -672,6 +702,11 @@ class GeomInt_IntSS {
 };
 
 
+%extend GeomInt_IntSS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_LineConstructor;
 class GeomInt_LineConstructor {
 	public:
@@ -730,6 +765,11 @@ class GeomInt_LineConstructor {
 };
 
 
+%extend GeomInt_LineConstructor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GeomInt_LineTool {
 	public:
 		%feature("compactdefaultargs") NbVertex;
@@ -761,6 +801,11 @@ class GeomInt_LineTool {
 };
 
 
+%extend GeomInt_LineTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_MyBSplGradientOfTheComputeLineOfWLApprox;
 class GeomInt_MyBSplGradientOfTheComputeLineOfWLApprox {
 	public:
@@ -849,6 +894,11 @@ class GeomInt_MyBSplGradientOfTheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_MyBSplGradientOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_MyGradientOfTheComputeLineBezierOfWLApprox;
 class GeomInt_MyGradientOfTheComputeLineBezierOfWLApprox {
 	public:
@@ -903,6 +953,11 @@ class GeomInt_MyGradientOfTheComputeLineBezierOfWLApprox {
 };
 
 
+%extend GeomInt_MyGradientOfTheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_MyGradientbisOfTheComputeLineOfWLApprox;
 class GeomInt_MyGradientbisOfTheComputeLineOfWLApprox {
 	public:
@@ -957,6 +1012,11 @@ class GeomInt_MyGradientbisOfTheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_MyGradientbisOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ParFunctionOfMyGradientOfTheComputeLineBezierOfWLApprox;
 class GeomInt_ParFunctionOfMyGradientOfTheComputeLineBezierOfWLApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -1049,6 +1109,11 @@ class GeomInt_ParFunctionOfMyGradientOfTheComputeLineBezierOfWLApprox : public m
 };
 
 
+%extend GeomInt_ParFunctionOfMyGradientOfTheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ParFunctionOfMyGradientbisOfTheComputeLineOfWLApprox;
 class GeomInt_ParFunctionOfMyGradientbisOfTheComputeLineOfWLApprox : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -1141,6 +1206,11 @@ class GeomInt_ParFunctionOfMyGradientbisOfTheComputeLineOfWLApprox : public math
 };
 
 
+%extend GeomInt_ParFunctionOfMyGradientbisOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfWLApprox;
 class GeomInt_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfWLApprox {
 	public:
@@ -1337,6 +1407,11 @@ class GeomInt_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfWLApprox {
 };
 
 
+%extend GeomInt_ParLeastSquareOfMyGradientOfTheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ParLeastSquareOfMyGradientbisOfTheComputeLineOfWLApprox;
 class GeomInt_ParLeastSquareOfMyGradientbisOfTheComputeLineOfWLApprox {
 	public:
@@ -1533,6 +1608,11 @@ class GeomInt_ParLeastSquareOfMyGradientbisOfTheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_ParLeastSquareOfMyGradientbisOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ParameterAndOrientation;
 class GeomInt_ParameterAndOrientation {
 	public:
@@ -1577,6 +1657,11 @@ class GeomInt_ParameterAndOrientation {
 };
 
 
+%extend GeomInt_ParameterAndOrientation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ResConstraintOfMyGradientOfTheComputeLineBezierOfWLApprox;
 class GeomInt_ResConstraintOfMyGradientOfTheComputeLineBezierOfWLApprox {
 	public:
@@ -1631,6 +1716,11 @@ class GeomInt_ResConstraintOfMyGradientOfTheComputeLineBezierOfWLApprox {
 };
 
 
+%extend GeomInt_ResConstraintOfMyGradientOfTheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ResConstraintOfMyGradientbisOfTheComputeLineOfWLApprox;
 class GeomInt_ResConstraintOfMyGradientbisOfTheComputeLineOfWLApprox {
 	public:
@@ -1685,6 +1775,11 @@ class GeomInt_ResConstraintOfMyGradientbisOfTheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_ResConstraintOfMyGradientbisOfTheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_SequenceNodeOfSequenceOfParameterAndOrientation;
 class GeomInt_SequenceNodeOfSequenceOfParameterAndOrientation : public TCollection_SeqNode {
 	public:
@@ -1751,6 +1846,11 @@ class Handle_GeomInt_SequenceNodeOfSequenceOfParameterAndOrientation : public Ha
     }
 };
 
+%extend GeomInt_SequenceNodeOfSequenceOfParameterAndOrientation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_SequenceOfParameterAndOrientation;
 class GeomInt_SequenceOfParameterAndOrientation : public TCollection_BaseSequence {
 	public:
@@ -1889,6 +1989,11 @@ class GeomInt_SequenceOfParameterAndOrientation : public TCollection_BaseSequenc
 };
 
 
+%extend GeomInt_SequenceOfParameterAndOrientation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheComputeLineBezierOfWLApprox;
 class GeomInt_TheComputeLineBezierOfWLApprox {
 	public:
@@ -2079,6 +2184,11 @@ class GeomInt_TheComputeLineBezierOfWLApprox {
 };
 
 
+%extend GeomInt_TheComputeLineBezierOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheComputeLineOfWLApprox;
 class GeomInt_TheComputeLineOfWLApprox {
 	public:
@@ -2279,6 +2389,11 @@ class GeomInt_TheComputeLineOfWLApprox {
 };
 
 
+%extend GeomInt_TheComputeLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfWLApprox;
 class GeomInt_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfWLApprox : public math_FunctionSetWithDerivatives {
 	public:
@@ -2385,6 +2500,11 @@ class GeomInt_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfWLApprox : public math
 };
 
 
+%extend GeomInt_TheFunctionOfTheInt2SOfThePrmPrmSvSurfacesOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheImpPrmSvSurfacesOfWLApprox;
 class GeomInt_TheImpPrmSvSurfacesOfWLApprox : public ApproxInt_SvSurfaces {
 	public:
@@ -2483,6 +2603,11 @@ class GeomInt_TheImpPrmSvSurfacesOfWLApprox : public ApproxInt_SvSurfaces {
 };
 
 
+%extend GeomInt_TheImpPrmSvSurfacesOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheInt2SOfThePrmPrmSvSurfacesOfWLApprox;
 class GeomInt_TheInt2SOfThePrmPrmSvSurfacesOfWLApprox {
 	public:
@@ -2565,6 +2690,11 @@ class GeomInt_TheInt2SOfThePrmPrmSvSurfacesOfWLApprox {
 };
 
 
+%extend GeomInt_TheInt2SOfThePrmPrmSvSurfacesOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheMultiLineOfWLApprox;
 class GeomInt_TheMultiLineOfWLApprox {
 	public:
@@ -2743,6 +2873,11 @@ class GeomInt_TheMultiLineOfWLApprox {
 };
 
 
+%extend GeomInt_TheMultiLineOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GeomInt_TheMultiLineToolOfWLApprox {
 	public:
 		%feature("compactdefaultargs") FirstPoint;
@@ -2890,6 +3025,11 @@ class GeomInt_TheMultiLineToolOfWLApprox {
 };
 
 
+%extend GeomInt_TheMultiLineToolOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_ThePrmPrmSvSurfacesOfWLApprox;
 class GeomInt_ThePrmPrmSvSurfacesOfWLApprox : public ApproxInt_SvSurfaces {
 	public:
@@ -2980,6 +3120,11 @@ class GeomInt_ThePrmPrmSvSurfacesOfWLApprox : public ApproxInt_SvSurfaces {
 };
 
 
+%extend GeomInt_ThePrmPrmSvSurfacesOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomInt_TheZerImpFuncOfTheImpPrmSvSurfacesOfWLApprox;
 class GeomInt_TheZerImpFuncOfTheImpPrmSvSurfacesOfWLApprox : public math_FunctionSetWithDerivatives {
 	public:
@@ -3088,3 +3233,8 @@ class GeomInt_TheZerImpFuncOfTheImpPrmSvSurfacesOfWLApprox : public math_Functio
 };
 
 
+%extend GeomInt_TheZerImpFuncOfTheImpPrmSvSurfacesOfWLApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomLProp.i
+++ b/src/SWIG_files/wrapper/GeomLProp.i
@@ -102,6 +102,11 @@ class GeomLProp {
 };
 
 
+%extend GeomLProp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLProp_CLProps;
 class GeomLProp_CLProps {
 	public:
@@ -192,6 +197,11 @@ class GeomLProp_CLProps {
 };
 
 
+%extend GeomLProp_CLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GeomLProp_CurveTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -281,6 +291,11 @@ class GeomLProp_CurveTool {
 };
 
 
+%extend GeomLProp_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLProp_SLProps;
 class GeomLProp_SLProps {
 	public:
@@ -417,6 +432,11 @@ class GeomLProp_SLProps {
 };
 
 
+%extend GeomLProp_SLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GeomLProp_SurfaceTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -516,3 +536,8 @@ class GeomLProp_SurfaceTool {
 };
 
 
+%extend GeomLProp_SurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomLib.i
+++ b/src/SWIG_files/wrapper/GeomLib.i
@@ -304,6 +304,11 @@ class GeomLib {
 };
 
 
+%extend GeomLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_Array1OfMat;
 class GeomLib_Array1OfMat {
 	public:
@@ -386,6 +391,11 @@ class GeomLib_Array1OfMat {
 };
 
 
+%extend GeomLib_Array1OfMat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_Check2dBSplineCurve;
 class GeomLib_Check2dBSplineCurve {
 	public:
@@ -432,6 +442,11 @@ class GeomLib_Check2dBSplineCurve {
 };
 
 
+%extend GeomLib_Check2dBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_CheckBSplineCurve;
 class GeomLib_CheckBSplineCurve {
 	public:
@@ -478,6 +493,11 @@ class GeomLib_CheckBSplineCurve {
 };
 
 
+%extend GeomLib_CheckBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_DenominatorMultiplier;
 class GeomLib_DenominatorMultiplier {
 	public:
@@ -504,6 +524,11 @@ class GeomLib_DenominatorMultiplier {
 };
 
 
+%extend GeomLib_DenominatorMultiplier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_Interpolate;
 class GeomLib_Interpolate {
 	public:
@@ -540,6 +565,11 @@ class GeomLib_Interpolate {
 };
 
 
+%extend GeomLib_Interpolate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_IsPlanarSurface;
 class GeomLib_IsPlanarSurface {
 	public:
@@ -566,6 +596,11 @@ class GeomLib_IsPlanarSurface {
 };
 
 
+%extend GeomLib_IsPlanarSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_LogSample;
 class GeomLib_LogSample : public math_FunctionSample {
 	public:
@@ -590,6 +625,11 @@ class GeomLib_LogSample : public math_FunctionSample {
 };
 
 
+%extend GeomLib_LogSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_MakeCurvefromApprox;
 class GeomLib_MakeCurvefromApprox {
 	public:
@@ -670,6 +710,11 @@ class GeomLib_MakeCurvefromApprox {
 };
 
 
+%extend GeomLib_MakeCurvefromApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomLib_PolyFunc;
 class GeomLib_PolyFunc : public math_FunctionWithDerivative {
 	public:
@@ -714,6 +759,11 @@ class GeomLib_PolyFunc : public math_FunctionWithDerivative {
 };
 
 
+%extend GeomLib_PolyFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class GeomLib_Tool {
 	public:
 		%feature("compactdefaultargs") Parameter;
@@ -763,3 +813,8 @@ class GeomLib_Tool {
 };
 
 
+%extend GeomLib_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomPlate.i
+++ b/src/SWIG_files/wrapper/GeomPlate.i
@@ -76,6 +76,11 @@ class GeomPlate_Aij {
 };
 
 
+%extend GeomPlate_Aij {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_Array1OfHCurveOnSurface;
 class GeomPlate_Array1OfHCurveOnSurface {
 	public:
@@ -158,6 +163,11 @@ class GeomPlate_Array1OfHCurveOnSurface {
 };
 
 
+%extend GeomPlate_Array1OfHCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_Array1OfSequenceOfReal;
 class GeomPlate_Array1OfSequenceOfReal {
 	public:
@@ -240,6 +250,11 @@ class GeomPlate_Array1OfSequenceOfReal {
 };
 
 
+%extend GeomPlate_Array1OfSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_BuildAveragePlane;
 class GeomPlate_BuildAveragePlane {
 	public:
@@ -324,6 +339,11 @@ class GeomPlate_BuildAveragePlane {
 };
 
 
+%extend GeomPlate_BuildAveragePlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_BuildPlateSurface;
 class GeomPlate_BuildPlateSurface {
 	public:
@@ -554,6 +574,11 @@ class GeomPlate_BuildPlateSurface {
 };
 
 
+%extend GeomPlate_BuildPlateSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_CurveConstraint;
 class GeomPlate_CurveConstraint : public MMgt_TShared {
 	public:
@@ -810,6 +835,11 @@ class Handle_GeomPlate_CurveConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_CurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_HArray1OfHCurveOnSurface;
 class GeomPlate_HArray1OfHCurveOnSurface : public MMgt_TShared {
 	public:
@@ -926,6 +956,11 @@ class Handle_GeomPlate_HArray1OfHCurveOnSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_HArray1OfHCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_HArray1OfSequenceOfReal;
 class GeomPlate_HArray1OfSequenceOfReal : public MMgt_TShared {
 	public:
@@ -1042,6 +1077,11 @@ class Handle_GeomPlate_HArray1OfSequenceOfReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_HArray1OfSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_HSequenceOfCurveConstraint;
 class GeomPlate_HSequenceOfCurveConstraint : public MMgt_TShared {
 	public:
@@ -1226,6 +1266,11 @@ class Handle_GeomPlate_HSequenceOfCurveConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_HSequenceOfCurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_HSequenceOfPointConstraint;
 class GeomPlate_HSequenceOfPointConstraint : public MMgt_TShared {
 	public:
@@ -1410,6 +1455,11 @@ class Handle_GeomPlate_HSequenceOfPointConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_HSequenceOfPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_MakeApprox;
 class GeomPlate_MakeApprox {
 	public:
@@ -1476,6 +1526,11 @@ class GeomPlate_MakeApprox {
 };
 
 
+%extend GeomPlate_MakeApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_PlateG0Criterion;
 class GeomPlate_PlateG0Criterion : public AdvApp2Var_Criterion {
 	public:
@@ -1510,6 +1565,11 @@ class GeomPlate_PlateG0Criterion : public AdvApp2Var_Criterion {
 };
 
 
+%extend GeomPlate_PlateG0Criterion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_PlateG1Criterion;
 class GeomPlate_PlateG1Criterion : public AdvApp2Var_Criterion {
 	public:
@@ -1544,6 +1604,11 @@ class GeomPlate_PlateG1Criterion : public AdvApp2Var_Criterion {
 };
 
 
+%extend GeomPlate_PlateG1Criterion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_PointConstraint;
 class GeomPlate_PointConstraint : public MMgt_TShared {
 	public:
@@ -1732,6 +1797,11 @@ class Handle_GeomPlate_PointConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomPlate_PointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceNodeOfSequenceOfAij;
 class GeomPlate_SequenceNodeOfSequenceOfAij : public TCollection_SeqNode {
 	public:
@@ -1798,6 +1868,11 @@ class Handle_GeomPlate_SequenceNodeOfSequenceOfAij : public Handle_TCollection_S
     }
 };
 
+%extend GeomPlate_SequenceNodeOfSequenceOfAij {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceNodeOfSequenceOfCurveConstraint;
 class GeomPlate_SequenceNodeOfSequenceOfCurveConstraint : public TCollection_SeqNode {
 	public:
@@ -1864,6 +1939,11 @@ class Handle_GeomPlate_SequenceNodeOfSequenceOfCurveConstraint : public Handle_T
     }
 };
 
+%extend GeomPlate_SequenceNodeOfSequenceOfCurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceNodeOfSequenceOfPointConstraint;
 class GeomPlate_SequenceNodeOfSequenceOfPointConstraint : public TCollection_SeqNode {
 	public:
@@ -1930,6 +2010,11 @@ class Handle_GeomPlate_SequenceNodeOfSequenceOfPointConstraint : public Handle_T
     }
 };
 
+%extend GeomPlate_SequenceNodeOfSequenceOfPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceOfAij;
 class GeomPlate_SequenceOfAij : public TCollection_BaseSequence {
 	public:
@@ -2068,6 +2153,11 @@ class GeomPlate_SequenceOfAij : public TCollection_BaseSequence {
 };
 
 
+%extend GeomPlate_SequenceOfAij {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceOfCurveConstraint;
 class GeomPlate_SequenceOfCurveConstraint : public TCollection_BaseSequence {
 	public:
@@ -2206,6 +2296,11 @@ class GeomPlate_SequenceOfCurveConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend GeomPlate_SequenceOfCurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_SequenceOfPointConstraint;
 class GeomPlate_SequenceOfPointConstraint : public TCollection_BaseSequence {
 	public:
@@ -2344,6 +2439,11 @@ class GeomPlate_SequenceOfPointConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend GeomPlate_SequenceOfPointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomPlate_Surface;
 class GeomPlate_Surface : public Geom_Surface {
 	public:
@@ -2678,3 +2778,8 @@ class Handle_GeomPlate_Surface : public Handle_Geom_Surface {
     }
 };
 
+%extend GeomPlate_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomProjLib.i
+++ b/src/SWIG_files/wrapper/GeomProjLib.i
@@ -188,3 +188,8 @@ class GeomProjLib {
 };
 
 
+%extend GeomProjLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomToStep.i
+++ b/src/SWIG_files/wrapper/GeomToStep.i
@@ -65,6 +65,11 @@ class GeomToStep_Root {
 };
 
 
+%extend GeomToStep_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeAxis1Placement;
 class GeomToStep_MakeAxis1Placement : public GeomToStep_Root {
 	public:
@@ -99,6 +104,11 @@ class GeomToStep_MakeAxis1Placement : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeAxis1Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeAxis2Placement2d;
 class GeomToStep_MakeAxis2Placement2d : public GeomToStep_Root {
 	public:
@@ -121,6 +131,11 @@ class GeomToStep_MakeAxis2Placement2d : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeAxis2Placement2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeAxis2Placement3d;
 class GeomToStep_MakeAxis2Placement3d : public GeomToStep_Root {
 	public:
@@ -159,6 +174,11 @@ class GeomToStep_MakeAxis2Placement3d : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeAxis2Placement3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBSplineCurveWithKnots;
 class GeomToStep_MakeBSplineCurveWithKnots : public GeomToStep_Root {
 	public:
@@ -181,6 +201,11 @@ class GeomToStep_MakeBSplineCurveWithKnots : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeBSplineCurveWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBSplineCurveWithKnotsAndRationalBSplineCurve;
 class GeomToStep_MakeBSplineCurveWithKnotsAndRationalBSplineCurve : public GeomToStep_Root {
 	public:
@@ -203,6 +228,11 @@ class GeomToStep_MakeBSplineCurveWithKnotsAndRationalBSplineCurve : public GeomT
 };
 
 
+%extend GeomToStep_MakeBSplineCurveWithKnotsAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBSplineSurfaceWithKnots;
 class GeomToStep_MakeBSplineSurfaceWithKnots : public GeomToStep_Root {
 	public:
@@ -219,6 +249,11 @@ class GeomToStep_MakeBSplineSurfaceWithKnots : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeBSplineSurfaceWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBSplineSurfaceWithKnotsAndRationalBSplineSurface;
 class GeomToStep_MakeBSplineSurfaceWithKnotsAndRationalBSplineSurface : public GeomToStep_Root {
 	public:
@@ -235,6 +270,11 @@ class GeomToStep_MakeBSplineSurfaceWithKnotsAndRationalBSplineSurface : public G
 };
 
 
+%extend GeomToStep_MakeBSplineSurfaceWithKnotsAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBoundedCurve;
 class GeomToStep_MakeBoundedCurve : public GeomToStep_Root {
 	public:
@@ -257,6 +297,11 @@ class GeomToStep_MakeBoundedCurve : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeBoundedSurface;
 class GeomToStep_MakeBoundedSurface : public GeomToStep_Root {
 	public:
@@ -273,6 +318,11 @@ class GeomToStep_MakeBoundedSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeCartesianPoint;
 class GeomToStep_MakeCartesianPoint : public GeomToStep_Root {
 	public:
@@ -307,6 +357,11 @@ class GeomToStep_MakeCartesianPoint : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeCircle;
 class GeomToStep_MakeCircle : public GeomToStep_Root {
 	public:
@@ -335,6 +390,11 @@ class GeomToStep_MakeCircle : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeConic;
 class GeomToStep_MakeConic : public GeomToStep_Root {
 	public:
@@ -357,6 +417,11 @@ class GeomToStep_MakeConic : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeConicalSurface;
 class GeomToStep_MakeConicalSurface : public GeomToStep_Root {
 	public:
@@ -373,6 +438,11 @@ class GeomToStep_MakeConicalSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeCurve;
 class GeomToStep_MakeCurve : public GeomToStep_Root {
 	public:
@@ -395,6 +465,11 @@ class GeomToStep_MakeCurve : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeCylindricalSurface;
 class GeomToStep_MakeCylindricalSurface : public GeomToStep_Root {
 	public:
@@ -411,6 +486,11 @@ class GeomToStep_MakeCylindricalSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeCylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeDirection;
 class GeomToStep_MakeDirection : public GeomToStep_Root {
 	public:
@@ -445,6 +525,11 @@ class GeomToStep_MakeDirection : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeDirection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeElementarySurface;
 class GeomToStep_MakeElementarySurface : public GeomToStep_Root {
 	public:
@@ -461,6 +546,11 @@ class GeomToStep_MakeElementarySurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeElementarySurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeEllipse;
 class GeomToStep_MakeEllipse : public GeomToStep_Root {
 	public:
@@ -489,6 +579,11 @@ class GeomToStep_MakeEllipse : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeHyperbola;
 class GeomToStep_MakeHyperbola : public GeomToStep_Root {
 	public:
@@ -511,6 +606,11 @@ class GeomToStep_MakeHyperbola : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeLine;
 class GeomToStep_MakeLine : public GeomToStep_Root {
 	public:
@@ -545,6 +645,11 @@ class GeomToStep_MakeLine : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeParabola;
 class GeomToStep_MakeParabola : public GeomToStep_Root {
 	public:
@@ -567,6 +672,11 @@ class GeomToStep_MakeParabola : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakePlane;
 class GeomToStep_MakePlane : public GeomToStep_Root {
 	public:
@@ -589,6 +699,11 @@ class GeomToStep_MakePlane : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakePlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakePolyline;
 class GeomToStep_MakePolyline : public GeomToStep_Root {
 	public:
@@ -611,6 +726,11 @@ class GeomToStep_MakePolyline : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakePolyline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeRectangularTrimmedSurface;
 class GeomToStep_MakeRectangularTrimmedSurface : public GeomToStep_Root {
 	public:
@@ -627,6 +747,11 @@ class GeomToStep_MakeRectangularTrimmedSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeRectangularTrimmedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeSphericalSurface;
 class GeomToStep_MakeSphericalSurface : public GeomToStep_Root {
 	public:
@@ -643,6 +768,11 @@ class GeomToStep_MakeSphericalSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeSphericalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeSurface;
 class GeomToStep_MakeSurface : public GeomToStep_Root {
 	public:
@@ -659,6 +789,11 @@ class GeomToStep_MakeSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeSurfaceOfLinearExtrusion;
 class GeomToStep_MakeSurfaceOfLinearExtrusion : public GeomToStep_Root {
 	public:
@@ -675,6 +810,11 @@ class GeomToStep_MakeSurfaceOfLinearExtrusion : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeSurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeSurfaceOfRevolution;
 class GeomToStep_MakeSurfaceOfRevolution : public GeomToStep_Root {
 	public:
@@ -691,6 +831,11 @@ class GeomToStep_MakeSurfaceOfRevolution : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeSurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeSweptSurface;
 class GeomToStep_MakeSweptSurface : public GeomToStep_Root {
 	public:
@@ -707,6 +852,11 @@ class GeomToStep_MakeSweptSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeSweptSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeToroidalSurface;
 class GeomToStep_MakeToroidalSurface : public GeomToStep_Root {
 	public:
@@ -723,6 +873,11 @@ class GeomToStep_MakeToroidalSurface : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomToStep_MakeVector;
 class GeomToStep_MakeVector : public GeomToStep_Root {
 	public:
@@ -757,3 +912,8 @@ class GeomToStep_MakeVector : public GeomToStep_Root {
 };
 
 
+%extend GeomToStep_MakeVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/GeomTools.i
+++ b/src/SWIG_files/wrapper/GeomTools.i
@@ -172,6 +172,11 @@ class GeomTools {
 };
 
 
+%extend GeomTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomTools_Curve2dSet;
 class GeomTools_Curve2dSet {
 	public:
@@ -269,6 +274,11 @@ class GeomTools_Curve2dSet {
 };
 
 
+%extend GeomTools_Curve2dSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomTools_CurveSet;
 class GeomTools_CurveSet {
 	public:
@@ -366,6 +376,11 @@ class GeomTools_CurveSet {
 };
 
 
+%extend GeomTools_CurveSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomTools_SurfaceSet;
 class GeomTools_SurfaceSet {
 	public:
@@ -463,6 +478,11 @@ class GeomTools_SurfaceSet {
 };
 
 
+%extend GeomTools_SurfaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor GeomTools_UndefinedTypeHandler;
 class GeomTools_UndefinedTypeHandler : public MMgt_TShared {
 	public:
@@ -579,3 +599,8 @@ class Handle_GeomTools_UndefinedTypeHandler : public Handle_MMgt_TShared {
     }
 };
 
+%extend GeomTools_UndefinedTypeHandler {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Graphic3d.i
+++ b/src/SWIG_files/wrapper/Graphic3d.i
@@ -449,6 +449,11 @@ class Graphic3d_Array1OfVector {
 };
 
 
+%extend Graphic3d_Array1OfVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Array1OfVertex;
 class Graphic3d_Array1OfVertex {
 	public:
@@ -531,6 +536,11 @@ class Graphic3d_Array1OfVertex {
 };
 
 
+%extend Graphic3d_Array1OfVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Array2OfVertex;
 class Graphic3d_Array2OfVertex {
 	public:
@@ -635,6 +645,11 @@ class Graphic3d_Array2OfVertex {
 };
 
 
+%extend Graphic3d_Array2OfVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfPrimitives;
 class Graphic3d_ArrayOfPrimitives : public MMgt_TShared {
 	public:
@@ -1297,6 +1312,11 @@ class Handle_Graphic3d_ArrayOfPrimitives : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_ArrayOfPrimitives {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_AspectFillArea3d;
 class Graphic3d_AspectFillArea3d : public Aspect_AspectFillArea {
 	public:
@@ -1515,6 +1535,11 @@ class Handle_Graphic3d_AspectFillArea3d : public Handle_Aspect_AspectFillArea {
     }
 };
 
+%extend Graphic3d_AspectFillArea3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_AspectLine3d;
 class Graphic3d_AspectLine3d : public Aspect_AspectLine {
 	public:
@@ -1597,6 +1622,11 @@ class Handle_Graphic3d_AspectLine3d : public Handle_Aspect_AspectLine {
     }
 };
 
+%extend Graphic3d_AspectLine3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_AspectMarker3d;
 class Graphic3d_AspectMarker3d : public Aspect_AspectMarker {
 	public:
@@ -1733,6 +1763,11 @@ class Handle_Graphic3d_AspectMarker3d : public Handle_Aspect_AspectMarker {
     }
 };
 
+%extend Graphic3d_AspectMarker3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_AspectText3d;
 class Graphic3d_AspectText3d : public MMgt_TShared {
 	public:
@@ -2003,6 +2038,11 @@ class Handle_Graphic3d_AspectText3d : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_AspectText3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Attribute;
 class Graphic3d_Attribute {
 	public:
@@ -2025,6 +2065,11 @@ class Graphic3d_Attribute {
 };
 
 
+%extend Graphic3d_Attribute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_BoundBuffer;
 class Graphic3d_BoundBuffer : public NCollection_Buffer {
 	public:
@@ -2098,6 +2143,11 @@ class Handle_Graphic3d_BoundBuffer : public Handle_NCollection_Buffer {
     }
 };
 
+%extend Graphic3d_BoundBuffer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CAspectFillArea;
 class Graphic3d_CAspectFillArea {
 	public:
@@ -2127,6 +2177,11 @@ class Graphic3d_CAspectFillArea {
 };
 
 
+%extend Graphic3d_CAspectFillArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CAspectLine;
 class Graphic3d_CAspectLine {
 	public:
@@ -2139,6 +2194,11 @@ class Graphic3d_CAspectLine {
 };
 
 
+%extend Graphic3d_CAspectLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CAspectMarker;
 class Graphic3d_CAspectMarker {
 	public:
@@ -2156,6 +2216,11 @@ class Graphic3d_CAspectMarker {
 };
 
 
+%extend Graphic3d_CAspectMarker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CAspectText;
 class Graphic3d_CAspectText {
 	public:
@@ -2174,6 +2239,11 @@ class Graphic3d_CAspectText {
 };
 
 
+%extend Graphic3d_CAspectText {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CBitFields16;
 class Graphic3d_CBitFields16 {
 	public:
@@ -2196,6 +2266,11 @@ class Graphic3d_CBitFields16 {
 };
 
 
+%extend Graphic3d_CBitFields16 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CBitFields20;
 class Graphic3d_CBitFields20 {
 	public:
@@ -2222,6 +2297,11 @@ class Graphic3d_CBitFields20 {
 };
 
 
+%extend Graphic3d_CBitFields20 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CBitFields4;
 class Graphic3d_CBitFields4 {
 	public:
@@ -2232,6 +2312,11 @@ class Graphic3d_CBitFields4 {
 };
 
 
+%extend Graphic3d_CBitFields4 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CBitFields8;
 class Graphic3d_CBitFields8 {
 	public:
@@ -2246,6 +2331,11 @@ class Graphic3d_CBitFields8 {
 };
 
 
+%extend Graphic3d_CBitFields8 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CGraduatedTrihedron;
 class Graphic3d_CGraduatedTrihedron {
 	public:
@@ -2296,6 +2386,11 @@ class Graphic3d_CGraduatedTrihedron {
 };
 
 
+%extend Graphic3d_CGraduatedTrihedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CLight;
 class Graphic3d_CLight {
 	public:
@@ -2364,6 +2459,11 @@ class Graphic3d_CLight {
 };
 
 
+%extend Graphic3d_CLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CStructure;
 class Graphic3d_CStructure : public Standard_Transient {
 	public:
@@ -2559,6 +2659,11 @@ class Handle_Graphic3d_CStructure : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_CStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CTexture;
 class Graphic3d_CTexture {
 	public:
@@ -2571,6 +2676,11 @@ class Graphic3d_CTexture {
 };
 
 
+%extend Graphic3d_CTexture {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_CView;
 class Graphic3d_CView {
 	public:
@@ -2598,6 +2708,11 @@ class Graphic3d_CView {
 };
 
 
+%extend Graphic3d_CView {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Camera;
 class Graphic3d_Camera : public Standard_Transient {
 	public:
@@ -3109,6 +3224,11 @@ class Handle_Graphic3d_Camera : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_Camera {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ClipPlane;
 class Graphic3d_ClipPlane : public Standard_Transient {
 	public:
@@ -3346,6 +3466,11 @@ class Handle_Graphic3d_ClipPlane : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_ClipPlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_DataStructureManager;
 class Graphic3d_DataStructureManager : public MMgt_TShared {
 	public:
@@ -3404,6 +3529,11 @@ class Handle_Graphic3d_DataStructureManager : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_DataStructureManager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_GraphicDriver;
 class Graphic3d_GraphicDriver : public MMgt_TShared {
 	public:
@@ -4404,6 +4534,11 @@ class Handle_Graphic3d_GraphicDriver : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_GraphicDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Group;
 class Graphic3d_Group : public MMgt_TShared {
 	public:
@@ -4764,6 +4899,11 @@ class Handle_Graphic3d_Group : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_Group {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_HSequenceOfStructure;
 class Graphic3d_HSequenceOfStructure : public MMgt_TShared {
 	public:
@@ -4948,6 +5088,11 @@ class Handle_Graphic3d_HSequenceOfStructure : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_HSequenceOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ListIteratorOfListOfShortReal;
 class Graphic3d_ListIteratorOfListOfShortReal {
 	public:
@@ -4982,6 +5127,11 @@ class Graphic3d_ListIteratorOfListOfShortReal {
 };
 
 
+%extend Graphic3d_ListIteratorOfListOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ListNodeOfListOfShortReal;
 class Graphic3d_ListNodeOfListOfShortReal : public TCollection_MapNode {
 	public:
@@ -5046,6 +5196,11 @@ class Handle_Graphic3d_ListNodeOfListOfShortReal : public Handle_TCollection_Map
     }
 };
 
+%extend Graphic3d_ListNodeOfListOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ListOfShortReal;
 class Graphic3d_ListOfShortReal {
 	public:
@@ -5176,6 +5331,11 @@ class Graphic3d_ListOfShortReal {
 };
 
 
+%extend Graphic3d_ListOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_MapIteratorOfMapOfStructure;
 class Graphic3d_MapIteratorOfMapOfStructure : public TCollection_BasicMapIterator {
 	public:
@@ -5202,6 +5362,11 @@ class Graphic3d_MapIteratorOfMapOfStructure : public TCollection_BasicMapIterato
 };
 
 
+%extend Graphic3d_MapIteratorOfMapOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_MapOfStructure;
 class Graphic3d_MapOfStructure : public TCollection_BasicMap {
 	public:
@@ -5260,6 +5425,11 @@ class Graphic3d_MapOfStructure : public TCollection_BasicMap {
 };
 
 
+%extend Graphic3d_MapOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_MarkerImage;
 class Graphic3d_MarkerImage : public Standard_Transient {
 	public:
@@ -5374,6 +5544,11 @@ class Handle_Graphic3d_MarkerImage : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_MarkerImage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_MaterialAspect;
 class Graphic3d_MaterialAspect {
 	public:
@@ -5720,6 +5895,11 @@ class Graphic3d_MaterialAspect {
 };
 
 
+%extend Graphic3d_MaterialAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_RenderingParams;
 class Graphic3d_RenderingParams {
 	public:
@@ -5738,6 +5918,11 @@ class Graphic3d_RenderingParams {
 };
 
 
+%extend Graphic3d_RenderingParams {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_SequenceNodeOfSequenceOfStructure;
 class Graphic3d_SequenceNodeOfSequenceOfStructure : public TCollection_SeqNode {
 	public:
@@ -5804,6 +5989,11 @@ class Handle_Graphic3d_SequenceNodeOfSequenceOfStructure : public Handle_TCollec
     }
 };
 
+%extend Graphic3d_SequenceNodeOfSequenceOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_SequenceOfStructure;
 class Graphic3d_SequenceOfStructure : public TCollection_BaseSequence {
 	public:
@@ -5942,6 +6132,11 @@ class Graphic3d_SequenceOfStructure : public TCollection_BaseSequence {
 };
 
 
+%extend Graphic3d_SequenceOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ShaderObject;
 class Graphic3d_ShaderObject : public Standard_Transient {
 	public:
@@ -6044,6 +6239,11 @@ class Handle_Graphic3d_ShaderObject : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_ShaderObject {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ShaderProgram;
 class Graphic3d_ShaderProgram : public Standard_Transient {
 	public:
@@ -6176,6 +6376,11 @@ class Handle_Graphic3d_ShaderProgram : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_ShaderProgram {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ShaderVariable;
 class Graphic3d_ShaderVariable : public Standard_Transient {
 	public:
@@ -6246,6 +6451,11 @@ class Handle_Graphic3d_ShaderVariable : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_ShaderVariable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_StdMapNodeOfMapOfStructure;
 class Graphic3d_StdMapNodeOfMapOfStructure : public TCollection_MapNode {
 	public:
@@ -6310,6 +6520,11 @@ class Handle_Graphic3d_StdMapNodeOfMapOfStructure : public Handle_TCollection_Ma
     }
 };
 
+%extend Graphic3d_StdMapNodeOfMapOfStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Structure;
 class Graphic3d_Structure : public MMgt_TShared {
 	public:
@@ -7048,6 +7263,11 @@ class Handle_Graphic3d_Structure : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_Structure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_StructureManager;
 class Graphic3d_StructureManager : public MMgt_TShared {
 	public:
@@ -7440,6 +7660,11 @@ class Handle_Graphic3d_StructureManager : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_StructureManager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_TextureParams;
 class Graphic3d_TextureParams : public Standard_Transient {
 	public:
@@ -7630,6 +7855,11 @@ class Handle_Graphic3d_TextureParams : public Handle_Standard_Transient {
     }
 };
 
+%extend Graphic3d_TextureParams {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_TextureRoot;
 class Graphic3d_TextureRoot : public MMgt_TShared {
 	public:
@@ -7728,54 +7958,99 @@ class Handle_Graphic3d_TextureRoot : public Handle_MMgt_TShared {
     }
 };
 
+%extend Graphic3d_TextureRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec2>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec2> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec2> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec2i>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec2i> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec2i> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec3>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec3> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec3> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec3i>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec3i> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec3i> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec4>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec4> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec4> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Graphic3d_Vec4i>;
 class Graphic3d_UniformValueTypeID<Graphic3d_Vec4i> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Graphic3d_Vec4i> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Standard_Integer>;
 class Graphic3d_UniformValueTypeID<Standard_Integer> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Standard_Integer> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_UniformValueTypeID<Standard_ShortReal>;
 class Graphic3d_UniformValueTypeID<Standard_ShortReal> {
 	public:
 };
 
 
+%extend Graphic3d_UniformValueTypeID<Standard_ShortReal> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ValueInterface;
 class Graphic3d_ValueInterface {
 	public:
@@ -7788,6 +8063,11 @@ class Graphic3d_ValueInterface {
 };
 
 
+%extend Graphic3d_ValueInterface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Vector;
 class Graphic3d_Vector {
 	public:
@@ -7936,6 +8216,11 @@ class Graphic3d_Vector {
 };
 
 
+%extend Graphic3d_Vector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Vertex;
 class Graphic3d_Vertex : public TEL_POINT {
 	public:
@@ -8054,6 +8339,11 @@ class Graphic3d_Vertex : public TEL_POINT {
 };
 
 
+%extend Graphic3d_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ZLayerSettings;
 class Graphic3d_ZLayerSettings {
 	public:
@@ -8103,6 +8393,11 @@ class Graphic3d_ZLayerSettings {
 };
 
 
+%extend Graphic3d_ZLayerSettings {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfPoints;
 class Graphic3d_ArrayOfPoints : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8167,6 +8462,11 @@ class Handle_Graphic3d_ArrayOfPoints : public Handle_Graphic3d_ArrayOfPrimitives
     }
 };
 
+%extend Graphic3d_ArrayOfPoints {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfPolygons;
 class Graphic3d_ArrayOfPolygons : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8239,6 +8539,11 @@ class Handle_Graphic3d_ArrayOfPolygons : public Handle_Graphic3d_ArrayOfPrimitiv
     }
 };
 
+%extend Graphic3d_ArrayOfPolygons {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfPolylines;
 class Graphic3d_ArrayOfPolylines : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8307,6 +8612,11 @@ class Handle_Graphic3d_ArrayOfPolylines : public Handle_Graphic3d_ArrayOfPrimiti
     }
 };
 
+%extend Graphic3d_ArrayOfPolylines {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfQuadrangleStrips;
 class Graphic3d_ArrayOfQuadrangleStrips : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8377,6 +8687,11 @@ class Handle_Graphic3d_ArrayOfQuadrangleStrips : public Handle_Graphic3d_ArrayOf
     }
 };
 
+%extend Graphic3d_ArrayOfQuadrangleStrips {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfQuadrangles;
 class Graphic3d_ArrayOfQuadrangles : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8445,6 +8760,11 @@ class Handle_Graphic3d_ArrayOfQuadrangles : public Handle_Graphic3d_ArrayOfPrimi
     }
 };
 
+%extend Graphic3d_ArrayOfQuadrangles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfSegments;
 class Graphic3d_ArrayOfSegments : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8509,6 +8829,11 @@ class Handle_Graphic3d_ArrayOfSegments : public Handle_Graphic3d_ArrayOfPrimitiv
     }
 };
 
+%extend Graphic3d_ArrayOfSegments {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfTriangleFans;
 class Graphic3d_ArrayOfTriangleFans : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8579,6 +8904,11 @@ class Handle_Graphic3d_ArrayOfTriangleFans : public Handle_Graphic3d_ArrayOfPrim
     }
 };
 
+%extend Graphic3d_ArrayOfTriangleFans {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfTriangleStrips;
 class Graphic3d_ArrayOfTriangleStrips : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8649,6 +8979,11 @@ class Handle_Graphic3d_ArrayOfTriangleStrips : public Handle_Graphic3d_ArrayOfPr
     }
 };
 
+%extend Graphic3d_ArrayOfTriangleStrips {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_ArrayOfTriangles;
 class Graphic3d_ArrayOfTriangles : public Graphic3d_ArrayOfPrimitives {
 	public:
@@ -8717,6 +9052,11 @@ class Handle_Graphic3d_ArrayOfTriangles : public Handle_Graphic3d_ArrayOfPrimiti
     }
 };
 
+%extend Graphic3d_ArrayOfTriangles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_TextureEnv;
 class Graphic3d_TextureEnv : public Graphic3d_TextureRoot {
 	public:
@@ -8805,6 +9145,11 @@ class Handle_Graphic3d_TextureEnv : public Handle_Graphic3d_TextureRoot {
     }
 };
 
+%extend Graphic3d_TextureEnv {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_TextureMap;
 class Graphic3d_TextureMap : public Graphic3d_TextureRoot {
 	public:
@@ -8925,6 +9270,11 @@ class Handle_Graphic3d_TextureMap : public Handle_Graphic3d_TextureRoot {
     }
 };
 
+%extend Graphic3d_TextureMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture1D;
 class Graphic3d_Texture1D : public Graphic3d_TextureMap {
 	public:
@@ -8997,6 +9347,11 @@ class Handle_Graphic3d_Texture1D : public Handle_Graphic3d_TextureMap {
     }
 };
 
+%extend Graphic3d_Texture1D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture2D;
 class Graphic3d_Texture2D : public Graphic3d_TextureMap {
 	public:
@@ -9069,6 +9424,11 @@ class Handle_Graphic3d_Texture2D : public Handle_Graphic3d_TextureMap {
     }
 };
 
+%extend Graphic3d_Texture2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture1Dmanual;
 class Graphic3d_Texture1Dmanual : public Graphic3d_Texture1D {
 	public:
@@ -9145,6 +9505,11 @@ class Handle_Graphic3d_Texture1Dmanual : public Handle_Graphic3d_Texture1D {
     }
 };
 
+%extend Graphic3d_Texture1Dmanual {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture1Dsegment;
 class Graphic3d_Texture1Dsegment : public Graphic3d_Texture1D {
 	public:
@@ -9257,6 +9622,11 @@ class Handle_Graphic3d_Texture1Dsegment : public Handle_Graphic3d_Texture1D {
     }
 };
 
+%extend Graphic3d_Texture1Dsegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture2Dmanual;
 class Graphic3d_Texture2Dmanual : public Graphic3d_Texture2D {
 	public:
@@ -9333,6 +9703,11 @@ class Handle_Graphic3d_Texture2Dmanual : public Handle_Graphic3d_Texture2D {
     }
 };
 
+%extend Graphic3d_Texture2Dmanual {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Graphic3d_Texture2Dplane;
 class Graphic3d_Texture2Dplane : public Graphic3d_Texture2D {
 	public:
@@ -9559,3 +9934,8 @@ class Handle_Graphic3d_Texture2Dplane : public Handle_Graphic3d_Texture2D {
     }
 };
 
+%extend Graphic3d_Texture2Dplane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/HLRAlgo.i
+++ b/src/SWIG_files/wrapper/HLRAlgo.i
@@ -150,6 +150,11 @@ class HLRAlgo {
 };
 
 
+%extend HLRAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Array1OfPHDat;
 class HLRAlgo_Array1OfPHDat {
 	public:
@@ -232,6 +237,11 @@ class HLRAlgo_Array1OfPHDat {
 };
 
 
+%extend HLRAlgo_Array1OfPHDat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Array1OfPINod;
 class HLRAlgo_Array1OfPINod {
 	public:
@@ -314,6 +324,11 @@ class HLRAlgo_Array1OfPINod {
 };
 
 
+%extend HLRAlgo_Array1OfPINod {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Array1OfPISeg;
 class HLRAlgo_Array1OfPISeg {
 	public:
@@ -396,6 +411,11 @@ class HLRAlgo_Array1OfPISeg {
 };
 
 
+%extend HLRAlgo_Array1OfPISeg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Array1OfTData;
 class HLRAlgo_Array1OfTData {
 	public:
@@ -478,6 +498,11 @@ class HLRAlgo_Array1OfTData {
 };
 
 
+%extend HLRAlgo_Array1OfTData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_BiPoint;
 class HLRAlgo_BiPoint {
 	public:
@@ -792,6 +817,11 @@ class HLRAlgo_BiPoint {
 };
 
 
+%extend HLRAlgo_BiPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Coincidence;
 class HLRAlgo_Coincidence {
 	public:
@@ -834,6 +864,11 @@ class HLRAlgo_Coincidence {
 };
 
 
+%extend HLRAlgo_Coincidence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_EdgeIterator;
 class HLRAlgo_EdgeIterator {
 	public:
@@ -902,6 +937,11 @@ class HLRAlgo_EdgeIterator {
 };
 
 
+%extend HLRAlgo_EdgeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_EdgeStatus;
 class HLRAlgo_EdgeStatus {
 	public:
@@ -1020,6 +1060,11 @@ class HLRAlgo_EdgeStatus {
 };
 
 
+%extend HLRAlgo_EdgeStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_EdgesBlock;
 class HLRAlgo_EdgesBlock : public MMgt_TShared {
 	public:
@@ -1178,6 +1223,11 @@ class Handle_HLRAlgo_EdgesBlock : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_EdgesBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_HArray1OfPHDat;
 class HLRAlgo_HArray1OfPHDat : public MMgt_TShared {
 	public:
@@ -1294,6 +1344,11 @@ class Handle_HLRAlgo_HArray1OfPHDat : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_HArray1OfPHDat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_HArray1OfPINod;
 class HLRAlgo_HArray1OfPINod : public MMgt_TShared {
 	public:
@@ -1410,6 +1465,11 @@ class Handle_HLRAlgo_HArray1OfPINod : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_HArray1OfPINod {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_HArray1OfPISeg;
 class HLRAlgo_HArray1OfPISeg : public MMgt_TShared {
 	public:
@@ -1526,6 +1586,11 @@ class Handle_HLRAlgo_HArray1OfPISeg : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_HArray1OfPISeg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_HArray1OfTData;
 class HLRAlgo_HArray1OfTData : public MMgt_TShared {
 	public:
@@ -1642,6 +1707,11 @@ class Handle_HLRAlgo_HArray1OfTData : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_HArray1OfTData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Interference;
 class HLRAlgo_Interference {
 	public:
@@ -1724,6 +1794,11 @@ class HLRAlgo_Interference {
 };
 
 
+%extend HLRAlgo_Interference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_InterferenceList;
 class HLRAlgo_InterferenceList {
 	public:
@@ -1854,6 +1929,11 @@ class HLRAlgo_InterferenceList {
 };
 
 
+%extend HLRAlgo_InterferenceList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Intersection;
 class HLRAlgo_Intersection {
 	public:
@@ -1952,6 +2032,11 @@ class HLRAlgo_Intersection {
 };
 
 
+%extend HLRAlgo_Intersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_ListIteratorOfInterferenceList;
 class HLRAlgo_ListIteratorOfInterferenceList {
 	public:
@@ -1986,6 +2071,11 @@ class HLRAlgo_ListIteratorOfInterferenceList {
 };
 
 
+%extend HLRAlgo_ListIteratorOfInterferenceList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_ListIteratorOfListOfBPoint;
 class HLRAlgo_ListIteratorOfListOfBPoint {
 	public:
@@ -2020,6 +2110,11 @@ class HLRAlgo_ListIteratorOfListOfBPoint {
 };
 
 
+%extend HLRAlgo_ListIteratorOfListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_ListNodeOfInterferenceList;
 class HLRAlgo_ListNodeOfInterferenceList : public TCollection_MapNode {
 	public:
@@ -2084,6 +2179,11 @@ class Handle_HLRAlgo_ListNodeOfInterferenceList : public Handle_TCollection_MapN
     }
 };
 
+%extend HLRAlgo_ListNodeOfInterferenceList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_ListNodeOfListOfBPoint;
 class HLRAlgo_ListNodeOfListOfBPoint : public TCollection_MapNode {
 	public:
@@ -2148,6 +2248,11 @@ class Handle_HLRAlgo_ListNodeOfListOfBPoint : public Handle_TCollection_MapNode 
     }
 };
 
+%extend HLRAlgo_ListNodeOfListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_ListOfBPoint;
 class HLRAlgo_ListOfBPoint {
 	public:
@@ -2278,6 +2383,11 @@ class HLRAlgo_ListOfBPoint {
 };
 
 
+%extend HLRAlgo_ListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyAlgo;
 class HLRAlgo_PolyAlgo : public MMgt_TShared {
 	public:
@@ -2416,6 +2526,11 @@ class Handle_HLRAlgo_PolyAlgo : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_PolyAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyData;
 class HLRAlgo_PolyData : public MMgt_TShared {
 	public:
@@ -2542,6 +2657,11 @@ class Handle_HLRAlgo_PolyData : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_PolyData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyHidingData;
 class HLRAlgo_PolyHidingData {
 	public:
@@ -2578,6 +2698,11 @@ class HLRAlgo_PolyHidingData {
 };
 
 
+%extend HLRAlgo_PolyHidingData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyInternalData;
 class HLRAlgo_PolyInternalData : public MMgt_TShared {
 	public:
@@ -2774,6 +2899,11 @@ class Handle_HLRAlgo_PolyInternalData : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_PolyInternalData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyInternalNode;
 class HLRAlgo_PolyInternalNode : public MMgt_TShared {
 	public:
@@ -2838,6 +2968,11 @@ class Handle_HLRAlgo_PolyInternalNode : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_PolyInternalNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyInternalSegment;
 class HLRAlgo_PolyInternalSegment {
 	public:
@@ -2852,6 +2987,11 @@ class HLRAlgo_PolyInternalSegment {
 };
 
 
+%extend HLRAlgo_PolyInternalSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_PolyShellData;
 class HLRAlgo_PolyShellData : public MMgt_TShared {
 	public:
@@ -2942,6 +3082,11 @@ class Handle_HLRAlgo_PolyShellData : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_PolyShellData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_Projector;
 class HLRAlgo_Projector {
 	public:
@@ -3118,6 +3263,11 @@ class HLRAlgo_Projector {
 };
 
 
+%extend HLRAlgo_Projector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_TriangleData;
 class HLRAlgo_TriangleData {
 	public:
@@ -3132,6 +3282,11 @@ class HLRAlgo_TriangleData {
 };
 
 
+%extend HLRAlgo_TriangleData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRAlgo_WiresBlock;
 class HLRAlgo_WiresBlock : public MMgt_TShared {
 	public:
@@ -3220,3 +3375,8 @@ class Handle_HLRAlgo_WiresBlock : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRAlgo_WiresBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/HLRAppli.i
+++ b/src/SWIG_files/wrapper/HLRAppli.i
@@ -104,3 +104,8 @@ class HLRAppli_ReflectLines {
 };
 
 
+%extend HLRAppli_ReflectLines {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/HLRBRep.i
+++ b/src/SWIG_files/wrapper/HLRBRep.i
@@ -92,6 +92,11 @@ class HLRBRep {
 };
 
 
+%extend HLRBRep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_AreaLimit;
 class HLRBRep_AreaLimit : public MMgt_TShared {
 	public:
@@ -240,6 +245,11 @@ class Handle_HLRBRep_AreaLimit : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRBRep_AreaLimit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Array1OfEData;
 class HLRBRep_Array1OfEData {
 	public:
@@ -322,6 +332,11 @@ class HLRBRep_Array1OfEData {
 };
 
 
+%extend HLRBRep_Array1OfEData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Array1OfFData;
 class HLRBRep_Array1OfFData {
 	public:
@@ -404,6 +419,11 @@ class HLRBRep_Array1OfFData {
 };
 
 
+%extend HLRBRep_Array1OfFData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_BCurveTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -661,6 +681,11 @@ class HLRBRep_BCurveTool {
 };
 
 
+%extend HLRBRep_BCurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_BiPnt2D;
 class HLRBRep_BiPnt2D {
 	public:
@@ -751,6 +776,11 @@ class HLRBRep_BiPnt2D {
 };
 
 
+%extend HLRBRep_BiPnt2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_BiPoint;
 class HLRBRep_BiPoint {
 	public:
@@ -845,6 +875,11 @@ class HLRBRep_BiPoint {
 };
 
 
+%extend HLRBRep_BiPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_CInter;
 class HLRBRep_CInter : public IntRes2d_Intersection {
 	public:
@@ -1019,6 +1054,11 @@ class HLRBRep_CInter : public IntRes2d_Intersection {
 };
 
 
+%extend HLRBRep_CInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_CLProps;
 class HLRBRep_CLProps {
 	public:
@@ -1109,6 +1149,11 @@ class HLRBRep_CLProps {
 };
 
 
+%extend HLRBRep_CLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_CLPropsATool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -1198,6 +1243,11 @@ class HLRBRep_CLPropsATool {
 };
 
 
+%extend HLRBRep_CLPropsATool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Curve;
 class HLRBRep_Curve {
 	public:
@@ -1528,6 +1578,11 @@ class HLRBRep_Curve {
 };
 
 
+%extend HLRBRep_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_CurveTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -1781,6 +1836,11 @@ class HLRBRep_CurveTool {
 };
 
 
+%extend HLRBRep_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Data;
 class HLRBRep_Data : public MMgt_TShared {
 	public:
@@ -2105,6 +2165,11 @@ class Handle_HLRBRep_Data : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRBRep_Data {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_EdgeBuilder;
 class HLRBRep_EdgeBuilder {
 	public:
@@ -2227,6 +2292,11 @@ class HLRBRep_EdgeBuilder {
 };
 
 
+%extend HLRBRep_EdgeBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_EdgeData;
 class HLRBRep_EdgeData {
 	public:
@@ -2457,6 +2527,11 @@ class HLRBRep_EdgeData {
 };
 
 
+%extend HLRBRep_EdgeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_EdgeFaceTool {
 	public:
 		%feature("compactdefaultargs") CurvatureValue;
@@ -2490,6 +2565,11 @@ class HLRBRep_EdgeFaceTool {
 };
 
 
+%extend HLRBRep_EdgeFaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_EdgeIList {
 	public:
 		%feature("compactdefaultargs") AddInterference;
@@ -2517,6 +2597,11 @@ class HLRBRep_EdgeIList {
 };
 
 
+%extend HLRBRep_EdgeIList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_EdgeInterferenceTool;
 class HLRBRep_EdgeInterferenceTool {
 	public:
@@ -2613,6 +2698,11 @@ class HLRBRep_EdgeInterferenceTool {
 };
 
 
+%extend HLRBRep_EdgeInterferenceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter;
 class HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter {
 	public:
@@ -2677,6 +2767,11 @@ class HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter {
 };
 
 
+%extend HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_FaceData;
 class HLRBRep_FaceData {
 	public:
@@ -2895,6 +2990,11 @@ class HLRBRep_FaceData {
 };
 
 
+%extend HLRBRep_FaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_FaceIterator;
 class HLRBRep_FaceIterator {
 	public:
@@ -2969,6 +3069,11 @@ class HLRBRep_FaceIterator {
 };
 
 
+%extend HLRBRep_FaceIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_HLRToShape;
 class HLRBRep_HLRToShape {
 	public:
@@ -3087,6 +3192,11 @@ class HLRBRep_HLRToShape {
 };
 
 
+%extend HLRBRep_HLRToShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Hider;
 class HLRBRep_Hider {
 	public:
@@ -3119,6 +3229,11 @@ class HLRBRep_Hider {
 };
 
 
+%extend HLRBRep_Hider {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_IntConicCurveOfCInter;
 class HLRBRep_IntConicCurveOfCInter : public IntRes2d_Intersection {
 	public:
@@ -3289,6 +3404,11 @@ class HLRBRep_IntConicCurveOfCInter : public IntRes2d_Intersection {
 };
 
 
+%extend HLRBRep_IntConicCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_InterCSurf;
 class HLRBRep_InterCSurf : public IntCurveSurface_Intersection {
 	public:
@@ -3353,6 +3473,11 @@ class HLRBRep_InterCSurf : public IntCurveSurface_Intersection {
 };
 
 
+%extend HLRBRep_InterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_InternalAlgo;
 class HLRBRep_InternalAlgo : public MMgt_TShared {
 	public:
@@ -3605,6 +3730,11 @@ class Handle_HLRBRep_InternalAlgo : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRBRep_InternalAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Intersector;
 class HLRBRep_Intersector {
 	public:
@@ -3719,6 +3849,11 @@ class HLRBRep_Intersector {
 };
 
 
+%extend HLRBRep_Intersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_LineTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -4024,6 +4159,11 @@ class HLRBRep_LineTool {
 };
 
 
+%extend HLRBRep_LineTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListIteratorOfListOfBPnt2D;
 class HLRBRep_ListIteratorOfListOfBPnt2D {
 	public:
@@ -4058,6 +4198,11 @@ class HLRBRep_ListIteratorOfListOfBPnt2D {
 };
 
 
+%extend HLRBRep_ListIteratorOfListOfBPnt2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListIteratorOfListOfBPoint;
 class HLRBRep_ListIteratorOfListOfBPoint {
 	public:
@@ -4092,6 +4237,11 @@ class HLRBRep_ListIteratorOfListOfBPoint {
 };
 
 
+%extend HLRBRep_ListIteratorOfListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListNodeOfListOfBPnt2D;
 class HLRBRep_ListNodeOfListOfBPnt2D : public TCollection_MapNode {
 	public:
@@ -4156,6 +4306,11 @@ class Handle_HLRBRep_ListNodeOfListOfBPnt2D : public Handle_TCollection_MapNode 
     }
 };
 
+%extend HLRBRep_ListNodeOfListOfBPnt2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListNodeOfListOfBPoint;
 class HLRBRep_ListNodeOfListOfBPoint : public TCollection_MapNode {
 	public:
@@ -4220,6 +4375,11 @@ class Handle_HLRBRep_ListNodeOfListOfBPoint : public Handle_TCollection_MapNode 
     }
 };
 
+%extend HLRBRep_ListNodeOfListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListOfBPnt2D;
 class HLRBRep_ListOfBPnt2D {
 	public:
@@ -4350,6 +4510,11 @@ class HLRBRep_ListOfBPnt2D {
 };
 
 
+%extend HLRBRep_ListOfBPnt2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ListOfBPoint;
 class HLRBRep_ListOfBPoint {
 	public:
@@ -4480,6 +4645,11 @@ class HLRBRep_ListOfBPoint {
 };
 
 
+%extend HLRBRep_ListOfBPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter;
 class HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter : public math_FunctionWithDerivative {
 	public:
@@ -4520,6 +4690,11 @@ class HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter : public ma
 };
 
 
+%extend HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter;
 class HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter : public math_FunctionWithDerivative {
 	public:
@@ -4614,6 +4789,11 @@ class HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter : public math_Function
 };
 
 
+%extend HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_PolyAlgo;
 class HLRBRep_PolyAlgo : public MMgt_TShared {
 	public:
@@ -4846,6 +5026,11 @@ class Handle_HLRBRep_PolyAlgo : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRBRep_PolyAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_PolyHLRToShape;
 class HLRBRep_PolyHLRToShape {
 	public:
@@ -4964,6 +5149,11 @@ class HLRBRep_PolyHLRToShape {
 };
 
 
+%extend HLRBRep_PolyHLRToShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_SLProps;
 class HLRBRep_SLProps {
 	public:
@@ -5100,6 +5290,11 @@ class HLRBRep_SLProps {
 };
 
 
+%extend HLRBRep_SLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_SLPropsATool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -5199,6 +5394,11 @@ class HLRBRep_SLPropsATool {
 };
 
 
+%extend HLRBRep_SLPropsATool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_SeqOfShapeBounds;
 class HLRBRep_SeqOfShapeBounds : public TCollection_BaseSequence {
 	public:
@@ -5337,6 +5537,11 @@ class HLRBRep_SeqOfShapeBounds : public TCollection_BaseSequence {
 };
 
 
+%extend HLRBRep_SeqOfShapeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter;
 class HLRBRep_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter : public TCollection_BaseSequence {
 	public:
@@ -5475,6 +5680,11 @@ class HLRBRep_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter : public TColle
 };
 
 
+%extend HLRBRep_SeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_SequenceNodeOfSeqOfShapeBounds;
 class HLRBRep_SequenceNodeOfSeqOfShapeBounds : public TCollection_SeqNode {
 	public:
@@ -5541,6 +5751,11 @@ class Handle_HLRBRep_SequenceNodeOfSeqOfShapeBounds : public Handle_TCollection_
     }
 };
 
+%extend HLRBRep_SequenceNodeOfSeqOfShapeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter;
 class HLRBRep_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter : public TCollection_SeqNode {
 	public:
@@ -5607,6 +5822,11 @@ class Handle_HLRBRep_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfC
     }
 };
 
+%extend HLRBRep_SequenceNodeOfSeqPCOfPCLocFOfTheLocateExtPCOfTheProjPCurOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ShapeBounds;
 class HLRBRep_ShapeBounds {
 	public:
@@ -5735,6 +5955,11 @@ class HLRBRep_ShapeBounds {
 };
 
 
+%extend HLRBRep_ShapeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_ShapeToHLR {
 	public:
 		%feature("compactdefaultargs") Load;
@@ -5754,6 +5979,11 @@ class HLRBRep_ShapeToHLR {
 };
 
 
+%extend HLRBRep_ShapeToHLR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_SurfaceTool {
 	public:
 		%feature("compactdefaultargs") FirstUParameter;
@@ -6113,6 +6343,11 @@ class HLRBRep_SurfaceTool {
 };
 
 
+%extend HLRBRep_SurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheCSFunctionOfInterCSurf;
 class HLRBRep_TheCSFunctionOfInterCSurf : public math_FunctionSetWithDerivatives {
 	public:
@@ -6177,6 +6412,11 @@ class HLRBRep_TheCSFunctionOfInterCSurf : public math_FunctionSetWithDerivatives
 };
 
 
+%extend HLRBRep_TheCSFunctionOfInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter;
 class HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter : public math_FunctionSetWithDerivatives {
 	public:
@@ -6225,6 +6465,11 @@ class HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter : public math_Fu
 };
 
 
+%extend HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheExactInterCSurf;
 class HLRBRep_TheExactInterCSurf {
 	public:
@@ -6307,6 +6552,11 @@ class HLRBRep_TheExactInterCSurf {
 };
 
 
+%extend HLRBRep_TheExactInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheIntConicCurveOfCInter;
 class HLRBRep_TheIntConicCurveOfCInter : public IntRes2d_Intersection {
 	public:
@@ -6477,6 +6727,11 @@ class HLRBRep_TheIntConicCurveOfCInter : public IntRes2d_Intersection {
 };
 
 
+%extend HLRBRep_TheIntConicCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheIntPCurvePCurveOfCInter;
 class HLRBRep_TheIntPCurvePCurveOfCInter : public IntRes2d_Intersection {
 	public:
@@ -6515,6 +6770,11 @@ class HLRBRep_TheIntPCurvePCurveOfCInter : public IntRes2d_Intersection {
 };
 
 
+%extend HLRBRep_TheIntPCurvePCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheInterferenceOfInterCSurf;
 class HLRBRep_TheInterferenceOfInterCSurf : public Intf_Interference {
 	public:
@@ -6651,6 +6911,11 @@ class HLRBRep_TheInterferenceOfInterCSurf : public Intf_Interference {
 };
 
 
+%extend HLRBRep_TheInterferenceOfInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter;
 class HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter : public IntRes2d_Intersection {
 	public:
@@ -6749,6 +7014,11 @@ class HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter : public IntRes2d_Interse
 };
 
 
+%extend HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter;
 class HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter {
 	public:
@@ -6823,6 +7093,11 @@ class HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter {
 };
 
 
+%extend HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter;
 class HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter : public Intf_Polygon2d {
 	public:
@@ -6933,6 +7208,11 @@ class HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter : public Intf_Polygon2d {
 };
 
 
+%extend HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_ThePolygonOfInterCSurf;
 class HLRBRep_ThePolygonOfInterCSurf {
 	public:
@@ -7027,6 +7307,11 @@ class HLRBRep_ThePolygonOfInterCSurf {
 };
 
 
+%extend HLRBRep_ThePolygonOfInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_ThePolygonToolOfInterCSurf {
 	public:
 		%feature("compactdefaultargs") Bounding;
@@ -7078,6 +7363,11 @@ class HLRBRep_ThePolygonToolOfInterCSurf {
 };
 
 
+%extend HLRBRep_ThePolygonToolOfInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_ThePolyhedronToolOfInterCSurf {
 	public:
 		%feature("compactdefaultargs") Bounding;
@@ -7167,6 +7457,11 @@ class HLRBRep_ThePolyhedronToolOfInterCSurf {
 };
 
 
+%extend HLRBRep_ThePolyhedronToolOfInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRBRep_TheProjPCurOfCInter {
 	public:
 		%feature("compactdefaultargs") FindParameter;
@@ -7196,6 +7491,11 @@ class HLRBRep_TheProjPCurOfCInter {
 };
 
 
+%extend HLRBRep_TheProjPCurOfCInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheQuadCurvExactInterCSurf;
 class HLRBRep_TheQuadCurvExactInterCSurf {
 	public:
@@ -7238,6 +7538,11 @@ class HLRBRep_TheQuadCurvExactInterCSurf {
 };
 
 
+%extend HLRBRep_TheQuadCurvExactInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf;
 class HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf : public math_FunctionWithDerivative {
 	public:
@@ -7278,6 +7583,11 @@ class HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf : public math_Function
 };
 
 
+%extend HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_VertexList;
 class HLRBRep_VertexList {
 	public:
@@ -7346,6 +7656,11 @@ class HLRBRep_VertexList {
 };
 
 
+%extend HLRBRep_VertexList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRBRep_Algo;
 class HLRBRep_Algo : public HLRBRep_InternalAlgo {
 	public:
@@ -7446,3 +7761,8 @@ class Handle_HLRBRep_Algo : public Handle_HLRBRep_InternalAlgo {
     }
 };
 
+%extend HLRBRep_Algo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/HLRTopoBRep.i
+++ b/src/SWIG_files/wrapper/HLRTopoBRep.i
@@ -77,6 +77,11 @@ class HLRTopoBRep_DSFiller {
 };
 
 
+%extend HLRTopoBRep_DSFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_Data;
 class HLRTopoBRep_Data {
 	public:
@@ -319,6 +324,11 @@ class HLRTopoBRep_Data {
 };
 
 
+%extend HLRTopoBRep_Data {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_DataMapIteratorOfDataMapOfShapeFaceData;
 class HLRTopoBRep_DataMapIteratorOfDataMapOfShapeFaceData : public TCollection_BasicMapIterator {
 	public:
@@ -349,6 +359,11 @@ class HLRTopoBRep_DataMapIteratorOfDataMapOfShapeFaceData : public TCollection_B
 };
 
 
+%extend HLRTopoBRep_DataMapIteratorOfDataMapOfShapeFaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_DataMapIteratorOfMapOfShapeListOfVData;
 class HLRTopoBRep_DataMapIteratorOfMapOfShapeListOfVData : public TCollection_BasicMapIterator {
 	public:
@@ -379,6 +394,11 @@ class HLRTopoBRep_DataMapIteratorOfMapOfShapeListOfVData : public TCollection_Ba
 };
 
 
+%extend HLRTopoBRep_DataMapIteratorOfMapOfShapeListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_DataMapNodeOfDataMapOfShapeFaceData;
 class HLRTopoBRep_DataMapNodeOfDataMapOfShapeFaceData : public TCollection_MapNode {
 	public:
@@ -449,6 +469,11 @@ class Handle_HLRTopoBRep_DataMapNodeOfDataMapOfShapeFaceData : public Handle_TCo
     }
 };
 
+%extend HLRTopoBRep_DataMapNodeOfDataMapOfShapeFaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_DataMapNodeOfMapOfShapeListOfVData;
 class HLRTopoBRep_DataMapNodeOfMapOfShapeListOfVData : public TCollection_MapNode {
 	public:
@@ -519,6 +544,11 @@ class Handle_HLRTopoBRep_DataMapNodeOfMapOfShapeListOfVData : public Handle_TCol
     }
 };
 
+%extend HLRTopoBRep_DataMapNodeOfMapOfShapeListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_DataMapOfShapeFaceData;
 class HLRTopoBRep_DataMapOfShapeFaceData : public TCollection_BasicMap {
 	public:
@@ -597,6 +627,11 @@ class HLRTopoBRep_DataMapOfShapeFaceData : public TCollection_BasicMap {
 };
 
 
+%extend HLRTopoBRep_DataMapOfShapeFaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_FaceData;
 class HLRTopoBRep_FaceData {
 	public:
@@ -631,6 +666,11 @@ class HLRTopoBRep_FaceData {
 };
 
 
+%extend HLRTopoBRep_FaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class HLRTopoBRep_FaceIsoLiner {
 	public:
 		%feature("compactdefaultargs") Perform;
@@ -682,6 +722,11 @@ class HLRTopoBRep_FaceIsoLiner {
 };
 
 
+%extend HLRTopoBRep_FaceIsoLiner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_ListIteratorOfListOfVData;
 class HLRTopoBRep_ListIteratorOfListOfVData {
 	public:
@@ -716,6 +761,11 @@ class HLRTopoBRep_ListIteratorOfListOfVData {
 };
 
 
+%extend HLRTopoBRep_ListIteratorOfListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_ListNodeOfListOfVData;
 class HLRTopoBRep_ListNodeOfListOfVData : public TCollection_MapNode {
 	public:
@@ -780,6 +830,11 @@ class Handle_HLRTopoBRep_ListNodeOfListOfVData : public Handle_TCollection_MapNo
     }
 };
 
+%extend HLRTopoBRep_ListNodeOfListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_ListOfVData;
 class HLRTopoBRep_ListOfVData {
 	public:
@@ -910,6 +965,11 @@ class HLRTopoBRep_ListOfVData {
 };
 
 
+%extend HLRTopoBRep_ListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_MapOfShapeListOfVData;
 class HLRTopoBRep_MapOfShapeListOfVData : public TCollection_BasicMap {
 	public:
@@ -988,6 +1048,11 @@ class HLRTopoBRep_MapOfShapeListOfVData : public TCollection_BasicMap {
 };
 
 
+%extend HLRTopoBRep_MapOfShapeListOfVData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_OutLiner;
 class HLRTopoBRep_OutLiner : public MMgt_TShared {
 	public:
@@ -1092,6 +1157,11 @@ class Handle_HLRTopoBRep_OutLiner : public Handle_MMgt_TShared {
     }
 };
 
+%extend HLRTopoBRep_OutLiner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HLRTopoBRep_VData;
 class HLRTopoBRep_VData {
 	public:
@@ -1118,3 +1188,8 @@ class HLRTopoBRep_VData {
 };
 
 
+%extend HLRTopoBRep_VData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Hatch.i
+++ b/src/SWIG_files/wrapper/Hatch.i
@@ -268,6 +268,11 @@ class Hatch_Hatcher {
 };
 
 
+%extend Hatch_Hatcher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_Line;
 class Hatch_Line {
 	public:
@@ -302,6 +307,11 @@ class Hatch_Line {
 };
 
 
+%extend Hatch_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_Parameter;
 class Hatch_Parameter {
 	public:
@@ -324,6 +334,11 @@ class Hatch_Parameter {
 };
 
 
+%extend Hatch_Parameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_SequenceNodeOfSequenceOfLine;
 class Hatch_SequenceNodeOfSequenceOfLine : public TCollection_SeqNode {
 	public:
@@ -390,6 +405,11 @@ class Handle_Hatch_SequenceNodeOfSequenceOfLine : public Handle_TCollection_SeqN
     }
 };
 
+%extend Hatch_SequenceNodeOfSequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_SequenceNodeOfSequenceOfParameter;
 class Hatch_SequenceNodeOfSequenceOfParameter : public TCollection_SeqNode {
 	public:
@@ -456,6 +476,11 @@ class Handle_Hatch_SequenceNodeOfSequenceOfParameter : public Handle_TCollection
     }
 };
 
+%extend Hatch_SequenceNodeOfSequenceOfParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_SequenceOfLine;
 class Hatch_SequenceOfLine : public TCollection_BaseSequence {
 	public:
@@ -594,6 +619,11 @@ class Hatch_SequenceOfLine : public TCollection_BaseSequence {
 };
 
 
+%extend Hatch_SequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Hatch_SequenceOfParameter;
 class Hatch_SequenceOfParameter : public TCollection_BaseSequence {
 	public:
@@ -732,3 +762,8 @@ class Hatch_SequenceOfParameter : public TCollection_BaseSequence {
 };
 
 
+%extend Hatch_SequenceOfParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/HatchGen.i
+++ b/src/SWIG_files/wrapper/HatchGen.i
@@ -179,6 +179,11 @@ class HatchGen_Domain {
 };
 
 
+%extend HatchGen_Domain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_Domains;
 class HatchGen_Domains : public TCollection_BaseSequence {
 	public:
@@ -317,6 +322,11 @@ class HatchGen_Domains : public TCollection_BaseSequence {
 };
 
 
+%extend HatchGen_Domains {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_IntersectionPoint;
 class HatchGen_IntersectionPoint {
 	public:
@@ -429,6 +439,11 @@ class HatchGen_IntersectionPoint {
 };
 
 
+%extend HatchGen_IntersectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_PointsOnElement;
 class HatchGen_PointsOnElement : public TCollection_BaseSequence {
 	public:
@@ -567,6 +582,11 @@ class HatchGen_PointsOnElement : public TCollection_BaseSequence {
 };
 
 
+%extend HatchGen_PointsOnElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_PointsOnHatching;
 class HatchGen_PointsOnHatching : public TCollection_BaseSequence {
 	public:
@@ -705,6 +725,11 @@ class HatchGen_PointsOnHatching : public TCollection_BaseSequence {
 };
 
 
+%extend HatchGen_PointsOnHatching {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_SequenceNodeOfDomains;
 class HatchGen_SequenceNodeOfDomains : public TCollection_SeqNode {
 	public:
@@ -771,6 +796,11 @@ class Handle_HatchGen_SequenceNodeOfDomains : public Handle_TCollection_SeqNode 
     }
 };
 
+%extend HatchGen_SequenceNodeOfDomains {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_SequenceNodeOfPointsOnElement;
 class HatchGen_SequenceNodeOfPointsOnElement : public TCollection_SeqNode {
 	public:
@@ -837,6 +867,11 @@ class Handle_HatchGen_SequenceNodeOfPointsOnElement : public Handle_TCollection_
     }
 };
 
+%extend HatchGen_SequenceNodeOfPointsOnElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_SequenceNodeOfPointsOnHatching;
 class HatchGen_SequenceNodeOfPointsOnHatching : public TCollection_SeqNode {
 	public:
@@ -903,6 +938,11 @@ class Handle_HatchGen_SequenceNodeOfPointsOnHatching : public Handle_TCollection
     }
 };
 
+%extend HatchGen_SequenceNodeOfPointsOnHatching {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_PointOnElement;
 class HatchGen_PointOnElement : public HatchGen_IntersectionPoint {
 	public:
@@ -973,6 +1013,11 @@ class HatchGen_PointOnElement : public HatchGen_IntersectionPoint {
 };
 
 
+%extend HatchGen_PointOnElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor HatchGen_PointOnHatching;
 class HatchGen_PointOnHatching : public HatchGen_IntersectionPoint {
 	public:
@@ -1083,3 +1128,8 @@ class HatchGen_PointOnHatching : public HatchGen_IntersectionPoint {
 };
 
 
+%extend HatchGen_PointOnHatching {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Hermit.i
+++ b/src/SWIG_files/wrapper/Hermit.i
@@ -102,3 +102,8 @@ class Hermit {
 };
 
 
+%extend Hermit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IFSelect.i
+++ b/src/SWIG_files/wrapper/IFSelect.i
@@ -128,6 +128,11 @@ class IFSelect {
 };
 
 
+%extend IFSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Activator;
 class IFSelect_Activator : public MMgt_TShared {
 	public:
@@ -316,6 +321,11 @@ class Handle_IFSelect_Activator : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_Activator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_AppliedModifiers;
 class IFSelect_AppliedModifiers : public MMgt_TShared {
 	public:
@@ -432,6 +442,11 @@ class Handle_IFSelect_AppliedModifiers : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_AppliedModifiers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ContextModif;
 class IFSelect_ContextModif {
 	public:
@@ -658,6 +673,11 @@ class IFSelect_ContextModif {
 };
 
 
+%extend IFSelect_ContextModif {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ContextWrite;
 class IFSelect_ContextWrite {
 	public:
@@ -838,6 +858,11 @@ class IFSelect_ContextWrite {
 };
 
 
+%extend IFSelect_ContextWrite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Dispatch;
 class IFSelect_Dispatch : public MMgt_TShared {
 	public:
@@ -996,6 +1021,11 @@ class Handle_IFSelect_Dispatch : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_Dispatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_EditForm;
 class IFSelect_EditForm : public MMgt_TShared {
 	public:
@@ -1401,6 +1431,11 @@ class Handle_IFSelect_EditForm : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_EditForm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Editor;
 class IFSelect_Editor : public MMgt_TShared {
 	public:
@@ -1659,6 +1694,11 @@ class Handle_IFSelect_Editor : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_Editor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IFSelect_Functions {
 	public:
 		%feature("compactdefaultargs") GiveEntity;
@@ -1714,6 +1754,11 @@ class IFSelect_Functions {
 };
 
 
+%extend IFSelect_Functions {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_GeneralModifier;
 class IFSelect_GeneralModifier : public MMgt_TShared {
 	public:
@@ -1826,6 +1871,11 @@ class Handle_IFSelect_GeneralModifier : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_GeneralModifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_HSeqOfSelection;
 class IFSelect_HSeqOfSelection : public MMgt_TShared {
 	public:
@@ -2010,6 +2060,11 @@ class Handle_IFSelect_HSeqOfSelection : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_HSeqOfSelection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_IntParam;
 class IFSelect_IntParam : public MMgt_TShared {
 	public:
@@ -2090,6 +2145,11 @@ class Handle_IFSelect_IntParam : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_IntParam {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ListEditor;
 class IFSelect_ListEditor : public MMgt_TShared {
 	public:
@@ -2284,6 +2344,11 @@ class Handle_IFSelect_ListEditor : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_ListEditor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ModelCopier;
 class IFSelect_ModelCopier : public MMgt_TShared {
 	public:
@@ -2542,6 +2607,11 @@ class Handle_IFSelect_ModelCopier : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_ModelCopier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_PacketList;
 class IFSelect_PacketList : public MMgt_TShared {
 	public:
@@ -2692,6 +2762,11 @@ class Handle_IFSelect_PacketList : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_PacketList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Selection;
 class IFSelect_Selection : public MMgt_TShared {
 	public:
@@ -2782,6 +2857,11 @@ class Handle_IFSelect_Selection : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_Selection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectionIterator;
 class IFSelect_SelectionIterator {
 	public:
@@ -2844,6 +2924,11 @@ class IFSelect_SelectionIterator {
 };
 
 
+%extend IFSelect_SelectionIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceNodeOfSequenceOfAppliedModifiers;
 class IFSelect_SequenceNodeOfSequenceOfAppliedModifiers : public TCollection_SeqNode {
 	public:
@@ -2910,6 +2995,11 @@ class Handle_IFSelect_SequenceNodeOfSequenceOfAppliedModifiers : public Handle_T
     }
 };
 
+%extend IFSelect_SequenceNodeOfSequenceOfAppliedModifiers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceNodeOfSequenceOfGeneralModifier;
 class IFSelect_SequenceNodeOfSequenceOfGeneralModifier : public TCollection_SeqNode {
 	public:
@@ -2976,6 +3066,11 @@ class Handle_IFSelect_SequenceNodeOfSequenceOfGeneralModifier : public Handle_TC
     }
 };
 
+%extend IFSelect_SequenceNodeOfSequenceOfGeneralModifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceNodeOfSequenceOfInterfaceModel;
 class IFSelect_SequenceNodeOfSequenceOfInterfaceModel : public TCollection_SeqNode {
 	public:
@@ -3042,6 +3137,11 @@ class Handle_IFSelect_SequenceNodeOfSequenceOfInterfaceModel : public Handle_TCo
     }
 };
 
+%extend IFSelect_SequenceNodeOfSequenceOfInterfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceNodeOfTSeqOfDispatch;
 class IFSelect_SequenceNodeOfTSeqOfDispatch : public TCollection_SeqNode {
 	public:
@@ -3108,6 +3208,11 @@ class Handle_IFSelect_SequenceNodeOfTSeqOfDispatch : public Handle_TCollection_S
     }
 };
 
+%extend IFSelect_SequenceNodeOfTSeqOfDispatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceNodeOfTSeqOfSelection;
 class IFSelect_SequenceNodeOfTSeqOfSelection : public TCollection_SeqNode {
 	public:
@@ -3174,6 +3279,11 @@ class Handle_IFSelect_SequenceNodeOfTSeqOfSelection : public Handle_TCollection_
     }
 };
 
+%extend IFSelect_SequenceNodeOfTSeqOfSelection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceOfAppliedModifiers;
 class IFSelect_SequenceOfAppliedModifiers : public TCollection_BaseSequence {
 	public:
@@ -3312,6 +3422,11 @@ class IFSelect_SequenceOfAppliedModifiers : public TCollection_BaseSequence {
 };
 
 
+%extend IFSelect_SequenceOfAppliedModifiers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceOfGeneralModifier;
 class IFSelect_SequenceOfGeneralModifier : public TCollection_BaseSequence {
 	public:
@@ -3450,6 +3565,11 @@ class IFSelect_SequenceOfGeneralModifier : public TCollection_BaseSequence {
 };
 
 
+%extend IFSelect_SequenceOfGeneralModifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SequenceOfInterfaceModel;
 class IFSelect_SequenceOfInterfaceModel : public TCollection_BaseSequence {
 	public:
@@ -3588,6 +3708,11 @@ class IFSelect_SequenceOfInterfaceModel : public TCollection_BaseSequence {
 };
 
 
+%extend IFSelect_SequenceOfInterfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SessionDumper;
 class IFSelect_SessionDumper : public MMgt_TShared {
 	public:
@@ -3674,6 +3799,11 @@ class Handle_IFSelect_SessionDumper : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_SessionDumper {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SessionFile;
 class IFSelect_SessionFile {
 	public:
@@ -3958,6 +4088,11 @@ class IFSelect_SessionFile {
 };
 
 
+%extend IFSelect_SessionFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ShareOut;
 class IFSelect_ShareOut : public MMgt_TShared {
 	public:
@@ -4270,6 +4405,11 @@ class Handle_IFSelect_ShareOut : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_ShareOut {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ShareOutResult;
 class IFSelect_ShareOutResult {
 	public:
@@ -4418,6 +4558,11 @@ class IFSelect_ShareOutResult {
 };
 
 
+%extend IFSelect_ShareOutResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Signature;
 class IFSelect_Signature : public Interface_SignType {
 	public:
@@ -4558,6 +4703,11 @@ class Handle_IFSelect_Signature : public Handle_Interface_SignType {
     }
 };
 
+%extend IFSelect_Signature {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignatureList;
 class IFSelect_SignatureList : public MMgt_TShared {
 	public:
@@ -4751,6 +4901,11 @@ class Handle_IFSelect_SignatureList : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_SignatureList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_TSeqOfDispatch;
 class IFSelect_TSeqOfDispatch : public TCollection_BaseSequence {
 	public:
@@ -4889,6 +5044,11 @@ class IFSelect_TSeqOfDispatch : public TCollection_BaseSequence {
 };
 
 
+%extend IFSelect_TSeqOfDispatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_TSeqOfSelection;
 class IFSelect_TSeqOfSelection : public TCollection_BaseSequence {
 	public:
@@ -5027,6 +5187,11 @@ class IFSelect_TSeqOfSelection : public TCollection_BaseSequence {
 };
 
 
+%extend IFSelect_TSeqOfSelection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Transformer;
 class IFSelect_Transformer : public MMgt_TShared {
 	public:
@@ -5117,6 +5282,11 @@ class Handle_IFSelect_Transformer : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_Transformer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_WorkLibrary;
 class IFSelect_WorkLibrary : public Standard_Transient {
 	public:
@@ -5271,6 +5441,11 @@ class Handle_IFSelect_WorkLibrary : public Handle_Standard_Transient {
     }
 };
 
+%extend IFSelect_WorkLibrary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_WorkSession;
 class IFSelect_WorkSession : public MMgt_TShared {
 	public:
@@ -6675,6 +6850,11 @@ class Handle_IFSelect_WorkSession : public Handle_MMgt_TShared {
     }
 };
 
+%extend IFSelect_WorkSession {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Act;
 class IFSelect_Act : public IFSelect_Activator {
 	public:
@@ -6791,6 +6971,11 @@ class Handle_IFSelect_Act : public Handle_IFSelect_Activator {
     }
 };
 
+%extend IFSelect_Act {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_BasicDumper;
 class IFSelect_BasicDumper : public IFSelect_SessionDumper {
 	public:
@@ -6871,6 +7056,11 @@ class Handle_IFSelect_BasicDumper : public Handle_IFSelect_SessionDumper {
     }
 };
 
+%extend IFSelect_BasicDumper {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_CheckCounter;
 class IFSelect_CheckCounter : public IFSelect_SignatureList {
 	public:
@@ -6959,6 +7149,11 @@ class Handle_IFSelect_CheckCounter : public Handle_IFSelect_SignatureList {
     }
 };
 
+%extend IFSelect_CheckCounter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_DispGlobal;
 class IFSelect_DispGlobal : public IFSelect_Dispatch {
 	public:
@@ -7053,6 +7248,11 @@ class Handle_IFSelect_DispGlobal : public Handle_IFSelect_Dispatch {
     }
 };
 
+%extend IFSelect_DispGlobal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_DispPerCount;
 class IFSelect_DispPerCount : public IFSelect_Dispatch {
 	public:
@@ -7167,6 +7367,11 @@ class Handle_IFSelect_DispPerCount : public Handle_IFSelect_Dispatch {
     }
 };
 
+%extend IFSelect_DispPerCount {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_DispPerFiles;
 class IFSelect_DispPerFiles : public IFSelect_Dispatch {
 	public:
@@ -7281,6 +7486,11 @@ class Handle_IFSelect_DispPerFiles : public Handle_IFSelect_Dispatch {
     }
 };
 
+%extend IFSelect_DispPerFiles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_DispPerOne;
 class IFSelect_DispPerOne : public IFSelect_Dispatch {
 	public:
@@ -7375,6 +7585,11 @@ class Handle_IFSelect_DispPerOne : public Handle_IFSelect_Dispatch {
     }
 };
 
+%extend IFSelect_DispPerOne {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_DispPerSignature;
 class IFSelect_DispPerSignature : public IFSelect_Dispatch {
 	public:
@@ -7479,6 +7694,11 @@ class Handle_IFSelect_DispPerSignature : public Handle_IFSelect_Dispatch {
     }
 };
 
+%extend IFSelect_DispPerSignature {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_Modifier;
 class IFSelect_Modifier : public IFSelect_GeneralModifier {
 	public:
@@ -7545,6 +7765,11 @@ class Handle_IFSelect_Modifier : public Handle_IFSelect_GeneralModifier {
     }
 };
 
+%extend IFSelect_Modifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ParamEditor;
 class IFSelect_ParamEditor : public IFSelect_Editor {
 	public:
@@ -7677,6 +7902,11 @@ class Handle_IFSelect_ParamEditor : public Handle_IFSelect_Editor {
     }
 };
 
+%extend IFSelect_ParamEditor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectBase;
 class IFSelect_SelectBase : public IFSelect_Selection {
 	public:
@@ -7737,6 +7967,11 @@ class Handle_IFSelect_SelectBase : public Handle_IFSelect_Selection {
     }
 };
 
+%extend IFSelect_SelectBase {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectCombine;
 class IFSelect_SelectCombine : public IFSelect_Selection {
 	public:
@@ -7845,6 +8080,11 @@ class Handle_IFSelect_SelectCombine : public Handle_IFSelect_Selection {
     }
 };
 
+%extend IFSelect_SelectCombine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectControl;
 class IFSelect_SelectControl : public IFSelect_Selection {
 	public:
@@ -7939,6 +8179,11 @@ class Handle_IFSelect_SelectControl : public Handle_IFSelect_Selection {
     }
 };
 
+%extend IFSelect_SelectControl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectDeduct;
 class IFSelect_SelectDeduct : public IFSelect_Selection {
 	public:
@@ -8039,6 +8284,11 @@ class Handle_IFSelect_SelectDeduct : public Handle_IFSelect_Selection {
     }
 };
 
+%extend IFSelect_SelectDeduct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SessionPilot;
 class IFSelect_SessionPilot : public IFSelect_Activator {
 	public:
@@ -8295,6 +8545,11 @@ class Handle_IFSelect_SessionPilot : public Handle_IFSelect_Activator {
     }
 };
 
+%extend IFSelect_SessionPilot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignCategory;
 class IFSelect_SignCategory : public IFSelect_Signature {
 	public:
@@ -8363,6 +8618,11 @@ class Handle_IFSelect_SignCategory : public Handle_IFSelect_Signature {
     }
 };
 
+%extend IFSelect_SignCategory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignCounter;
 class IFSelect_SignCounter : public IFSelect_SignatureList {
 	public:
@@ -8567,6 +8827,11 @@ class Handle_IFSelect_SignCounter : public Handle_IFSelect_SignatureList {
     }
 };
 
+%extend IFSelect_SignCounter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignMultiple;
 class IFSelect_SignMultiple : public IFSelect_Signature {
 	public:
@@ -8663,6 +8928,11 @@ class Handle_IFSelect_SignMultiple : public Handle_IFSelect_Signature {
     }
 };
 
+%extend IFSelect_SignMultiple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignType;
 class IFSelect_SignType : public IFSelect_Signature {
 	public:
@@ -8733,6 +9003,11 @@ class Handle_IFSelect_SignType : public Handle_IFSelect_Signature {
     }
 };
 
+%extend IFSelect_SignType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignValidity;
 class IFSelect_SignValidity : public IFSelect_Signature {
 	public:
@@ -8811,6 +9086,11 @@ class Handle_IFSelect_SignValidity : public Handle_IFSelect_Signature {
     }
 };
 
+%extend IFSelect_SignValidity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_TransformStandard;
 class IFSelect_TransformStandard : public IFSelect_Transformer {
 	public:
@@ -9027,6 +9307,11 @@ class Handle_IFSelect_TransformStandard : public Handle_IFSelect_Transformer {
     }
 };
 
+%extend IFSelect_TransformStandard {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_GraphCounter;
 class IFSelect_GraphCounter : public IFSelect_SignCounter {
 	public:
@@ -9113,6 +9398,11 @@ class Handle_IFSelect_GraphCounter : public Handle_IFSelect_SignCounter {
     }
 };
 
+%extend IFSelect_GraphCounter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ModifEditForm;
 class IFSelect_ModifEditForm : public IFSelect_Modifier {
 	public:
@@ -9199,6 +9489,11 @@ class Handle_IFSelect_ModifEditForm : public Handle_IFSelect_Modifier {
     }
 };
 
+%extend IFSelect_ModifEditForm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_ModifReorder;
 class IFSelect_ModifReorder : public IFSelect_Modifier {
 	public:
@@ -9279,6 +9574,11 @@ class Handle_IFSelect_ModifReorder : public Handle_IFSelect_Modifier {
     }
 };
 
+%extend IFSelect_ModifReorder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectAnyList;
 class IFSelect_SelectAnyList : public IFSelect_SelectDeduct {
 	public:
@@ -9451,6 +9751,11 @@ class Handle_IFSelect_SelectAnyList : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectAnyList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectDiff;
 class IFSelect_SelectDiff : public IFSelect_SelectControl {
 	public:
@@ -9523,6 +9828,11 @@ class Handle_IFSelect_SelectDiff : public Handle_IFSelect_SelectControl {
     }
 };
 
+%extend IFSelect_SelectDiff {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectEntityNumber;
 class IFSelect_SelectEntityNumber : public IFSelect_SelectBase {
 	public:
@@ -9609,6 +9919,11 @@ class Handle_IFSelect_SelectEntityNumber : public Handle_IFSelect_SelectBase {
     }
 };
 
+%extend IFSelect_SelectEntityNumber {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectExplore;
 class IFSelect_SelectExplore : public IFSelect_SelectDeduct {
 	public:
@@ -9701,6 +10016,11 @@ class Handle_IFSelect_SelectExplore : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectExplore {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectExtract;
 class IFSelect_SelectExtract : public IFSelect_SelectDeduct {
 	public:
@@ -9811,6 +10131,11 @@ class Handle_IFSelect_SelectExtract : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectExtract {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectIntersection;
 class IFSelect_SelectIntersection : public IFSelect_SelectCombine {
 	public:
@@ -9883,6 +10208,11 @@ class Handle_IFSelect_SelectIntersection : public Handle_IFSelect_SelectCombine 
     }
 };
 
+%extend IFSelect_SelectIntersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectModelEntities;
 class IFSelect_SelectModelEntities : public IFSelect_SelectBase {
 	public:
@@ -9963,6 +10293,11 @@ class Handle_IFSelect_SelectModelEntities : public Handle_IFSelect_SelectBase {
     }
 };
 
+%extend IFSelect_SelectModelEntities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectModelRoots;
 class IFSelect_SelectModelRoots : public IFSelect_SelectBase {
 	public:
@@ -10035,6 +10370,11 @@ class Handle_IFSelect_SelectModelRoots : public Handle_IFSelect_SelectBase {
     }
 };
 
+%extend IFSelect_SelectModelRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectPointed;
 class IFSelect_SelectPointed : public IFSelect_SelectBase {
 	public:
@@ -10221,6 +10561,11 @@ class Handle_IFSelect_SelectPointed : public Handle_IFSelect_SelectBase {
     }
 };
 
+%extend IFSelect_SelectPointed {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectShared;
 class IFSelect_SelectShared : public IFSelect_SelectDeduct {
 	public:
@@ -10293,6 +10638,11 @@ class Handle_IFSelect_SelectShared : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectShared {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSharing;
 class IFSelect_SelectSharing : public IFSelect_SelectDeduct {
 	public:
@@ -10365,6 +10715,11 @@ class Handle_IFSelect_SelectSharing : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectSharing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSuite;
 class IFSelect_SelectSuite : public IFSelect_SelectDeduct {
 	public:
@@ -10483,6 +10838,11 @@ class Handle_IFSelect_SelectSuite : public Handle_IFSelect_SelectDeduct {
     }
 };
 
+%extend IFSelect_SelectSuite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectUnion;
 class IFSelect_SelectUnion : public IFSelect_SelectCombine {
 	public:
@@ -10555,6 +10915,11 @@ class Handle_IFSelect_SelectUnion : public Handle_IFSelect_SelectCombine {
     }
 };
 
+%extend IFSelect_SelectUnion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SignAncestor;
 class IFSelect_SignAncestor : public IFSelect_SignType {
 	public:
@@ -10625,6 +10990,11 @@ class Handle_IFSelect_SignAncestor : public Handle_IFSelect_SignType {
     }
 };
 
+%extend IFSelect_SignAncestor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectAnyType;
 class IFSelect_SelectAnyType : public IFSelect_SelectExtract {
 	public:
@@ -10695,6 +11065,11 @@ class Handle_IFSelect_SelectAnyType : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectAnyType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectErrorEntities;
 class IFSelect_SelectErrorEntities : public IFSelect_SelectExtract {
 	public:
@@ -10771,6 +11146,11 @@ class Handle_IFSelect_SelectErrorEntities : public Handle_IFSelect_SelectExtract
     }
 };
 
+%extend IFSelect_SelectErrorEntities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectFlag;
 class IFSelect_SelectFlag : public IFSelect_SelectExtract {
 	public:
@@ -10863,6 +11243,11 @@ class Handle_IFSelect_SelectFlag : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectFlag {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectInList;
 class IFSelect_SelectInList : public IFSelect_SelectAnyList {
 	public:
@@ -10939,6 +11324,11 @@ class Handle_IFSelect_SelectInList : public Handle_IFSelect_SelectAnyList {
     }
 };
 
+%extend IFSelect_SelectInList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectRange;
 class IFSelect_SelectRange : public IFSelect_SelectExtract {
 	public:
@@ -11085,6 +11475,11 @@ class Handle_IFSelect_SelectRange : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectRootComps;
 class IFSelect_SelectRootComps : public IFSelect_SelectExtract {
 	public:
@@ -11169,6 +11564,11 @@ class Handle_IFSelect_SelectRootComps : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectRootComps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectRoots;
 class IFSelect_SelectRoots : public IFSelect_SelectExtract {
 	public:
@@ -11253,6 +11653,11 @@ class Handle_IFSelect_SelectRoots : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSent;
 class IFSelect_SelectSent : public IFSelect_SelectExtract {
 	public:
@@ -11353,6 +11758,11 @@ class Handle_IFSelect_SelectSent : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectSent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSignature;
 class IFSelect_SelectSignature : public IFSelect_SelectExtract {
 	public:
@@ -11495,6 +11905,11 @@ class Handle_IFSelect_SelectSignature : public Handle_IFSelect_SelectExtract {
     }
 };
 
+%extend IFSelect_SelectSignature {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSignedShared;
 class IFSelect_SelectSignedShared : public IFSelect_SelectExplore {
 	public:
@@ -11599,6 +12014,11 @@ class Handle_IFSelect_SelectSignedShared : public Handle_IFSelect_SelectExplore 
     }
 };
 
+%extend IFSelect_SelectSignedShared {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectSignedSharing;
 class IFSelect_SelectSignedSharing : public IFSelect_SelectExplore {
 	public:
@@ -11703,6 +12123,11 @@ class Handle_IFSelect_SelectSignedSharing : public Handle_IFSelect_SelectExplore
     }
 };
 
+%extend IFSelect_SelectSignedSharing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectUnknownEntities;
 class IFSelect_SelectUnknownEntities : public IFSelect_SelectExtract {
 	public:
@@ -11779,6 +12204,11 @@ class Handle_IFSelect_SelectUnknownEntities : public Handle_IFSelect_SelectExtra
     }
 };
 
+%extend IFSelect_SelectUnknownEntities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectIncorrectEntities;
 class IFSelect_SelectIncorrectEntities : public IFSelect_SelectFlag {
 	public:
@@ -11837,6 +12267,11 @@ class Handle_IFSelect_SelectIncorrectEntities : public Handle_IFSelect_SelectFla
     }
 };
 
+%extend IFSelect_SelectIncorrectEntities {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IFSelect_SelectType;
 class IFSelect_SelectType : public IFSelect_SelectAnyType {
 	public:
@@ -11923,3 +12358,8 @@ class Handle_IFSelect_SelectType : public Handle_IFSelect_SelectAnyType {
     }
 };
 
+%extend IFSelect_SelectType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IGESCAFControl.i
+++ b/src/SWIG_files/wrapper/IGESCAFControl.i
@@ -78,6 +78,11 @@ class IGESCAFControl {
 };
 
 
+%extend IGESCAFControl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESCAFControl_Reader;
 class IGESCAFControl_Reader : public IGESControl_Reader {
 	public:
@@ -162,6 +167,11 @@ class IGESCAFControl_Reader : public IGESControl_Reader {
 };
 
 
+%extend IGESCAFControl_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESCAFControl_Writer;
 class IGESCAFControl_Writer : public IGESControl_Writer {
 	public:
@@ -246,3 +256,8 @@ class IGESCAFControl_Writer : public IGESControl_Writer {
 };
 
 
+%extend IGESCAFControl_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IGESControl.i
+++ b/src/SWIG_files/wrapper/IGESControl.i
@@ -130,6 +130,11 @@ class Handle_IGESControl_ActorWrite : public Handle_Transfer_ActorOfFinderProces
     }
 };
 
+%extend IGESControl_ActorWrite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_AlgoContainer;
 class IGESControl_AlgoContainer : public IGESToBRep_AlgoContainer {
 	public:
@@ -188,6 +193,11 @@ class Handle_IGESControl_AlgoContainer : public Handle_IGESToBRep_AlgoContainer 
     }
 };
 
+%extend IGESControl_AlgoContainer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_Controller;
 class IGESControl_Controller : public XSControl_Controller {
 	public:
@@ -288,6 +298,11 @@ class Handle_IGESControl_Controller : public Handle_XSControl_Controller {
     }
 };
 
+%extend IGESControl_Controller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_IGESBoundary;
 class IGESControl_IGESBoundary : public IGESToBRep_IGESBoundary {
 	public:
@@ -368,6 +383,11 @@ class Handle_IGESControl_IGESBoundary : public Handle_IGESToBRep_IGESBoundary {
     }
 };
 
+%extend IGESControl_IGESBoundary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_Reader;
 class IGESControl_Reader : public XSControl_Reader {
 	public:
@@ -424,6 +444,11 @@ class IGESControl_Reader : public XSControl_Reader {
 };
 
 
+%extend IGESControl_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_ToolContainer;
 class IGESControl_ToolContainer : public IGESToBRep_ToolContainer {
 	public:
@@ -488,6 +513,11 @@ class Handle_IGESControl_ToolContainer : public Handle_IGESToBRep_ToolContainer 
     }
 };
 
+%extend IGESControl_ToolContainer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IGESControl_Writer;
 class IGESControl_Writer {
 	public:
@@ -598,3 +628,8 @@ class IGESControl_Writer {
 };
 
 
+%extend IGESControl_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntAna.i
+++ b/src/SWIG_files/wrapper/IntAna.i
@@ -269,6 +269,11 @@ class IntAna_Curve {
 };
 
 
+%extend IntAna_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_Int3Pln;
 class IntAna_Int3Pln {
 	public:
@@ -321,6 +326,11 @@ class IntAna_Int3Pln {
 };
 
 
+%extend IntAna_Int3Pln {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_IntConicQuad;
 class IntAna_IntConicQuad {
 	public:
@@ -609,6 +619,11 @@ class IntAna_IntConicQuad {
 };
 
 
+%extend IntAna_IntConicQuad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_IntLinTorus;
 class IntAna_IntLinTorus {
 	public:
@@ -679,6 +694,11 @@ class IntAna_IntLinTorus {
 };
 
 
+%extend IntAna_IntLinTorus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_IntQuadQuad;
 class IntAna_IntQuadQuad {
 	public:
@@ -827,6 +847,11 @@ class IntAna_IntQuadQuad {
 };
 
 
+%extend IntAna_IntQuadQuad {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_ListIteratorOfListOfCurve;
 class IntAna_ListIteratorOfListOfCurve {
 	public:
@@ -861,6 +886,11 @@ class IntAna_ListIteratorOfListOfCurve {
 };
 
 
+%extend IntAna_ListIteratorOfListOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_ListNodeOfListOfCurve;
 class IntAna_ListNodeOfListOfCurve : public TCollection_MapNode {
 	public:
@@ -925,6 +955,11 @@ class Handle_IntAna_ListNodeOfListOfCurve : public Handle_TCollection_MapNode {
     }
 };
 
+%extend IntAna_ListNodeOfListOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_ListOfCurve;
 class IntAna_ListOfCurve {
 	public:
@@ -1055,6 +1090,11 @@ class IntAna_ListOfCurve {
 };
 
 
+%extend IntAna_ListOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_QuadQuadGeo;
 class IntAna_QuadQuadGeo {
 	public:
@@ -1513,6 +1553,11 @@ class IntAna_QuadQuadGeo {
 };
 
 
+%extend IntAna_QuadQuadGeo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna_Quadric;
 class IntAna_Quadric {
 	public:
@@ -1643,3 +1688,8 @@ class IntAna_Quadric {
 };
 
 
+%extend IntAna_Quadric {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntAna2d.i
+++ b/src/SWIG_files/wrapper/IntAna2d.i
@@ -266,6 +266,11 @@ class IntAna2d_AnaIntersection {
 };
 
 
+%extend IntAna2d_AnaIntersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna2d_Conic;
 class IntAna2d_Conic {
 	public:
@@ -374,6 +379,11 @@ class IntAna2d_Conic {
 };
 
 
+%extend IntAna2d_Conic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntAna2d_IntPoint;
 class IntAna2d_IntPoint {
 	public:
@@ -494,3 +504,8 @@ class IntAna2d_IntPoint {
 };
 
 
+%extend IntAna2d_IntPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntCurve.i
+++ b/src/SWIG_files/wrapper/IntCurve.i
@@ -154,6 +154,11 @@ class IntCurve_IConicTool {
 };
 
 
+%extend IntCurve_IConicTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurve_IntConicConic;
 class IntCurve_IntConicConic : public IntRes2d_Intersection {
 	public:
@@ -706,6 +711,11 @@ class IntCurve_IntConicConic : public IntRes2d_Intersection {
 };
 
 
+%extend IntCurve_IntConicConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurve_IntImpConicParConic;
 class IntCurve_IntImpConicParConic : public IntRes2d_Intersection {
 	public:
@@ -804,6 +814,11 @@ class IntCurve_IntImpConicParConic : public IntRes2d_Intersection {
 };
 
 
+%extend IntCurve_IntImpConicParConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurve_MyImpParToolOfIntImpConicParConic;
 class IntCurve_MyImpParToolOfIntImpConicParConic : public math_FunctionWithDerivative {
 	public:
@@ -844,6 +859,11 @@ class IntCurve_MyImpParToolOfIntImpConicParConic : public math_FunctionWithDeriv
 };
 
 
+%extend IntCurve_MyImpParToolOfIntImpConicParConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurve_PConic;
 class IntCurve_PConic {
 	public:
@@ -928,6 +948,11 @@ class IntCurve_PConic {
 };
 
 
+%extend IntCurve_PConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntCurve_PConicTool {
 	public:
 		%feature("compactdefaultargs") EpsX;
@@ -989,6 +1014,11 @@ class IntCurve_PConicTool {
 };
 
 
+%extend IntCurve_PConicTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntCurve_ProjectOnPConicTool {
 	public:
 		%feature("compactdefaultargs") FindParameter;
@@ -1022,3 +1052,8 @@ class IntCurve_ProjectOnPConicTool {
 };
 
 
+%extend IntCurve_ProjectOnPConicTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntCurveSurface.i
+++ b/src/SWIG_files/wrapper/IntCurveSurface.i
@@ -108,6 +108,11 @@ class IntCurveSurface_Intersection {
 };
 
 
+%extend IntCurveSurface_Intersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_IntersectionPoint;
 class IntCurveSurface_IntersectionPoint {
 	public:
@@ -204,6 +209,11 @@ class IntCurveSurface_IntersectionPoint {
 };
 
 
+%extend IntCurveSurface_IntersectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_IntersectionSegment;
 class IntCurveSurface_IntersectionSegment {
 	public:
@@ -262,6 +272,11 @@ class IntCurveSurface_IntersectionSegment {
 };
 
 
+%extend IntCurveSurface_IntersectionSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_SequenceNodeOfSequenceOfPnt;
 class IntCurveSurface_SequenceNodeOfSequenceOfPnt : public TCollection_SeqNode {
 	public:
@@ -328,6 +343,11 @@ class Handle_IntCurveSurface_SequenceNodeOfSequenceOfPnt : public Handle_TCollec
     }
 };
 
+%extend IntCurveSurface_SequenceNodeOfSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_SequenceNodeOfSequenceOfSeg;
 class IntCurveSurface_SequenceNodeOfSequenceOfSeg : public TCollection_SeqNode {
 	public:
@@ -394,6 +414,11 @@ class Handle_IntCurveSurface_SequenceNodeOfSequenceOfSeg : public Handle_TCollec
     }
 };
 
+%extend IntCurveSurface_SequenceNodeOfSequenceOfSeg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_SequenceOfPnt;
 class IntCurveSurface_SequenceOfPnt : public TCollection_BaseSequence {
 	public:
@@ -532,6 +557,11 @@ class IntCurveSurface_SequenceOfPnt : public TCollection_BaseSequence {
 };
 
 
+%extend IntCurveSurface_SequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_SequenceOfSeg;
 class IntCurveSurface_SequenceOfSeg : public TCollection_BaseSequence {
 	public:
@@ -670,6 +700,11 @@ class IntCurveSurface_SequenceOfSeg : public TCollection_BaseSequence {
 };
 
 
+%extend IntCurveSurface_SequenceOfSeg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_TheCSFunctionOfHInter;
 class IntCurveSurface_TheCSFunctionOfHInter : public math_FunctionSetWithDerivatives {
 	public:
@@ -734,6 +769,11 @@ class IntCurveSurface_TheCSFunctionOfHInter : public math_FunctionSetWithDerivat
 };
 
 
+%extend IntCurveSurface_TheCSFunctionOfHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_TheExactHInter;
 class IntCurveSurface_TheExactHInter {
 	public:
@@ -816,6 +856,11 @@ class IntCurveSurface_TheExactHInter {
 };
 
 
+%extend IntCurveSurface_TheExactHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntCurveSurface_TheHCurveTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -1027,6 +1072,11 @@ class IntCurveSurface_TheHCurveTool {
 };
 
 
+%extend IntCurveSurface_TheHCurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_TheInterferenceOfHInter;
 class IntCurveSurface_TheInterferenceOfHInter : public Intf_Interference {
 	public:
@@ -1163,6 +1213,11 @@ class IntCurveSurface_TheInterferenceOfHInter : public Intf_Interference {
 };
 
 
+%extend IntCurveSurface_TheInterferenceOfHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_ThePolygonOfHInter;
 class IntCurveSurface_ThePolygonOfHInter {
 	public:
@@ -1257,6 +1312,11 @@ class IntCurveSurface_ThePolygonOfHInter {
 };
 
 
+%extend IntCurveSurface_ThePolygonOfHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntCurveSurface_ThePolygonToolOfHInter {
 	public:
 		%feature("compactdefaultargs") Bounding;
@@ -1308,6 +1368,11 @@ class IntCurveSurface_ThePolygonToolOfHInter {
 };
 
 
+%extend IntCurveSurface_ThePolygonToolOfHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntCurveSurface_ThePolyhedronToolOfHInter {
 	public:
 		%feature("compactdefaultargs") Bounding;
@@ -1397,6 +1462,11 @@ class IntCurveSurface_ThePolyhedronToolOfHInter {
 };
 
 
+%extend IntCurveSurface_ThePolyhedronToolOfHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_TheQuadCurvExactHInter;
 class IntCurveSurface_TheQuadCurvExactHInter {
 	public:
@@ -1439,6 +1509,11 @@ class IntCurveSurface_TheQuadCurvExactHInter {
 };
 
 
+%extend IntCurveSurface_TheQuadCurvExactHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_TheQuadCurvFuncOfTheQuadCurvExactHInter;
 class IntCurveSurface_TheQuadCurvFuncOfTheQuadCurvExactHInter : public math_FunctionWithDerivative {
 	public:
@@ -1479,6 +1554,11 @@ class IntCurveSurface_TheQuadCurvFuncOfTheQuadCurvExactHInter : public math_Func
 };
 
 
+%extend IntCurveSurface_TheQuadCurvFuncOfTheQuadCurvExactHInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurveSurface_HInter;
 class IntCurveSurface_HInter : public IntCurveSurface_Intersection {
 	public:
@@ -1543,3 +1623,8 @@ class IntCurveSurface_HInter : public IntCurveSurface_Intersection {
 };
 
 
+%extend IntCurveSurface_HInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntCurvesFace.i
+++ b/src/SWIG_files/wrapper/IntCurvesFace.i
@@ -180,6 +180,11 @@ class IntCurvesFace_Intersector {
 };
 
 
+%extend IntCurvesFace_Intersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntCurvesFace_ShapeIntersector;
 class IntCurvesFace_ShapeIntersector {
 	public:
@@ -310,3 +315,8 @@ class IntCurvesFace_ShapeIntersector {
 };
 
 
+%extend IntCurvesFace_ShapeIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntImpParGen.i
+++ b/src/SWIG_files/wrapper/IntImpParGen.i
@@ -124,3 +124,8 @@ class IntImpParGen {
 };
 
 
+%extend IntImpParGen {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntPatch.i
+++ b/src/SWIG_files/wrapper/IntPatch.i
@@ -164,6 +164,11 @@ class IntPatch_ALineToWLine {
 };
 
 
+%extend IntPatch_ALineToWLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_ArcFunction;
 class IntPatch_ArcFunction : public math_FunctionWithDerivative {
 	public:
@@ -244,6 +249,11 @@ class IntPatch_ArcFunction : public math_FunctionWithDerivative {
 };
 
 
+%extend IntPatch_ArcFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_CSFunction;
 class IntPatch_CSFunction : public math_FunctionSetWithDerivatives {
 	public:
@@ -312,6 +322,11 @@ class IntPatch_CSFunction : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend IntPatch_CSFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_CurvIntSurf;
 class IntPatch_CurvIntSurf {
 	public:
@@ -394,6 +409,11 @@ class IntPatch_CurvIntSurf {
 };
 
 
+%extend IntPatch_CurvIntSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntPatch_HCurve2dTool {
 	public:
 		%feature("compactdefaultargs") FirstParameter;
@@ -609,6 +629,11 @@ class IntPatch_HCurve2dTool {
 };
 
 
+%extend IntPatch_HCurve2dTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_HInterTool;
 class IntPatch_HInterTool {
 	public:
@@ -829,6 +854,11 @@ class IntPatch_HInterTool {
 };
 
 
+%extend IntPatch_HInterTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_ImpImpIntersection;
 class IntPatch_ImpImpIntersection {
 	public:
@@ -925,6 +955,11 @@ class IntPatch_ImpImpIntersection {
 };
 
 
+%extend IntPatch_ImpImpIntersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_ImpPrmIntersection;
 class IntPatch_ImpPrmIntersection {
 	public:
@@ -1025,6 +1060,11 @@ class IntPatch_ImpPrmIntersection {
 };
 
 
+%extend IntPatch_ImpPrmIntersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_InterferencePolyhedron;
 class IntPatch_InterferencePolyhedron : public Intf_Interference {
 	public:
@@ -1073,6 +1113,11 @@ class IntPatch_InterferencePolyhedron : public Intf_Interference {
 };
 
 
+%extend IntPatch_InterferencePolyhedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_Intersection;
 class IntPatch_Intersection {
 	public:
@@ -1275,6 +1320,11 @@ class IntPatch_Intersection {
 };
 
 
+%extend IntPatch_Intersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_Line;
 class IntPatch_Line : public MMgt_TShared {
 	public:
@@ -1401,6 +1451,11 @@ class Handle_IntPatch_Line : public Handle_MMgt_TShared {
     }
 };
 
+%extend IntPatch_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_LineConstructor;
 class IntPatch_LineConstructor {
 	public:
@@ -1441,6 +1496,11 @@ class IntPatch_LineConstructor {
 };
 
 
+%extend IntPatch_LineConstructor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_Point;
 class IntPatch_Point {
 	public:
@@ -1695,6 +1755,11 @@ class IntPatch_Point {
 };
 
 
+%extend IntPatch_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_Polygo;
 class IntPatch_Polygo : public Intf_Polygon2d {
 	public:
@@ -1743,6 +1808,11 @@ class IntPatch_Polygo : public Intf_Polygon2d {
 };
 
 
+%extend IntPatch_Polygo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_PrmPrmIntersection;
 class IntPatch_PrmPrmIntersection {
 	public:
@@ -2115,6 +2185,11 @@ class IntPatch_PrmPrmIntersection {
 };
 
 
+%extend IntPatch_PrmPrmIntersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_PrmPrmIntersection_T3Bits;
 class IntPatch_PrmPrmIntersection_T3Bits {
 	public:
@@ -2161,6 +2236,11 @@ class IntPatch_PrmPrmIntersection_T3Bits {
 };
 
 
+%extend IntPatch_PrmPrmIntersection_T3Bits {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntPatch_RstInt {
 	public:
 		%feature("compactdefaultargs") PutVertexOnLine;
@@ -2184,6 +2264,11 @@ class IntPatch_RstInt {
 };
 
 
+%extend IntPatch_RstInt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceNodeOfSequenceOfIWLineOfTheIWalking;
 class IntPatch_SequenceNodeOfSequenceOfIWLineOfTheIWalking : public TCollection_SeqNode {
 	public:
@@ -2250,6 +2335,11 @@ class Handle_IntPatch_SequenceNodeOfSequenceOfIWLineOfTheIWalking : public Handl
     }
 };
 
+%extend IntPatch_SequenceNodeOfSequenceOfIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceNodeOfSequenceOfLine;
 class IntPatch_SequenceNodeOfSequenceOfLine : public TCollection_SeqNode {
 	public:
@@ -2316,6 +2406,11 @@ class Handle_IntPatch_SequenceNodeOfSequenceOfLine : public Handle_TCollection_S
     }
 };
 
+%extend IntPatch_SequenceNodeOfSequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceNodeOfSequenceOfPathPointOfTheSOnBounds;
 class IntPatch_SequenceNodeOfSequenceOfPathPointOfTheSOnBounds : public TCollection_SeqNode {
 	public:
@@ -2382,6 +2477,11 @@ class Handle_IntPatch_SequenceNodeOfSequenceOfPathPointOfTheSOnBounds : public H
     }
 };
 
+%extend IntPatch_SequenceNodeOfSequenceOfPathPointOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceNodeOfSequenceOfPoint;
 class IntPatch_SequenceNodeOfSequenceOfPoint : public TCollection_SeqNode {
 	public:
@@ -2448,6 +2548,11 @@ class Handle_IntPatch_SequenceNodeOfSequenceOfPoint : public Handle_TCollection_
     }
 };
 
+%extend IntPatch_SequenceNodeOfSequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceNodeOfSequenceOfSegmentOfTheSOnBounds;
 class IntPatch_SequenceNodeOfSequenceOfSegmentOfTheSOnBounds : public TCollection_SeqNode {
 	public:
@@ -2514,6 +2619,11 @@ class Handle_IntPatch_SequenceNodeOfSequenceOfSegmentOfTheSOnBounds : public Han
     }
 };
 
+%extend IntPatch_SequenceNodeOfSequenceOfSegmentOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceOfIWLineOfTheIWalking;
 class IntPatch_SequenceOfIWLineOfTheIWalking : public TCollection_BaseSequence {
 	public:
@@ -2652,6 +2762,11 @@ class IntPatch_SequenceOfIWLineOfTheIWalking : public TCollection_BaseSequence {
 };
 
 
+%extend IntPatch_SequenceOfIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceOfLine;
 class IntPatch_SequenceOfLine : public TCollection_BaseSequence {
 	public:
@@ -2790,6 +2905,11 @@ class IntPatch_SequenceOfLine : public TCollection_BaseSequence {
 };
 
 
+%extend IntPatch_SequenceOfLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceOfPathPointOfTheSOnBounds;
 class IntPatch_SequenceOfPathPointOfTheSOnBounds : public TCollection_BaseSequence {
 	public:
@@ -2928,6 +3048,11 @@ class IntPatch_SequenceOfPathPointOfTheSOnBounds : public TCollection_BaseSequen
 };
 
 
+%extend IntPatch_SequenceOfPathPointOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceOfPoint;
 class IntPatch_SequenceOfPoint : public TCollection_BaseSequence {
 	public:
@@ -3066,6 +3191,11 @@ class IntPatch_SequenceOfPoint : public TCollection_BaseSequence {
 };
 
 
+%extend IntPatch_SequenceOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_SequenceOfSegmentOfTheSOnBounds;
 class IntPatch_SequenceOfSegmentOfTheSOnBounds : public TCollection_BaseSequence {
 	public:
@@ -3204,6 +3334,11 @@ class IntPatch_SequenceOfSegmentOfTheSOnBounds : public TCollection_BaseSequence
 };
 
 
+%extend IntPatch_SequenceOfSegmentOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheIWLineOfTheIWalking;
 class IntPatch_TheIWLineOfTheIWalking : public MMgt_TShared {
 	public:
@@ -3420,6 +3555,11 @@ class Handle_IntPatch_TheIWLineOfTheIWalking : public Handle_MMgt_TShared {
     }
 };
 
+%extend IntPatch_TheIWLineOfTheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheIWalking;
 class IntPatch_TheIWalking {
 	public:
@@ -3496,6 +3636,11 @@ class IntPatch_TheIWalking {
 };
 
 
+%extend IntPatch_TheIWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_ThePathPointOfTheSOnBounds;
 class IntPatch_ThePathPointOfTheSOnBounds {
 	public:
@@ -3582,6 +3727,11 @@ class IntPatch_ThePathPointOfTheSOnBounds {
 };
 
 
+%extend IntPatch_ThePathPointOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheSOnBounds;
 class IntPatch_TheSOnBounds {
 	public:
@@ -3634,6 +3784,11 @@ class IntPatch_TheSOnBounds {
 };
 
 
+%extend IntPatch_TheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheSearchInside;
 class IntPatch_TheSearchInside {
 	public:
@@ -3694,6 +3849,11 @@ class IntPatch_TheSearchInside {
 };
 
 
+%extend IntPatch_TheSearchInside {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheSegmentOfTheSOnBounds;
 class IntPatch_TheSegmentOfTheSOnBounds {
 	public:
@@ -3738,6 +3898,11 @@ class IntPatch_TheSegmentOfTheSOnBounds {
 };
 
 
+%extend IntPatch_TheSegmentOfTheSOnBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_TheSurfFunction;
 class IntPatch_TheSurfFunction : public math_FunctionSetWithDerivatives {
 	public:
@@ -3846,6 +4011,11 @@ class IntPatch_TheSurfFunction : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend IntPatch_TheSurfFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_ALine;
 class IntPatch_ALine : public IntPatch_Line {
 	public:
@@ -4060,6 +4230,11 @@ class Handle_IntPatch_ALine : public Handle_IntPatch_Line {
     }
 };
 
+%extend IntPatch_ALine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_GLine;
 class IntPatch_GLine : public IntPatch_Line {
 	public:
@@ -4406,6 +4581,11 @@ class Handle_IntPatch_GLine : public Handle_IntPatch_Line {
     }
 };
 
+%extend IntPatch_GLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_PolyArc;
 class IntPatch_PolyArc : public IntPatch_Polygo {
 	public:
@@ -4456,6 +4636,11 @@ class IntPatch_PolyArc : public IntPatch_Polygo {
 };
 
 
+%extend IntPatch_PolyArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_PolyLine;
 class IntPatch_PolyLine : public IntPatch_Polygo {
 	public:
@@ -4502,6 +4687,11 @@ class IntPatch_PolyLine : public IntPatch_Polygo {
 };
 
 
+%extend IntPatch_PolyLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_RLine;
 class IntPatch_RLine : public IntPatch_Line {
 	public:
@@ -4746,6 +4936,11 @@ class Handle_IntPatch_RLine : public Handle_IntPatch_Line {
     }
 };
 
+%extend IntPatch_RLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPatch_WLine;
 class IntPatch_WLine : public IntPatch_Line {
 	public:
@@ -5034,3 +5229,8 @@ class Handle_IntPatch_WLine : public Handle_IntPatch_Line {
     }
 };
 
+%extend IntPatch_WLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntPolyh.i
+++ b/src/SWIG_files/wrapper/IntPolyh.i
@@ -124,6 +124,11 @@ class IntPolyh_Couple {
 };
 
 
+%extend IntPolyh_Couple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_Edge;
 class IntPolyh_Edge {
 	public:
@@ -202,6 +207,11 @@ class IntPolyh_Edge {
 };
 
 
+%extend IntPolyh_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_Intersection;
 class IntPolyh_Intersection {
 	public:
@@ -344,6 +354,11 @@ class IntPolyh_Intersection {
 };
 
 
+%extend IntPolyh_Intersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_Point;
 class IntPolyh_Point {
 	public:
@@ -558,6 +573,11 @@ class IntPolyh_Point {
 };
 
 
+%extend IntPolyh_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_SectionLine;
 class IntPolyh_SectionLine {
 	public:
@@ -630,6 +650,11 @@ class IntPolyh_SectionLine {
 };
 
 
+%extend IntPolyh_SectionLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_SeqOfStartPoints;
 class IntPolyh_SeqOfStartPoints : public TCollection_BaseSequence {
 	public:
@@ -768,6 +793,11 @@ class IntPolyh_SeqOfStartPoints : public TCollection_BaseSequence {
 };
 
 
+%extend IntPolyh_SeqOfStartPoints {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_SequenceNodeOfSeqOfStartPoints;
 class IntPolyh_SequenceNodeOfSeqOfStartPoints : public TCollection_SeqNode {
 	public:
@@ -834,6 +864,11 @@ class Handle_IntPolyh_SequenceNodeOfSeqOfStartPoints : public Handle_TCollection
     }
 };
 
+%extend IntPolyh_SequenceNodeOfSeqOfStartPoints {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_StartPoint;
 class IntPolyh_StartPoint {
 	public:
@@ -1046,6 +1081,11 @@ class IntPolyh_StartPoint {
 };
 
 
+%extend IntPolyh_StartPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntPolyh_Triangle;
 class IntPolyh_Triangle {
 	public:
@@ -1322,3 +1362,8 @@ class IntPolyh_Triangle {
 };
 
 
+%extend IntPolyh_Triangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntRes2d.i
+++ b/src/SWIG_files/wrapper/IntRes2d.i
@@ -231,6 +231,11 @@ class IntRes2d_Domain {
 };
 
 
+%extend IntRes2d_Domain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_Intersection;
 class IntRes2d_Intersection {
 	public:
@@ -283,6 +288,11 @@ class IntRes2d_Intersection {
 };
 
 
+%extend IntRes2d_Intersection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_IntersectionPoint;
 class IntRes2d_IntersectionPoint {
 	public:
@@ -393,6 +403,11 @@ class IntRes2d_IntersectionPoint {
 };
 
 
+%extend IntRes2d_IntersectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_IntersectionSegment;
 class IntRes2d_IntersectionSegment {
 	public:
@@ -505,6 +520,11 @@ class IntRes2d_IntersectionSegment {
 };
 
 
+%extend IntRes2d_IntersectionSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_SequenceNodeOfSequenceOfIntersectionPoint;
 class IntRes2d_SequenceNodeOfSequenceOfIntersectionPoint : public TCollection_SeqNode {
 	public:
@@ -571,6 +591,11 @@ class Handle_IntRes2d_SequenceNodeOfSequenceOfIntersectionPoint : public Handle_
     }
 };
 
+%extend IntRes2d_SequenceNodeOfSequenceOfIntersectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_SequenceNodeOfSequenceOfIntersectionSegment;
 class IntRes2d_SequenceNodeOfSequenceOfIntersectionSegment : public TCollection_SeqNode {
 	public:
@@ -637,6 +662,11 @@ class Handle_IntRes2d_SequenceNodeOfSequenceOfIntersectionSegment : public Handl
     }
 };
 
+%extend IntRes2d_SequenceNodeOfSequenceOfIntersectionSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_SequenceOfIntersectionPoint;
 class IntRes2d_SequenceOfIntersectionPoint : public TCollection_BaseSequence {
 	public:
@@ -775,6 +805,11 @@ class IntRes2d_SequenceOfIntersectionPoint : public TCollection_BaseSequence {
 };
 
 
+%extend IntRes2d_SequenceOfIntersectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_SequenceOfIntersectionSegment;
 class IntRes2d_SequenceOfIntersectionSegment : public TCollection_BaseSequence {
 	public:
@@ -913,6 +948,11 @@ class IntRes2d_SequenceOfIntersectionSegment : public TCollection_BaseSequence {
 };
 
 
+%extend IntRes2d_SequenceOfIntersectionSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntRes2d_Transition;
 class IntRes2d_Transition {
 	public:
@@ -1081,3 +1121,8 @@ class IntRes2d_Transition {
 };
 
 
+%extend IntRes2d_Transition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntStart.i
+++ b/src/SWIG_files/wrapper/IntStart.i
@@ -116,3 +116,8 @@ class Handle_IntStart_SITopolTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend IntStart_SITopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntSurf.i
+++ b/src/SWIG_files/wrapper/IntSurf.i
@@ -93,6 +93,11 @@ class IntSurf {
 };
 
 
+%extend IntSurf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_Couple;
 class IntSurf_Couple {
 	public:
@@ -123,6 +128,11 @@ class IntSurf_Couple {
 };
 
 
+%extend IntSurf_Couple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_InteriorPoint;
 class IntSurf_InteriorPoint {
 	public:
@@ -201,6 +211,11 @@ class IntSurf_InteriorPoint {
 };
 
 
+%extend IntSurf_InteriorPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntSurf_InteriorPointTool {
 	public:
 		%feature("compactdefaultargs") Value3d;
@@ -242,6 +257,11 @@ class IntSurf_InteriorPointTool {
 };
 
 
+%extend IntSurf_InteriorPointTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_LineOn2S;
 class IntSurf_LineOn2S : public MMgt_TShared {
 	public:
@@ -378,6 +398,11 @@ class Handle_IntSurf_LineOn2S : public Handle_MMgt_TShared {
     }
 };
 
+%extend IntSurf_LineOn2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_ListIteratorOfListOfPntOn2S;
 class IntSurf_ListIteratorOfListOfPntOn2S {
 	public:
@@ -412,6 +437,11 @@ class IntSurf_ListIteratorOfListOfPntOn2S {
 };
 
 
+%extend IntSurf_ListIteratorOfListOfPntOn2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_ListNodeOfListOfPntOn2S;
 class IntSurf_ListNodeOfListOfPntOn2S : public TCollection_MapNode {
 	public:
@@ -476,6 +506,11 @@ class Handle_IntSurf_ListNodeOfListOfPntOn2S : public Handle_TCollection_MapNode
     }
 };
 
+%extend IntSurf_ListNodeOfListOfPntOn2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_ListOfPntOn2S;
 class IntSurf_ListOfPntOn2S {
 	public:
@@ -606,6 +641,11 @@ class IntSurf_ListOfPntOn2S {
 };
 
 
+%extend IntSurf_ListOfPntOn2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_PathPoint;
 class IntSurf_PathPoint {
 	public:
@@ -706,6 +746,11 @@ class IntSurf_PathPoint {
 };
 
 
+%extend IntSurf_PathPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntSurf_PathPointTool {
 	public:
 		%feature("compactdefaultargs") Value3d;
@@ -785,6 +830,11 @@ class IntSurf_PathPointTool {
 };
 
 
+%extend IntSurf_PathPointTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_PntOn2S;
 class IntSurf_PntOn2S {
 	public:
@@ -901,6 +951,11 @@ class IntSurf_PntOn2S {
 };
 
 
+%extend IntSurf_PntOn2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_Quadric;
 class IntSurf_Quadric {
 	public:
@@ -1075,6 +1130,11 @@ class IntSurf_Quadric {
 };
 
 
+%extend IntSurf_Quadric {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntSurf_QuadricTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -1136,6 +1196,11 @@ class IntSurf_QuadricTool {
 };
 
 
+%extend IntSurf_QuadricTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceNodeOfSequenceOfCouple;
 class IntSurf_SequenceNodeOfSequenceOfCouple : public TCollection_SeqNode {
 	public:
@@ -1202,6 +1267,11 @@ class Handle_IntSurf_SequenceNodeOfSequenceOfCouple : public Handle_TCollection_
     }
 };
 
+%extend IntSurf_SequenceNodeOfSequenceOfCouple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceNodeOfSequenceOfInteriorPoint;
 class IntSurf_SequenceNodeOfSequenceOfInteriorPoint : public TCollection_SeqNode {
 	public:
@@ -1268,6 +1338,11 @@ class Handle_IntSurf_SequenceNodeOfSequenceOfInteriorPoint : public Handle_TColl
     }
 };
 
+%extend IntSurf_SequenceNodeOfSequenceOfInteriorPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceNodeOfSequenceOfPathPoint;
 class IntSurf_SequenceNodeOfSequenceOfPathPoint : public TCollection_SeqNode {
 	public:
@@ -1334,6 +1409,11 @@ class Handle_IntSurf_SequenceNodeOfSequenceOfPathPoint : public Handle_TCollecti
     }
 };
 
+%extend IntSurf_SequenceNodeOfSequenceOfPathPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceOfCouple;
 class IntSurf_SequenceOfCouple : public TCollection_BaseSequence {
 	public:
@@ -1472,6 +1552,11 @@ class IntSurf_SequenceOfCouple : public TCollection_BaseSequence {
 };
 
 
+%extend IntSurf_SequenceOfCouple {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceOfInteriorPoint;
 class IntSurf_SequenceOfInteriorPoint : public TCollection_BaseSequence {
 	public:
@@ -1610,6 +1695,11 @@ class IntSurf_SequenceOfInteriorPoint : public TCollection_BaseSequence {
 };
 
 
+%extend IntSurf_SequenceOfInteriorPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_SequenceOfPathPoint;
 class IntSurf_SequenceOfPathPoint : public TCollection_BaseSequence {
 	public:
@@ -1748,6 +1838,11 @@ class IntSurf_SequenceOfPathPoint : public TCollection_BaseSequence {
 };
 
 
+%extend IntSurf_SequenceOfPathPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntSurf_Transition;
 class IntSurf_Transition {
 	public:
@@ -1834,3 +1929,8 @@ class IntSurf_Transition {
 };
 
 
+%extend IntSurf_Transition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntTools.i
+++ b/src/SWIG_files/wrapper/IntTools.i
@@ -138,6 +138,11 @@ class IntTools {
 };
 
 
+%extend IntTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Array1OfRange;
 class IntTools_Array1OfRange {
 	public:
@@ -220,6 +225,11 @@ class IntTools_Array1OfRange {
 };
 
 
+%extend IntTools_Array1OfRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Array1OfRoots;
 class IntTools_Array1OfRoots {
 	public:
@@ -302,6 +312,11 @@ class IntTools_Array1OfRoots {
 };
 
 
+%extend IntTools_Array1OfRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_BaseRangeSample;
 class IntTools_BaseRangeSample {
 	public:
@@ -328,6 +343,11 @@ class IntTools_BaseRangeSample {
 };
 
 
+%extend IntTools_BaseRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_BeanFaceIntersector;
 class IntTools_BeanFaceIntersector {
 	public:
@@ -496,6 +516,11 @@ class IntTools_BeanFaceIntersector {
 };
 
 
+%extend IntTools_BeanFaceIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_CommonPrt;
 class IntTools_CommonPrt {
 	public:
@@ -704,6 +729,11 @@ class IntTools_CommonPrt {
 };
 
 
+%extend IntTools_CommonPrt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Compare;
 class IntTools_Compare {
 	public:
@@ -754,6 +784,11 @@ class IntTools_Compare {
 };
 
 
+%extend IntTools_Compare {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_CompareRange;
 class IntTools_CompareRange {
 	public:
@@ -804,6 +839,11 @@ class IntTools_CompareRange {
 };
 
 
+%extend IntTools_CompareRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Context;
 class IntTools_Context : public MMgt_TShared {
 	public:
@@ -1094,6 +1134,11 @@ class Handle_IntTools_Context : public Handle_MMgt_TShared {
     }
 };
 
+%extend IntTools_Context {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Curve;
 class IntTools_Curve {
 	public:
@@ -1208,6 +1253,11 @@ class IntTools_Curve {
 };
 
 
+%extend IntTools_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_CurveRangeLocalizeData;
 class IntTools_CurveRangeLocalizeData {
 	public:
@@ -1264,6 +1314,11 @@ class IntTools_CurveRangeLocalizeData {
 };
 
 
+%extend IntTools_CurveRangeLocalizeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapIteratorOfDataMapOfCurveSampleBox;
 class IntTools_DataMapIteratorOfDataMapOfCurveSampleBox : public TCollection_BasicMapIterator {
 	public:
@@ -1294,6 +1349,11 @@ class IntTools_DataMapIteratorOfDataMapOfCurveSampleBox : public TCollection_Bas
 };
 
 
+%extend IntTools_DataMapIteratorOfDataMapOfCurveSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapIteratorOfDataMapOfSurfaceSampleBox;
 class IntTools_DataMapIteratorOfDataMapOfSurfaceSampleBox : public TCollection_BasicMapIterator {
 	public:
@@ -1324,6 +1384,11 @@ class IntTools_DataMapIteratorOfDataMapOfSurfaceSampleBox : public TCollection_B
 };
 
 
+%extend IntTools_DataMapIteratorOfDataMapOfSurfaceSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapNodeOfDataMapOfCurveSampleBox;
 class IntTools_DataMapNodeOfDataMapOfCurveSampleBox : public TCollection_MapNode {
 	public:
@@ -1394,6 +1459,11 @@ class Handle_IntTools_DataMapNodeOfDataMapOfCurveSampleBox : public Handle_TColl
     }
 };
 
+%extend IntTools_DataMapNodeOfDataMapOfCurveSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapNodeOfDataMapOfSurfaceSampleBox;
 class IntTools_DataMapNodeOfDataMapOfSurfaceSampleBox : public TCollection_MapNode {
 	public:
@@ -1464,6 +1534,11 @@ class Handle_IntTools_DataMapNodeOfDataMapOfSurfaceSampleBox : public Handle_TCo
     }
 };
 
+%extend IntTools_DataMapNodeOfDataMapOfSurfaceSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapOfCurveSampleBox;
 class IntTools_DataMapOfCurveSampleBox : public TCollection_BasicMap {
 	public:
@@ -1542,6 +1617,11 @@ class IntTools_DataMapOfCurveSampleBox : public TCollection_BasicMap {
 };
 
 
+%extend IntTools_DataMapOfCurveSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_DataMapOfSurfaceSampleBox;
 class IntTools_DataMapOfSurfaceSampleBox : public TCollection_BasicMap {
 	public:
@@ -1620,6 +1700,11 @@ class IntTools_DataMapOfSurfaceSampleBox : public TCollection_BasicMap {
 };
 
 
+%extend IntTools_DataMapOfSurfaceSampleBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_EdgeEdge;
 class IntTools_EdgeEdge {
 	public:
@@ -1754,6 +1839,11 @@ class IntTools_EdgeEdge {
 };
 
 
+%extend IntTools_EdgeEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_EdgeFace;
 class IntTools_EdgeFace {
 	public:
@@ -1928,6 +2018,11 @@ class IntTools_EdgeFace {
 };
 
 
+%extend IntTools_EdgeFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_FClass2d;
 class IntTools_FClass2d {
 	public:
@@ -1998,6 +2093,11 @@ class IntTools_FClass2d {
 };
 
 
+%extend IntTools_FClass2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_FaceFace;
 class IntTools_FaceFace {
 	public:
@@ -2110,6 +2210,11 @@ class IntTools_FaceFace {
 };
 
 
+%extend IntTools_FaceFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_IndexedDataMapNodeOfIndexedDataMapOfTransientAddress;
 class IntTools_IndexedDataMapNodeOfIndexedDataMapOfTransientAddress : public TCollection_MapNode {
 	public:
@@ -2201,6 +2306,11 @@ class Handle_IntTools_IndexedDataMapNodeOfIndexedDataMapOfTransientAddress : pub
     }
 };
 
+%extend IntTools_IndexedDataMapNodeOfIndexedDataMapOfTransientAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_IndexedDataMapOfTransientAddress;
 class IntTools_IndexedDataMapOfTransientAddress : public TCollection_BasicMap {
 	public:
@@ -2311,6 +2421,11 @@ class IntTools_IndexedDataMapOfTransientAddress : public TCollection_BasicMap {
 };
 
 
+%extend IntTools_IndexedDataMapOfTransientAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListIteratorOfListOfBox;
 class IntTools_ListIteratorOfListOfBox {
 	public:
@@ -2345,6 +2460,11 @@ class IntTools_ListIteratorOfListOfBox {
 };
 
 
+%extend IntTools_ListIteratorOfListOfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListIteratorOfListOfCurveRangeSample;
 class IntTools_ListIteratorOfListOfCurveRangeSample {
 	public:
@@ -2379,6 +2499,11 @@ class IntTools_ListIteratorOfListOfCurveRangeSample {
 };
 
 
+%extend IntTools_ListIteratorOfListOfCurveRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListIteratorOfListOfSurfaceRangeSample;
 class IntTools_ListIteratorOfListOfSurfaceRangeSample {
 	public:
@@ -2413,6 +2538,11 @@ class IntTools_ListIteratorOfListOfSurfaceRangeSample {
 };
 
 
+%extend IntTools_ListIteratorOfListOfSurfaceRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListNodeOfListOfBox;
 class IntTools_ListNodeOfListOfBox : public TCollection_MapNode {
 	public:
@@ -2477,6 +2607,11 @@ class Handle_IntTools_ListNodeOfListOfBox : public Handle_TCollection_MapNode {
     }
 };
 
+%extend IntTools_ListNodeOfListOfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListNodeOfListOfCurveRangeSample;
 class IntTools_ListNodeOfListOfCurveRangeSample : public TCollection_MapNode {
 	public:
@@ -2541,6 +2676,11 @@ class Handle_IntTools_ListNodeOfListOfCurveRangeSample : public Handle_TCollecti
     }
 };
 
+%extend IntTools_ListNodeOfListOfCurveRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListNodeOfListOfSurfaceRangeSample;
 class IntTools_ListNodeOfListOfSurfaceRangeSample : public TCollection_MapNode {
 	public:
@@ -2605,6 +2745,11 @@ class Handle_IntTools_ListNodeOfListOfSurfaceRangeSample : public Handle_TCollec
     }
 };
 
+%extend IntTools_ListNodeOfListOfSurfaceRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListOfBox;
 class IntTools_ListOfBox {
 	public:
@@ -2735,6 +2880,11 @@ class IntTools_ListOfBox {
 };
 
 
+%extend IntTools_ListOfBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListOfCurveRangeSample;
 class IntTools_ListOfCurveRangeSample {
 	public:
@@ -2865,6 +3015,11 @@ class IntTools_ListOfCurveRangeSample {
 };
 
 
+%extend IntTools_ListOfCurveRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ListOfSurfaceRangeSample;
 class IntTools_ListOfSurfaceRangeSample {
 	public:
@@ -2995,6 +3150,11 @@ class IntTools_ListOfSurfaceRangeSample {
 };
 
 
+%extend IntTools_ListOfSurfaceRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_MapIteratorOfMapOfCurveSample;
 class IntTools_MapIteratorOfMapOfCurveSample : public TCollection_BasicMapIterator {
 	public:
@@ -3021,6 +3181,11 @@ class IntTools_MapIteratorOfMapOfCurveSample : public TCollection_BasicMapIterat
 };
 
 
+%extend IntTools_MapIteratorOfMapOfCurveSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_MapIteratorOfMapOfSurfaceSample;
 class IntTools_MapIteratorOfMapOfSurfaceSample : public TCollection_BasicMapIterator {
 	public:
@@ -3047,6 +3212,11 @@ class IntTools_MapIteratorOfMapOfSurfaceSample : public TCollection_BasicMapIter
 };
 
 
+%extend IntTools_MapIteratorOfMapOfSurfaceSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_MapOfCurveSample;
 class IntTools_MapOfCurveSample : public TCollection_BasicMap {
 	public:
@@ -3105,6 +3275,11 @@ class IntTools_MapOfCurveSample : public TCollection_BasicMap {
 };
 
 
+%extend IntTools_MapOfCurveSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_MapOfSurfaceSample;
 class IntTools_MapOfSurfaceSample : public TCollection_BasicMap {
 	public:
@@ -3163,6 +3338,11 @@ class IntTools_MapOfSurfaceSample : public TCollection_BasicMap {
 };
 
 
+%extend IntTools_MapOfSurfaceSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_MarkedRangeSet;
 class IntTools_MarkedRangeSet {
 	public:
@@ -3323,6 +3503,11 @@ class IntTools_MarkedRangeSet {
 };
 
 
+%extend IntTools_MarkedRangeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_PntOn2Faces;
 class IntTools_PntOn2Faces {
 	public:
@@ -3387,6 +3572,11 @@ class IntTools_PntOn2Faces {
 };
 
 
+%extend IntTools_PntOn2Faces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_PntOnFace;
 class IntTools_PntOnFace {
 	public:
@@ -3469,6 +3659,11 @@ class IntTools_PntOnFace {
 };
 
 
+%extend IntTools_PntOnFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntTools_QuickSort {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -3482,6 +3677,11 @@ class IntTools_QuickSort {
 };
 
 
+%extend IntTools_QuickSort {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntTools_QuickSortRange {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -3495,6 +3695,11 @@ class IntTools_QuickSortRange {
 };
 
 
+%extend IntTools_QuickSortRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Range;
 class IntTools_Range {
 	public:
@@ -3555,6 +3760,11 @@ class IntTools_Range {
 };
 
 
+%extend IntTools_Range {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_Root;
 class IntTools_Root {
 	public:
@@ -3681,6 +3891,11 @@ class IntTools_Root {
 };
 
 
+%extend IntTools_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceNodeOfSequenceOfCommonPrts;
 class IntTools_SequenceNodeOfSequenceOfCommonPrts : public TCollection_SeqNode {
 	public:
@@ -3747,6 +3962,11 @@ class Handle_IntTools_SequenceNodeOfSequenceOfCommonPrts : public Handle_TCollec
     }
 };
 
+%extend IntTools_SequenceNodeOfSequenceOfCommonPrts {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceNodeOfSequenceOfCurves;
 class IntTools_SequenceNodeOfSequenceOfCurves : public TCollection_SeqNode {
 	public:
@@ -3813,6 +4033,11 @@ class Handle_IntTools_SequenceNodeOfSequenceOfCurves : public Handle_TCollection
     }
 };
 
+%extend IntTools_SequenceNodeOfSequenceOfCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceNodeOfSequenceOfPntOn2Faces;
 class IntTools_SequenceNodeOfSequenceOfPntOn2Faces : public TCollection_SeqNode {
 	public:
@@ -3879,6 +4104,11 @@ class Handle_IntTools_SequenceNodeOfSequenceOfPntOn2Faces : public Handle_TColle
     }
 };
 
+%extend IntTools_SequenceNodeOfSequenceOfPntOn2Faces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceNodeOfSequenceOfRanges;
 class IntTools_SequenceNodeOfSequenceOfRanges : public TCollection_SeqNode {
 	public:
@@ -3945,6 +4175,11 @@ class Handle_IntTools_SequenceNodeOfSequenceOfRanges : public Handle_TCollection
     }
 };
 
+%extend IntTools_SequenceNodeOfSequenceOfRanges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceNodeOfSequenceOfRoots;
 class IntTools_SequenceNodeOfSequenceOfRoots : public TCollection_SeqNode {
 	public:
@@ -4011,6 +4246,11 @@ class Handle_IntTools_SequenceNodeOfSequenceOfRoots : public Handle_TCollection_
     }
 };
 
+%extend IntTools_SequenceNodeOfSequenceOfRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceOfCommonPrts;
 class IntTools_SequenceOfCommonPrts : public TCollection_BaseSequence {
 	public:
@@ -4149,6 +4389,11 @@ class IntTools_SequenceOfCommonPrts : public TCollection_BaseSequence {
 };
 
 
+%extend IntTools_SequenceOfCommonPrts {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceOfCurves;
 class IntTools_SequenceOfCurves : public TCollection_BaseSequence {
 	public:
@@ -4287,6 +4532,11 @@ class IntTools_SequenceOfCurves : public TCollection_BaseSequence {
 };
 
 
+%extend IntTools_SequenceOfCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceOfPntOn2Faces;
 class IntTools_SequenceOfPntOn2Faces : public TCollection_BaseSequence {
 	public:
@@ -4425,6 +4675,11 @@ class IntTools_SequenceOfPntOn2Faces : public TCollection_BaseSequence {
 };
 
 
+%extend IntTools_SequenceOfPntOn2Faces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceOfRanges;
 class IntTools_SequenceOfRanges : public TCollection_BaseSequence {
 	public:
@@ -4563,6 +4818,11 @@ class IntTools_SequenceOfRanges : public TCollection_BaseSequence {
 };
 
 
+%extend IntTools_SequenceOfRanges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SequenceOfRoots;
 class IntTools_SequenceOfRoots : public TCollection_BaseSequence {
 	public:
@@ -4701,6 +4961,11 @@ class IntTools_SequenceOfRoots : public TCollection_BaseSequence {
 };
 
 
+%extend IntTools_SequenceOfRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_ShrunkRange;
 class IntTools_ShrunkRange {
 	public:
@@ -4769,6 +5034,11 @@ class IntTools_ShrunkRange {
 };
 
 
+%extend IntTools_ShrunkRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_StdMapNodeOfMapOfCurveSample;
 class IntTools_StdMapNodeOfMapOfCurveSample : public TCollection_MapNode {
 	public:
@@ -4833,6 +5103,11 @@ class Handle_IntTools_StdMapNodeOfMapOfCurveSample : public Handle_TCollection_M
     }
 };
 
+%extend IntTools_StdMapNodeOfMapOfCurveSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_StdMapNodeOfMapOfSurfaceSample;
 class IntTools_StdMapNodeOfMapOfSurfaceSample : public TCollection_MapNode {
 	public:
@@ -4897,6 +5172,11 @@ class Handle_IntTools_StdMapNodeOfMapOfSurfaceSample : public Handle_TCollection
     }
 };
 
+%extend IntTools_StdMapNodeOfMapOfSurfaceSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SurfaceRangeLocalizeData;
 class IntTools_SurfaceRangeLocalizeData {
 	public:
@@ -5149,6 +5429,11 @@ class IntTools_SurfaceRangeLocalizeData {
 };
 
 
+%extend IntTools_SurfaceRangeLocalizeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_SurfaceRangeSample;
 class IntTools_SurfaceRangeSample {
 	public:
@@ -5335,6 +5620,11 @@ class IntTools_SurfaceRangeSample {
 };
 
 
+%extend IntTools_SurfaceRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntTools_SurfaceRangeSampleMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -5360,6 +5650,11 @@ class IntTools_SurfaceRangeSampleMapHasher {
 };
 
 
+%extend IntTools_SurfaceRangeSampleMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class IntTools_Tools {
 	public:
 		%feature("compactdefaultargs") ComputeVV;
@@ -5611,6 +5906,11 @@ class IntTools_Tools {
 };
 
 
+%extend IntTools_Tools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_TopolTool;
 class IntTools_TopolTool : public Adaptor3d_TopolTool {
 	public:
@@ -5737,6 +6037,11 @@ class Handle_IntTools_TopolTool : public Handle_Adaptor3d_TopolTool {
     }
 };
 
+%extend IntTools_TopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntTools_CurveRangeSample;
 class IntTools_CurveRangeSample : public IntTools_BaseRangeSample {
 	public:
@@ -5785,3 +6090,8 @@ class IntTools_CurveRangeSample : public IntTools_BaseRangeSample {
 };
 
 
+%extend IntTools_CurveRangeSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/IntWalk.i
+++ b/src/SWIG_files/wrapper/IntWalk.i
@@ -254,6 +254,11 @@ class IntWalk_PWalking {
 };
 
 
+%extend IntWalk_PWalking {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntWalk_TheFunctionOfTheInt2S;
 class IntWalk_TheFunctionOfTheInt2S : public math_FunctionSetWithDerivatives {
 	public:
@@ -360,6 +365,11 @@ class IntWalk_TheFunctionOfTheInt2S : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend IntWalk_TheFunctionOfTheInt2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntWalk_TheInt2S;
 class IntWalk_TheInt2S {
 	public:
@@ -442,6 +452,11 @@ class IntWalk_TheInt2S {
 };
 
 
+%extend IntWalk_TheInt2S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor IntWalk_WalkingData;
 class IntWalk_WalkingData {
 	public:
@@ -451,3 +466,8 @@ class IntWalk_WalkingData {
 };
 
 
+%extend IntWalk_WalkingData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Interface.i
+++ b/src/SWIG_files/wrapper/Interface.i
@@ -173,6 +173,11 @@ class Interface_Array1OfFileParameter {
 };
 
 
+%extend Interface_Array1OfFileParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Array1OfHAsciiString;
 class Interface_Array1OfHAsciiString {
 	public:
@@ -255,6 +260,11 @@ class Interface_Array1OfHAsciiString {
 };
 
 
+%extend Interface_Array1OfHAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_BitMap;
 class Interface_BitMap {
 	public:
@@ -479,6 +489,11 @@ class Interface_BitMap {
 };
 
 
+%extend Interface_BitMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Category;
 class Interface_Category {
 	public:
@@ -585,6 +600,11 @@ class Interface_Category {
 };
 
 
+%extend Interface_Category {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Check;
 class Interface_Check : public MMgt_TShared {
 	public:
@@ -1001,6 +1021,11 @@ class Handle_Interface_Check : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_Check {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_CheckIterator;
 class Interface_CheckIterator {
 	public:
@@ -1231,6 +1256,11 @@ class Interface_CheckIterator {
 };
 
 
+%extend Interface_CheckIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_CheckTool;
 class Interface_CheckTool {
 	public:
@@ -1353,6 +1383,11 @@ class Interface_CheckTool {
 };
 
 
+%extend Interface_CheckTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_CopyControl;
 class Interface_CopyControl : public MMgt_TShared {
 	public:
@@ -1431,6 +1466,11 @@ class Handle_Interface_CopyControl : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_CopyControl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_CopyTool;
 class Interface_CopyTool {
 	public:
@@ -1593,6 +1633,11 @@ class Interface_CopyTool {
 };
 
 
+%extend Interface_CopyTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_DataMapIteratorOfDataMapOfTransientInteger;
 class Interface_DataMapIteratorOfDataMapOfTransientInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1623,6 +1668,11 @@ class Interface_DataMapIteratorOfDataMapOfTransientInteger : public TCollection_
 };
 
 
+%extend Interface_DataMapIteratorOfDataMapOfTransientInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_DataMapNodeOfDataMapOfTransientInteger;
 class Interface_DataMapNodeOfDataMapOfTransientInteger : public TCollection_MapNode {
 	public:
@@ -1702,6 +1752,11 @@ class Handle_Interface_DataMapNodeOfDataMapOfTransientInteger : public Handle_TC
     }
 };
 
+%extend Interface_DataMapNodeOfDataMapOfTransientInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_DataMapOfTransientInteger;
 class Interface_DataMapOfTransientInteger : public TCollection_BasicMap {
 	public:
@@ -1780,6 +1835,11 @@ class Interface_DataMapOfTransientInteger : public TCollection_BasicMap {
 };
 
 
+%extend Interface_DataMapOfTransientInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_EntityCluster;
 class Interface_EntityCluster : public MMgt_TShared {
 	public:
@@ -1920,6 +1980,11 @@ class Handle_Interface_EntityCluster : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_EntityCluster {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_EntityIterator;
 class Interface_EntityIterator {
 	public:
@@ -2032,6 +2097,11 @@ class Interface_EntityIterator {
 };
 
 
+%extend Interface_EntityIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_EntityList;
 class Interface_EntityList {
 	public:
@@ -2138,6 +2208,11 @@ class Interface_EntityList {
 };
 
 
+%extend Interface_EntityList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_FileParameter;
 class Interface_FileParameter {
 	public:
@@ -2206,6 +2281,11 @@ class Interface_FileParameter {
 };
 
 
+%extend Interface_FileParameter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_FileReaderData;
 class Interface_FileReaderData : public MMgt_TShared {
 	public:
@@ -2482,6 +2562,11 @@ class Handle_Interface_FileReaderData : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_FileReaderData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_FileReaderTool;
 class Interface_FileReaderTool {
 	public:
@@ -2652,6 +2737,11 @@ class Interface_FileReaderTool {
 };
 
 
+%extend Interface_FileReaderTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_FloatWriter;
 class Interface_FloatWriter {
 	public:
@@ -2760,6 +2850,11 @@ class Interface_FloatWriter {
 };
 
 
+%extend Interface_FloatWriter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_GTool;
 class Interface_GTool : public MMgt_TShared {
 	public:
@@ -2910,6 +3005,11 @@ class Handle_Interface_GTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_GTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Interface_GeneralLib {
 	public:
 		%feature("compactdefaultargs") SetGlobal;
@@ -2977,6 +3077,11 @@ class Interface_GeneralLib {
 };
 
 
+%extend Interface_GeneralLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_GeneralModule;
 class Interface_GeneralModule : public MMgt_TShared {
 	public:
@@ -3217,6 +3322,11 @@ class Handle_Interface_GeneralModule : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_GeneralModule {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_GlobalNodeOfGeneralLib;
 class Interface_GlobalNodeOfGeneralLib : public Standard_Transient {
 	public:
@@ -3293,6 +3403,11 @@ class Handle_Interface_GlobalNodeOfGeneralLib : public Handle_Standard_Transient
     }
 };
 
+%extend Interface_GlobalNodeOfGeneralLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_GlobalNodeOfReaderLib;
 class Interface_GlobalNodeOfReaderLib : public Standard_Transient {
 	public:
@@ -3369,6 +3484,11 @@ class Handle_Interface_GlobalNodeOfReaderLib : public Handle_Standard_Transient 
     }
 };
 
+%extend Interface_GlobalNodeOfReaderLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Graph;
 class Interface_Graph {
 	public:
@@ -3701,6 +3821,11 @@ class Interface_Graph {
 };
 
 
+%extend Interface_Graph {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_HArray1OfHAsciiString;
 class Interface_HArray1OfHAsciiString : public MMgt_TShared {
 	public:
@@ -3817,6 +3942,11 @@ class Handle_Interface_HArray1OfHAsciiString : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_HArray1OfHAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_HGraph;
 class Interface_HGraph : public MMgt_TShared {
 	public:
@@ -3935,6 +4065,11 @@ class Handle_Interface_HGraph : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_HGraph {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_HSequenceOfCheck;
 class Interface_HSequenceOfCheck : public MMgt_TShared {
 	public:
@@ -4119,6 +4254,11 @@ class Handle_Interface_HSequenceOfCheck : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_HSequenceOfCheck {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_IndexedMapNodeOfIndexedMapOfAsciiString;
 class Interface_IndexedMapNodeOfIndexedMapOfAsciiString : public TCollection_MapNode {
 	public:
@@ -4204,6 +4344,11 @@ class Handle_Interface_IndexedMapNodeOfIndexedMapOfAsciiString : public Handle_T
     }
 };
 
+%extend Interface_IndexedMapNodeOfIndexedMapOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_IndexedMapOfAsciiString;
 class Interface_IndexedMapOfAsciiString : public TCollection_BasicMap {
 	public:
@@ -4280,6 +4425,11 @@ class Interface_IndexedMapOfAsciiString : public TCollection_BasicMap {
 };
 
 
+%extend Interface_IndexedMapOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_IntList;
 class Interface_IntList {
 	public:
@@ -4436,6 +4586,11 @@ class Interface_IntList {
 };
 
 
+%extend Interface_IntList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_IntVal;
 class Interface_IntVal : public MMgt_TShared {
 	public:
@@ -4509,6 +4664,11 @@ class Handle_Interface_IntVal : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_IntVal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_InterfaceModel;
 class Interface_InterfaceModel : public MMgt_TShared {
 	public:
@@ -5076,6 +5236,11 @@ class Handle_Interface_InterfaceModel : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_InterfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_LineBuffer;
 class Interface_LineBuffer {
 	public:
@@ -5200,6 +5365,11 @@ class Interface_LineBuffer {
 };
 
 
+%extend Interface_LineBuffer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_MSG;
 class Interface_MSG {
 	public:
@@ -5471,6 +5641,11 @@ class Interface_MSG {
 };
 
 
+%extend Interface_MSG {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Interface_MapAsciiStringHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -5492,6 +5667,11 @@ class Interface_MapAsciiStringHasher {
 };
 
 
+%extend Interface_MapAsciiStringHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_NodeOfGeneralLib;
 class Interface_NodeOfGeneralLib : public MMgt_TShared {
 	public:
@@ -5566,6 +5746,11 @@ class Handle_Interface_NodeOfGeneralLib : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_NodeOfGeneralLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_NodeOfReaderLib;
 class Interface_NodeOfReaderLib : public MMgt_TShared {
 	public:
@@ -5640,6 +5825,11 @@ class Handle_Interface_NodeOfReaderLib : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_NodeOfReaderLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ParamList;
 class Interface_ParamList : public MMgt_TShared {
 	public:
@@ -5748,6 +5938,11 @@ class Handle_Interface_ParamList : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_ParamList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ParamSet;
 class Interface_ParamSet : public MMgt_TShared {
 	public:
@@ -5880,6 +6075,11 @@ class Handle_Interface_ParamSet : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_ParamSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Protocol;
 class Interface_Protocol : public MMgt_TShared {
 	public:
@@ -6046,6 +6246,11 @@ class Handle_Interface_Protocol : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_Protocol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Interface_ReaderLib {
 	public:
 		%feature("compactdefaultargs") SetGlobal;
@@ -6113,6 +6318,11 @@ class Interface_ReaderLib {
 };
 
 
+%extend Interface_ReaderLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ReaderModule;
 class Interface_ReaderModule : public MMgt_TShared {
 	public:
@@ -6207,6 +6417,11 @@ class Handle_Interface_ReaderModule : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_ReaderModule {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ReportEntity;
 class Interface_ReportEntity : public MMgt_TShared {
 	public:
@@ -6333,6 +6548,11 @@ class Handle_Interface_ReportEntity : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_ReportEntity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_SequenceNodeOfSequenceOfCheck;
 class Interface_SequenceNodeOfSequenceOfCheck : public TCollection_SeqNode {
 	public:
@@ -6399,6 +6619,11 @@ class Handle_Interface_SequenceNodeOfSequenceOfCheck : public Handle_TCollection
     }
 };
 
+%extend Interface_SequenceNodeOfSequenceOfCheck {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_SequenceOfCheck;
 class Interface_SequenceOfCheck : public TCollection_BaseSequence {
 	public:
@@ -6537,6 +6762,11 @@ class Interface_SequenceOfCheck : public TCollection_BaseSequence {
 };
 
 
+%extend Interface_SequenceOfCheck {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ShareFlags;
 class Interface_ShareFlags {
 	public:
@@ -6623,6 +6853,11 @@ class Interface_ShareFlags {
 };
 
 
+%extend Interface_ShareFlags {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_ShareTool;
 class Interface_ShareTool {
 	public:
@@ -6765,6 +7000,11 @@ class Interface_ShareTool {
 };
 
 
+%extend Interface_ShareTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_SignLabel;
 class Interface_SignLabel : public MoniTool_SignText {
 	public:
@@ -6837,6 +7077,11 @@ class Handle_Interface_SignLabel : public Handle_MoniTool_SignText {
     }
 };
 
+%extend Interface_SignLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_SignType;
 class Interface_SignType : public MoniTool_SignText {
 	public:
@@ -6917,6 +7162,11 @@ class Handle_Interface_SignType : public Handle_MoniTool_SignText {
     }
 };
 
+%extend Interface_SignType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_TypedValue;
 class Interface_TypedValue : public MoniTool_TypedValue {
 	public:
@@ -7003,6 +7253,11 @@ class Handle_Interface_TypedValue : public Handle_MoniTool_TypedValue {
     }
 };
 
+%extend Interface_TypedValue {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_UndefinedContent;
 class Interface_UndefinedContent : public MMgt_TShared {
 	public:
@@ -7207,6 +7462,11 @@ class Handle_Interface_UndefinedContent : public Handle_MMgt_TShared {
     }
 };
 
+%extend Interface_UndefinedContent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_CopyMap;
 class Interface_CopyMap : public Interface_CopyControl {
 	public:
@@ -7299,6 +7559,11 @@ class Handle_Interface_CopyMap : public Handle_Interface_CopyControl {
     }
 };
 
+%extend Interface_CopyMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_GraphContent;
 class Interface_GraphContent : public Interface_EntityIterator {
 	public:
@@ -7375,6 +7640,11 @@ class Interface_GraphContent : public Interface_EntityIterator {
 };
 
 
+%extend Interface_GraphContent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Interface_Static;
 class Interface_Static : public Interface_TypedValue {
 	public:
@@ -7653,3 +7923,8 @@ class Handle_Interface_Static : public Handle_Interface_TypedValue {
     }
 };
 
+%extend Interface_Static {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Intf.i
+++ b/src/SWIG_files/wrapper/Intf.i
@@ -99,6 +99,11 @@ class Intf {
 };
 
 
+%extend Intf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_Array1OfLin;
 class Intf_Array1OfLin {
 	public:
@@ -181,6 +186,11 @@ class Intf_Array1OfLin {
 };
 
 
+%extend Intf_Array1OfLin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_Interference;
 class Intf_Interference {
 	public:
@@ -265,6 +275,11 @@ class Intf_Interference {
 };
 
 
+%extend Intf_Interference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_Polygon2d;
 class Intf_Polygon2d {
 	public:
@@ -307,6 +322,11 @@ class Intf_Polygon2d {
 };
 
 
+%extend Intf_Polygon2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Intf_SectionLine {
 	public:
 		%feature("compactdefaultargs") NumberOfPoints;
@@ -434,6 +454,11 @@ class Intf_SectionLine {
 };
 
 
+%extend Intf_SectionLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Intf_SectionPoint {
 	public:
 		%feature("compactdefaultargs") Pnt;
@@ -619,6 +644,11 @@ class Intf_SectionPoint {
 };
 
 
+%extend Intf_SectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SeqOfSectionLine;
 class Intf_SeqOfSectionLine : public TCollection_BaseSequence {
 	public:
@@ -757,6 +787,11 @@ class Intf_SeqOfSectionLine : public TCollection_BaseSequence {
 };
 
 
+%extend Intf_SeqOfSectionLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SeqOfSectionPoint;
 class Intf_SeqOfSectionPoint : public TCollection_BaseSequence {
 	public:
@@ -895,6 +930,11 @@ class Intf_SeqOfSectionPoint : public TCollection_BaseSequence {
 };
 
 
+%extend Intf_SeqOfSectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SeqOfTangentZone;
 class Intf_SeqOfTangentZone : public TCollection_BaseSequence {
 	public:
@@ -1033,6 +1073,11 @@ class Intf_SeqOfTangentZone : public TCollection_BaseSequence {
 };
 
 
+%extend Intf_SeqOfTangentZone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SequenceNodeOfSeqOfSectionLine;
 class Intf_SequenceNodeOfSeqOfSectionLine : public TCollection_SeqNode {
 	public:
@@ -1099,6 +1144,11 @@ class Handle_Intf_SequenceNodeOfSeqOfSectionLine : public Handle_TCollection_Seq
     }
 };
 
+%extend Intf_SequenceNodeOfSeqOfSectionLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SequenceNodeOfSeqOfSectionPoint;
 class Intf_SequenceNodeOfSeqOfSectionPoint : public TCollection_SeqNode {
 	public:
@@ -1165,6 +1215,11 @@ class Handle_Intf_SequenceNodeOfSeqOfSectionPoint : public Handle_TCollection_Se
     }
 };
 
+%extend Intf_SequenceNodeOfSeqOfSectionPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_SequenceNodeOfSeqOfTangentZone;
 class Intf_SequenceNodeOfSeqOfTangentZone : public TCollection_SeqNode {
 	public:
@@ -1231,6 +1286,11 @@ class Handle_Intf_SequenceNodeOfSeqOfTangentZone : public Handle_TCollection_Seq
     }
 };
 
+%extend Intf_SequenceNodeOfSeqOfTangentZone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Intf_TangentZone {
 	public:
 		%feature("compactdefaultargs") NumberOfPoints;
@@ -1416,6 +1476,11 @@ class Intf_TangentZone {
 };
 
 
+%extend Intf_TangentZone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_Tool;
 class Intf_Tool {
 	public:
@@ -1502,6 +1567,11 @@ class Intf_Tool {
 };
 
 
+%extend Intf_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intf_InterferencePolygon2d;
 class Intf_InterferencePolygon2d : public Intf_Interference {
 	public:
@@ -1558,3 +1628,8 @@ class Intf_InterferencePolygon2d : public Intf_Interference {
 };
 
 
+%extend Intf_InterferencePolygon2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Intrv.i
+++ b/src/SWIG_files/wrapper/Intrv.i
@@ -304,6 +304,11 @@ class Intrv_Interval {
 };
 
 
+%extend Intrv_Interval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intrv_Intervals;
 class Intrv_Intervals {
 	public:
@@ -394,6 +399,11 @@ class Intrv_Intervals {
 };
 
 
+%extend Intrv_Intervals {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intrv_SequenceNodeOfSequenceOfInterval;
 class Intrv_SequenceNodeOfSequenceOfInterval : public TCollection_SeqNode {
 	public:
@@ -460,6 +470,11 @@ class Handle_Intrv_SequenceNodeOfSequenceOfInterval : public Handle_TCollection_
     }
 };
 
+%extend Intrv_SequenceNodeOfSequenceOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Intrv_SequenceOfInterval;
 class Intrv_SequenceOfInterval : public TCollection_BaseSequence {
 	public:
@@ -598,3 +613,8 @@ class Intrv_SequenceOfInterval : public TCollection_BaseSequence {
 };
 
 
+%extend Intrv_SequenceOfInterval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/LProp.i
+++ b/src/SWIG_files/wrapper/LProp.i
@@ -91,6 +91,11 @@ class LProp_AnalyticCurInf {
 };
 
 
+%extend LProp_AnalyticCurInf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LProp_CurAndInf;
 class LProp_CurAndInf {
 	public:
@@ -145,6 +150,11 @@ class LProp_CurAndInf {
 };
 
 
+%extend LProp_CurAndInf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LProp_SequenceNodeOfSequenceOfCIType;
 class LProp_SequenceNodeOfSequenceOfCIType : public TCollection_SeqNode {
 	public:
@@ -211,6 +221,11 @@ class Handle_LProp_SequenceNodeOfSequenceOfCIType : public Handle_TCollection_Se
     }
 };
 
+%extend LProp_SequenceNodeOfSequenceOfCIType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LProp_SequenceOfCIType;
 class LProp_SequenceOfCIType : public TCollection_BaseSequence {
 	public:
@@ -349,3 +364,8 @@ class LProp_SequenceOfCIType : public TCollection_BaseSequence {
 };
 
 
+%extend LProp_SequenceOfCIType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/LProp3d.i
+++ b/src/SWIG_files/wrapper/LProp3d.i
@@ -146,6 +146,11 @@ class LProp3d_CLProps {
 };
 
 
+%extend LProp3d_CLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class LProp3d_CurveTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -235,6 +240,11 @@ class LProp3d_CurveTool {
 };
 
 
+%extend LProp3d_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LProp3d_SLProps;
 class LProp3d_SLProps {
 	public:
@@ -371,6 +381,11 @@ class LProp3d_SLProps {
 };
 
 
+%extend LProp3d_SLProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class LProp3d_SurfaceTool {
 	public:
 		%feature("compactdefaultargs") Value;
@@ -470,3 +485,8 @@ class LProp3d_SurfaceTool {
 };
 
 
+%extend LProp3d_SurfaceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Law.i
+++ b/src/SWIG_files/wrapper/Law.i
@@ -158,6 +158,11 @@ class Law {
 };
 
 
+%extend Law {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_BSpline;
 class Law_BSpline : public MMgt_TShared {
 	public:
@@ -802,6 +807,11 @@ class Handle_Law_BSpline : public Handle_MMgt_TShared {
     }
 };
 
+%extend Law_BSpline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_BSplineKnotSplitting;
 class Law_BSplineKnotSplitting {
 	public:
@@ -840,6 +850,11 @@ class Law_BSplineKnotSplitting {
 };
 
 
+%extend Law_BSplineKnotSplitting {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Function;
 class Law_Function : public MMgt_TShared {
 	public:
@@ -970,6 +985,11 @@ class Handle_Law_Function : public Handle_MMgt_TShared {
     }
 };
 
+%extend Law_Function {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Interpolate;
 class Law_Interpolate {
 	public:
@@ -1036,6 +1056,11 @@ class Law_Interpolate {
 };
 
 
+%extend Law_Interpolate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Laws;
 class Law_Laws {
 	public:
@@ -1166,6 +1191,11 @@ class Law_Laws {
 };
 
 
+%extend Law_Laws {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_ListIteratorOfLaws;
 class Law_ListIteratorOfLaws {
 	public:
@@ -1200,6 +1230,11 @@ class Law_ListIteratorOfLaws {
 };
 
 
+%extend Law_ListIteratorOfLaws {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_ListNodeOfLaws;
 class Law_ListNodeOfLaws : public TCollection_MapNode {
 	public:
@@ -1264,6 +1299,11 @@ class Handle_Law_ListNodeOfLaws : public Handle_TCollection_MapNode {
     }
 };
 
+%extend Law_ListNodeOfLaws {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_BSpFunc;
 class Law_BSpFunc : public Law_Function {
 	public:
@@ -1410,6 +1450,11 @@ class Handle_Law_BSpFunc : public Handle_Law_Function {
     }
 };
 
+%extend Law_BSpFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Composite;
 class Law_Composite : public Law_Function {
 	public:
@@ -1578,6 +1623,11 @@ class Handle_Law_Composite : public Handle_Law_Function {
     }
 };
 
+%extend Law_Composite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Constant;
 class Law_Constant : public Law_Function {
 	public:
@@ -1722,6 +1772,11 @@ class Handle_Law_Constant : public Handle_Law_Function {
     }
 };
 
+%extend Law_Constant {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Linear;
 class Law_Linear : public Law_Function {
 	public:
@@ -1872,6 +1927,11 @@ class Handle_Law_Linear : public Handle_Law_Function {
     }
 };
 
+%extend Law_Linear {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_Interpol;
 class Law_Interpol : public Law_BSpFunc {
 	public:
@@ -1982,6 +2042,11 @@ class Handle_Law_Interpol : public Handle_Law_BSpFunc {
     }
 };
 
+%extend Law_Interpol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Law_S;
 class Law_S : public Law_BSpFunc {
 	public:
@@ -2072,3 +2137,8 @@ class Handle_Law_S : public Handle_Law_BSpFunc {
     }
 };
 
+%extend Law_S {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/LocOpe.i
+++ b/src/SWIG_files/wrapper/LocOpe.i
@@ -108,6 +108,11 @@ class LocOpe {
 };
 
 
+%extend LocOpe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_BuildShape;
 class LocOpe_BuildShape {
 	public:
@@ -138,6 +143,11 @@ class LocOpe_BuildShape {
 };
 
 
+%extend LocOpe_BuildShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_BuildWires;
 class LocOpe_BuildWires {
 	public:
@@ -172,6 +182,11 @@ class LocOpe_BuildWires {
 };
 
 
+%extend LocOpe_BuildWires {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_CSIntersector;
 class LocOpe_CSIntersector {
 	public:
@@ -318,6 +333,11 @@ class LocOpe_CSIntersector {
 };
 
 
+%extend LocOpe_CSIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_CurveShapeIntersector;
 class LocOpe_CurveShapeIntersector {
 	public:
@@ -446,6 +466,11 @@ class LocOpe_CurveShapeIntersector {
 };
 
 
+%extend LocOpe_CurveShapeIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_DPrism;
 class LocOpe_DPrism {
 	public:
@@ -514,6 +539,11 @@ class LocOpe_DPrism {
 };
 
 
+%extend LocOpe_DPrism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_DataMapIteratorOfDataMapOfShapePnt;
 class LocOpe_DataMapIteratorOfDataMapOfShapePnt : public TCollection_BasicMapIterator {
 	public:
@@ -544,6 +574,11 @@ class LocOpe_DataMapIteratorOfDataMapOfShapePnt : public TCollection_BasicMapIte
 };
 
 
+%extend LocOpe_DataMapIteratorOfDataMapOfShapePnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_DataMapNodeOfDataMapOfShapePnt;
 class LocOpe_DataMapNodeOfDataMapOfShapePnt : public TCollection_MapNode {
 	public:
@@ -614,6 +649,11 @@ class Handle_LocOpe_DataMapNodeOfDataMapOfShapePnt : public Handle_TCollection_M
     }
 };
 
+%extend LocOpe_DataMapNodeOfDataMapOfShapePnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_DataMapOfShapePnt;
 class LocOpe_DataMapOfShapePnt : public TCollection_BasicMap {
 	public:
@@ -692,6 +732,11 @@ class LocOpe_DataMapOfShapePnt : public TCollection_BasicMap {
 };
 
 
+%extend LocOpe_DataMapOfShapePnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_FindEdges;
 class LocOpe_FindEdges {
 	public:
@@ -738,6 +783,11 @@ class LocOpe_FindEdges {
 };
 
 
+%extend LocOpe_FindEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_FindEdgesInFace;
 class LocOpe_FindEdgesInFace {
 	public:
@@ -780,6 +830,11 @@ class LocOpe_FindEdgesInFace {
 };
 
 
+%extend LocOpe_FindEdgesInFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_GeneratedShape;
 class LocOpe_GeneratedShape : public MMgt_TShared {
 	public:
@@ -858,6 +913,11 @@ class Handle_LocOpe_GeneratedShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend LocOpe_GeneratedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_Generator;
 class LocOpe_Generator {
 	public:
@@ -916,6 +976,11 @@ class LocOpe_Generator {
 };
 
 
+%extend LocOpe_Generator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_Gluer;
 class LocOpe_Gluer {
 	public:
@@ -996,6 +1061,11 @@ class LocOpe_Gluer {
 };
 
 
+%extend LocOpe_Gluer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_HBuilder;
 class LocOpe_HBuilder : public TopOpeBRepBuild_HBuilder {
 	public:
@@ -1064,6 +1134,11 @@ class Handle_LocOpe_HBuilder : public Handle_TopOpeBRepBuild_HBuilder {
     }
 };
 
+%extend LocOpe_HBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_LinearForm;
 class LocOpe_LinearForm {
 	public:
@@ -1144,6 +1219,11 @@ class LocOpe_LinearForm {
 };
 
 
+%extend LocOpe_LinearForm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_Pipe;
 class LocOpe_Pipe {
 	public:
@@ -1194,6 +1274,11 @@ class LocOpe_Pipe {
 };
 
 
+%extend LocOpe_Pipe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_PntFace;
 class LocOpe_PntFace {
 	public:
@@ -1250,6 +1335,11 @@ class LocOpe_PntFace {
 };
 
 
+%extend LocOpe_PntFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_Prism;
 class LocOpe_Prism {
 	public:
@@ -1324,6 +1414,11 @@ class LocOpe_Prism {
 };
 
 
+%extend LocOpe_Prism {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceNodeOfSequenceOfCirc;
 class LocOpe_SequenceNodeOfSequenceOfCirc : public TCollection_SeqNode {
 	public:
@@ -1390,6 +1485,11 @@ class Handle_LocOpe_SequenceNodeOfSequenceOfCirc : public Handle_TCollection_Seq
     }
 };
 
+%extend LocOpe_SequenceNodeOfSequenceOfCirc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceNodeOfSequenceOfLin;
 class LocOpe_SequenceNodeOfSequenceOfLin : public TCollection_SeqNode {
 	public:
@@ -1456,6 +1556,11 @@ class Handle_LocOpe_SequenceNodeOfSequenceOfLin : public Handle_TCollection_SeqN
     }
 };
 
+%extend LocOpe_SequenceNodeOfSequenceOfLin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceNodeOfSequenceOfPntFace;
 class LocOpe_SequenceNodeOfSequenceOfPntFace : public TCollection_SeqNode {
 	public:
@@ -1522,6 +1627,11 @@ class Handle_LocOpe_SequenceNodeOfSequenceOfPntFace : public Handle_TCollection_
     }
 };
 
+%extend LocOpe_SequenceNodeOfSequenceOfPntFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceOfCirc;
 class LocOpe_SequenceOfCirc : public TCollection_BaseSequence {
 	public:
@@ -1660,6 +1770,11 @@ class LocOpe_SequenceOfCirc : public TCollection_BaseSequence {
 };
 
 
+%extend LocOpe_SequenceOfCirc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceOfLin;
 class LocOpe_SequenceOfLin : public TCollection_BaseSequence {
 	public:
@@ -1798,6 +1913,11 @@ class LocOpe_SequenceOfLin : public TCollection_BaseSequence {
 };
 
 
+%extend LocOpe_SequenceOfLin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SequenceOfPntFace;
 class LocOpe_SequenceOfPntFace : public TCollection_BaseSequence {
 	public:
@@ -1936,6 +2056,11 @@ class LocOpe_SequenceOfPntFace : public TCollection_BaseSequence {
 };
 
 
+%extend LocOpe_SequenceOfPntFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SplitDrafts;
 class LocOpe_SplitDrafts {
 	public:
@@ -2030,6 +2155,11 @@ class LocOpe_SplitDrafts {
 };
 
 
+%extend LocOpe_SplitDrafts {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_SplitShape;
 class LocOpe_SplitShape {
 	public:
@@ -2122,6 +2252,11 @@ class LocOpe_SplitShape {
 };
 
 
+%extend LocOpe_SplitShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_Spliter;
 class LocOpe_Spliter {
 	public:
@@ -2192,6 +2327,11 @@ class LocOpe_Spliter {
 };
 
 
+%extend LocOpe_Spliter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_WiresOnShape;
 class LocOpe_WiresOnShape : public MMgt_TShared {
 	public:
@@ -2376,6 +2516,11 @@ class Handle_LocOpe_WiresOnShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend LocOpe_WiresOnShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocOpe_GluedShape;
 class LocOpe_GluedShape : public LocOpe_GeneratedShape {
 	public:
@@ -2476,3 +2621,8 @@ class Handle_LocOpe_GluedShape : public Handle_LocOpe_GeneratedShape {
     }
 };
 
+%extend LocOpe_GluedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/LocalAnalysis.i
+++ b/src/SWIG_files/wrapper/LocalAnalysis.i
@@ -90,6 +90,11 @@ class LocalAnalysis {
 };
 
 
+%extend LocalAnalysis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocalAnalysis_CurveContinuity;
 class LocalAnalysis_CurveContinuity {
 	public:
@@ -192,6 +197,11 @@ class LocalAnalysis_CurveContinuity {
 };
 
 
+%extend LocalAnalysis_CurveContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor LocalAnalysis_SurfaceContinuity;
 class LocalAnalysis_SurfaceContinuity {
 	public:
@@ -368,3 +378,8 @@ class LocalAnalysis_SurfaceContinuity {
 };
 
 
+%extend LocalAnalysis_SurfaceContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/MAT.i
+++ b/src/SWIG_files/wrapper/MAT.i
@@ -251,6 +251,11 @@ class Handle_MAT_Arc : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Arc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_BasicElt;
 class MAT_BasicElt : public MMgt_TShared {
 	public:
@@ -359,6 +364,11 @@ class Handle_MAT_BasicElt : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_BasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_Bisector;
 class MAT_Bisector : public MMgt_TShared {
 	public:
@@ -561,6 +571,11 @@ class Handle_MAT_Bisector : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Bisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapIteratorOfDataMapOfIntegerArc;
 class MAT_DataMapIteratorOfDataMapOfIntegerArc : public TCollection_BasicMapIterator {
 	public:
@@ -591,6 +606,11 @@ class MAT_DataMapIteratorOfDataMapOfIntegerArc : public TCollection_BasicMapIter
 };
 
 
+%extend MAT_DataMapIteratorOfDataMapOfIntegerArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapIteratorOfDataMapOfIntegerBasicElt;
 class MAT_DataMapIteratorOfDataMapOfIntegerBasicElt : public TCollection_BasicMapIterator {
 	public:
@@ -621,6 +641,11 @@ class MAT_DataMapIteratorOfDataMapOfIntegerBasicElt : public TCollection_BasicMa
 };
 
 
+%extend MAT_DataMapIteratorOfDataMapOfIntegerBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapIteratorOfDataMapOfIntegerBisector;
 class MAT_DataMapIteratorOfDataMapOfIntegerBisector : public TCollection_BasicMapIterator {
 	public:
@@ -651,6 +676,11 @@ class MAT_DataMapIteratorOfDataMapOfIntegerBisector : public TCollection_BasicMa
 };
 
 
+%extend MAT_DataMapIteratorOfDataMapOfIntegerBisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapIteratorOfDataMapOfIntegerNode;
 class MAT_DataMapIteratorOfDataMapOfIntegerNode : public TCollection_BasicMapIterator {
 	public:
@@ -681,6 +711,11 @@ class MAT_DataMapIteratorOfDataMapOfIntegerNode : public TCollection_BasicMapIte
 };
 
 
+%extend MAT_DataMapIteratorOfDataMapOfIntegerNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapNodeOfDataMapOfIntegerArc;
 class MAT_DataMapNodeOfDataMapOfIntegerArc : public TCollection_MapNode {
 	public:
@@ -760,6 +795,11 @@ class Handle_MAT_DataMapNodeOfDataMapOfIntegerArc : public Handle_TCollection_Ma
     }
 };
 
+%extend MAT_DataMapNodeOfDataMapOfIntegerArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapNodeOfDataMapOfIntegerBasicElt;
 class MAT_DataMapNodeOfDataMapOfIntegerBasicElt : public TCollection_MapNode {
 	public:
@@ -839,6 +879,11 @@ class Handle_MAT_DataMapNodeOfDataMapOfIntegerBasicElt : public Handle_TCollecti
     }
 };
 
+%extend MAT_DataMapNodeOfDataMapOfIntegerBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapNodeOfDataMapOfIntegerBisector;
 class MAT_DataMapNodeOfDataMapOfIntegerBisector : public TCollection_MapNode {
 	public:
@@ -918,6 +963,11 @@ class Handle_MAT_DataMapNodeOfDataMapOfIntegerBisector : public Handle_TCollecti
     }
 };
 
+%extend MAT_DataMapNodeOfDataMapOfIntegerBisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapNodeOfDataMapOfIntegerNode;
 class MAT_DataMapNodeOfDataMapOfIntegerNode : public TCollection_MapNode {
 	public:
@@ -997,6 +1047,11 @@ class Handle_MAT_DataMapNodeOfDataMapOfIntegerNode : public Handle_TCollection_M
     }
 };
 
+%extend MAT_DataMapNodeOfDataMapOfIntegerNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapOfIntegerArc;
 class MAT_DataMapOfIntegerArc : public TCollection_BasicMap {
 	public:
@@ -1075,6 +1130,11 @@ class MAT_DataMapOfIntegerArc : public TCollection_BasicMap {
 };
 
 
+%extend MAT_DataMapOfIntegerArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapOfIntegerBasicElt;
 class MAT_DataMapOfIntegerBasicElt : public TCollection_BasicMap {
 	public:
@@ -1153,6 +1213,11 @@ class MAT_DataMapOfIntegerBasicElt : public TCollection_BasicMap {
 };
 
 
+%extend MAT_DataMapOfIntegerBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapOfIntegerBisector;
 class MAT_DataMapOfIntegerBisector : public TCollection_BasicMap {
 	public:
@@ -1231,6 +1296,11 @@ class MAT_DataMapOfIntegerBisector : public TCollection_BasicMap {
 };
 
 
+%extend MAT_DataMapOfIntegerBisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_DataMapOfIntegerNode;
 class MAT_DataMapOfIntegerNode : public TCollection_BasicMap {
 	public:
@@ -1309,6 +1379,11 @@ class MAT_DataMapOfIntegerNode : public TCollection_BasicMap {
 };
 
 
+%extend MAT_DataMapOfIntegerNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_Edge;
 class MAT_Edge : public MMgt_TShared {
 	public:
@@ -1423,6 +1498,11 @@ class Handle_MAT_Edge : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_Graph;
 class MAT_Graph : public MMgt_TShared {
 	public:
@@ -1585,6 +1665,11 @@ class Handle_MAT_Graph : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Graph {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_ListOfBisector;
 class MAT_ListOfBisector : public MMgt_TShared {
 	public:
@@ -1755,6 +1840,11 @@ class Handle_MAT_ListOfBisector : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_ListOfBisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_ListOfEdge;
 class MAT_ListOfEdge : public MMgt_TShared {
 	public:
@@ -1925,6 +2015,11 @@ class Handle_MAT_ListOfEdge : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_ListOfEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_Node;
 class MAT_Node : public MMgt_TShared {
 	public:
@@ -2051,6 +2146,11 @@ class Handle_MAT_Node : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Node {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_SequenceNodeOfSequenceOfArc;
 class MAT_SequenceNodeOfSequenceOfArc : public TCollection_SeqNode {
 	public:
@@ -2117,6 +2217,11 @@ class Handle_MAT_SequenceNodeOfSequenceOfArc : public Handle_TCollection_SeqNode
     }
 };
 
+%extend MAT_SequenceNodeOfSequenceOfArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_SequenceNodeOfSequenceOfBasicElt;
 class MAT_SequenceNodeOfSequenceOfBasicElt : public TCollection_SeqNode {
 	public:
@@ -2183,6 +2288,11 @@ class Handle_MAT_SequenceNodeOfSequenceOfBasicElt : public Handle_TCollection_Se
     }
 };
 
+%extend MAT_SequenceNodeOfSequenceOfBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_SequenceOfArc;
 class MAT_SequenceOfArc : public TCollection_BaseSequence {
 	public:
@@ -2321,6 +2431,11 @@ class MAT_SequenceOfArc : public TCollection_BaseSequence {
 };
 
 
+%extend MAT_SequenceOfArc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_SequenceOfBasicElt;
 class MAT_SequenceOfBasicElt : public TCollection_BaseSequence {
 	public:
@@ -2459,6 +2574,11 @@ class MAT_SequenceOfBasicElt : public TCollection_BaseSequence {
 };
 
 
+%extend MAT_SequenceOfBasicElt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_TListNodeOfListOfBisector;
 class MAT_TListNodeOfListOfBisector : public MMgt_TShared {
 	public:
@@ -2555,6 +2675,11 @@ class Handle_MAT_TListNodeOfListOfBisector : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_TListNodeOfListOfBisector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_TListNodeOfListOfEdge;
 class MAT_TListNodeOfListOfEdge : public MMgt_TShared {
 	public:
@@ -2651,6 +2776,11 @@ class Handle_MAT_TListNodeOfListOfEdge : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_TListNodeOfListOfEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT_Zone;
 class MAT_Zone : public MMgt_TShared {
 	public:
@@ -2749,3 +2879,8 @@ class Handle_MAT_Zone : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT_Zone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/MAT2d.i
+++ b/src/SWIG_files/wrapper/MAT2d.i
@@ -160,6 +160,11 @@ class MAT2d_Array2OfConnexion {
 };
 
 
+%extend MAT2d_Array2OfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_BiInt;
 class MAT2d_BiInt {
 	public:
@@ -214,6 +219,11 @@ class MAT2d_BiInt {
         };
 
 
+%extend MAT2d_BiInt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_Circuit;
 class MAT2d_Circuit : public MMgt_TShared {
 	public:
@@ -334,6 +344,11 @@ class Handle_MAT2d_Circuit : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT2d_Circuit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_Connexion;
 class MAT2d_Connexion : public MMgt_TShared {
 	public:
@@ -546,6 +561,11 @@ class Handle_MAT2d_Connexion : public Handle_MMgt_TShared {
     }
 };
 
+%extend MAT2d_Connexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfBiIntInteger;
 class MAT2d_DataMapIteratorOfDataMapOfBiIntInteger : public TCollection_BasicMapIterator {
 	public:
@@ -576,6 +596,11 @@ class MAT2d_DataMapIteratorOfDataMapOfBiIntInteger : public TCollection_BasicMap
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfBiIntInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfBiIntSequenceOfInteger;
 class MAT2d_DataMapIteratorOfDataMapOfBiIntSequenceOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -606,6 +631,11 @@ class MAT2d_DataMapIteratorOfDataMapOfBiIntSequenceOfInteger : public TCollectio
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfBiIntSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfIntegerBisec;
 class MAT2d_DataMapIteratorOfDataMapOfIntegerBisec : public TCollection_BasicMapIterator {
 	public:
@@ -636,6 +666,11 @@ class MAT2d_DataMapIteratorOfDataMapOfIntegerBisec : public TCollection_BasicMap
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfIntegerBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfIntegerConnexion;
 class MAT2d_DataMapIteratorOfDataMapOfIntegerConnexion : public TCollection_BasicMapIterator {
 	public:
@@ -666,6 +701,11 @@ class MAT2d_DataMapIteratorOfDataMapOfIntegerConnexion : public TCollection_Basi
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfIntegerConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfIntegerPnt2d;
 class MAT2d_DataMapIteratorOfDataMapOfIntegerPnt2d : public TCollection_BasicMapIterator {
 	public:
@@ -696,6 +736,11 @@ class MAT2d_DataMapIteratorOfDataMapOfIntegerPnt2d : public TCollection_BasicMap
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfIntegerPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfIntegerSequenceOfConnexion;
 class MAT2d_DataMapIteratorOfDataMapOfIntegerSequenceOfConnexion : public TCollection_BasicMapIterator {
 	public:
@@ -726,6 +771,11 @@ class MAT2d_DataMapIteratorOfDataMapOfIntegerSequenceOfConnexion : public TColle
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfIntegerSequenceOfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapIteratorOfDataMapOfIntegerVec2d;
 class MAT2d_DataMapIteratorOfDataMapOfIntegerVec2d : public TCollection_BasicMapIterator {
 	public:
@@ -756,6 +806,11 @@ class MAT2d_DataMapIteratorOfDataMapOfIntegerVec2d : public TCollection_BasicMap
 };
 
 
+%extend MAT2d_DataMapIteratorOfDataMapOfIntegerVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfBiIntInteger;
 class MAT2d_DataMapNodeOfDataMapOfBiIntInteger : public TCollection_MapNode {
 	public:
@@ -835,6 +890,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfBiIntInteger : public Handle_TCollectio
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfBiIntInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfBiIntSequenceOfInteger;
 class MAT2d_DataMapNodeOfDataMapOfBiIntSequenceOfInteger : public TCollection_MapNode {
 	public:
@@ -905,6 +965,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfBiIntSequenceOfInteger : public Handle_
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfBiIntSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfIntegerBisec;
 class MAT2d_DataMapNodeOfDataMapOfIntegerBisec : public TCollection_MapNode {
 	public:
@@ -984,6 +1049,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfIntegerBisec : public Handle_TCollectio
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfIntegerBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfIntegerConnexion;
 class MAT2d_DataMapNodeOfDataMapOfIntegerConnexion : public TCollection_MapNode {
 	public:
@@ -1063,6 +1133,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfIntegerConnexion : public Handle_TColle
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfIntegerConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfIntegerPnt2d;
 class MAT2d_DataMapNodeOfDataMapOfIntegerPnt2d : public TCollection_MapNode {
 	public:
@@ -1142,6 +1217,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfIntegerPnt2d : public Handle_TCollectio
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfIntegerPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfIntegerSequenceOfConnexion;
 class MAT2d_DataMapNodeOfDataMapOfIntegerSequenceOfConnexion : public TCollection_MapNode {
 	public:
@@ -1221,6 +1301,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfIntegerSequenceOfConnexion : public Han
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfIntegerSequenceOfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapNodeOfDataMapOfIntegerVec2d;
 class MAT2d_DataMapNodeOfDataMapOfIntegerVec2d : public TCollection_MapNode {
 	public:
@@ -1300,6 +1385,11 @@ class Handle_MAT2d_DataMapNodeOfDataMapOfIntegerVec2d : public Handle_TCollectio
     }
 };
 
+%extend MAT2d_DataMapNodeOfDataMapOfIntegerVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfBiIntInteger;
 class MAT2d_DataMapOfBiIntInteger : public TCollection_BasicMap {
 	public:
@@ -1378,6 +1468,11 @@ class MAT2d_DataMapOfBiIntInteger : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfBiIntInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfBiIntSequenceOfInteger;
 class MAT2d_DataMapOfBiIntSequenceOfInteger : public TCollection_BasicMap {
 	public:
@@ -1456,6 +1551,11 @@ class MAT2d_DataMapOfBiIntSequenceOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfBiIntSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfIntegerBisec;
 class MAT2d_DataMapOfIntegerBisec : public TCollection_BasicMap {
 	public:
@@ -1534,6 +1634,11 @@ class MAT2d_DataMapOfIntegerBisec : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfIntegerBisec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfIntegerConnexion;
 class MAT2d_DataMapOfIntegerConnexion : public TCollection_BasicMap {
 	public:
@@ -1612,6 +1717,11 @@ class MAT2d_DataMapOfIntegerConnexion : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfIntegerConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfIntegerPnt2d;
 class MAT2d_DataMapOfIntegerPnt2d : public TCollection_BasicMap {
 	public:
@@ -1690,6 +1800,11 @@ class MAT2d_DataMapOfIntegerPnt2d : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfIntegerPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfIntegerSequenceOfConnexion;
 class MAT2d_DataMapOfIntegerSequenceOfConnexion : public TCollection_BasicMap {
 	public:
@@ -1768,6 +1883,11 @@ class MAT2d_DataMapOfIntegerSequenceOfConnexion : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfIntegerSequenceOfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_DataMapOfIntegerVec2d;
 class MAT2d_DataMapOfIntegerVec2d : public TCollection_BasicMap {
 	public:
@@ -1846,6 +1966,11 @@ class MAT2d_DataMapOfIntegerVec2d : public TCollection_BasicMap {
 };
 
 
+%extend MAT2d_DataMapOfIntegerVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class MAT2d_MapBiIntHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -1867,6 +1992,11 @@ class MAT2d_MapBiIntHasher {
 };
 
 
+%extend MAT2d_MapBiIntHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_Mat2d;
 class MAT2d_Mat2d {
 	public:
@@ -1939,6 +2069,11 @@ class MAT2d_Mat2d {
 };
 
 
+%extend MAT2d_Mat2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_MiniPath;
 class MAT2d_MiniPath {
 	public:
@@ -2005,6 +2140,11 @@ class MAT2d_MiniPath {
 };
 
 
+%extend MAT2d_MiniPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceNodeOfSequenceOfConnexion;
 class MAT2d_SequenceNodeOfSequenceOfConnexion : public TCollection_SeqNode {
 	public:
@@ -2071,6 +2211,11 @@ class Handle_MAT2d_SequenceNodeOfSequenceOfConnexion : public Handle_TCollection
     }
 };
 
+%extend MAT2d_SequenceNodeOfSequenceOfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceNodeOfSequenceOfSequenceOfCurve;
 class MAT2d_SequenceNodeOfSequenceOfSequenceOfCurve : public TCollection_SeqNode {
 	public:
@@ -2137,6 +2282,11 @@ class Handle_MAT2d_SequenceNodeOfSequenceOfSequenceOfCurve : public Handle_TColl
     }
 };
 
+%extend MAT2d_SequenceNodeOfSequenceOfSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceNodeOfSequenceOfSequenceOfGeometry;
 class MAT2d_SequenceNodeOfSequenceOfSequenceOfGeometry : public TCollection_SeqNode {
 	public:
@@ -2203,6 +2353,11 @@ class Handle_MAT2d_SequenceNodeOfSequenceOfSequenceOfGeometry : public Handle_TC
     }
 };
 
+%extend MAT2d_SequenceNodeOfSequenceOfSequenceOfGeometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceOfConnexion;
 class MAT2d_SequenceOfConnexion : public TCollection_BaseSequence {
 	public:
@@ -2341,6 +2496,11 @@ class MAT2d_SequenceOfConnexion : public TCollection_BaseSequence {
 };
 
 
+%extend MAT2d_SequenceOfConnexion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceOfSequenceOfCurve;
 class MAT2d_SequenceOfSequenceOfCurve : public TCollection_BaseSequence {
 	public:
@@ -2479,6 +2639,11 @@ class MAT2d_SequenceOfSequenceOfCurve : public TCollection_BaseSequence {
 };
 
 
+%extend MAT2d_SequenceOfSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_SequenceOfSequenceOfGeometry;
 class MAT2d_SequenceOfSequenceOfGeometry : public TCollection_BaseSequence {
 	public:
@@ -2617,6 +2782,11 @@ class MAT2d_SequenceOfSequenceOfGeometry : public TCollection_BaseSequence {
 };
 
 
+%extend MAT2d_SequenceOfSequenceOfGeometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MAT2d_Tool2d;
 class MAT2d_Tool2d {
 	public:
@@ -2813,3 +2983,8 @@ class MAT2d_Tool2d {
 };
 
 
+%extend MAT2d_Tool2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/MMgt.i
+++ b/src/SWIG_files/wrapper/MMgt.i
@@ -112,3 +112,8 @@ class Handle_MMgt_TShared : public Handle_Standard_Transient {
     }
 };
 
+%extend MMgt_TShared {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/MeshVS.i
+++ b/src/SWIG_files/wrapper/MeshVS.i
@@ -243,6 +243,11 @@ class MeshVS_Array1OfSequenceOfInteger {
 };
 
 
+%extend MeshVS_Array1OfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class MeshVS_ColorHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -264,6 +269,11 @@ class MeshVS_ColorHasher {
 };
 
 
+%extend MeshVS_ColorHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfColorMapOfInteger;
 class MeshVS_DataMapIteratorOfDataMapOfColorMapOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -294,6 +304,11 @@ class MeshVS_DataMapIteratorOfDataMapOfColorMapOfInteger : public TCollection_Ba
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfColorMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfHArray1OfSequenceOfInteger;
 class MeshVS_DataMapIteratorOfDataMapOfHArray1OfSequenceOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -324,6 +339,11 @@ class MeshVS_DataMapIteratorOfDataMapOfHArray1OfSequenceOfInteger : public TColl
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfHArray1OfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerAsciiString;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerAsciiString : public TCollection_BasicMapIterator {
 	public:
@@ -354,6 +374,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerAsciiString : public TCollection_B
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerBoolean;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerBoolean : public TCollection_BasicMapIterator {
 	public:
@@ -384,6 +409,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerBoolean : public TCollection_Basic
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerColor;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerColor : public TCollection_BasicMapIterator {
 	public:
@@ -414,6 +444,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerColor : public TCollection_BasicMa
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerMaterial;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerMaterial : public TCollection_BasicMapIterator {
 	public:
@@ -444,6 +479,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerMaterial : public TCollection_Basi
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerMaterial {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerMeshEntityOwner;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerMeshEntityOwner : public TCollection_BasicMapIterator {
 	public:
@@ -474,6 +514,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerMeshEntityOwner : public TCollecti
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerMeshEntityOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerOwner;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerOwner : public TCollection_BasicMapIterator {
 	public:
@@ -504,6 +549,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerOwner : public TCollection_BasicMa
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerTwoColors;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerTwoColors : public TCollection_BasicMapIterator {
 	public:
@@ -534,6 +584,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerTwoColors : public TCollection_Bas
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerTwoColors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfIntegerVector;
 class MeshVS_DataMapIteratorOfDataMapOfIntegerVector : public TCollection_BasicMapIterator {
 	public:
@@ -564,6 +619,11 @@ class MeshVS_DataMapIteratorOfDataMapOfIntegerVector : public TCollection_BasicM
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfIntegerVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapIteratorOfDataMapOfTwoColorsMapOfInteger;
 class MeshVS_DataMapIteratorOfDataMapOfTwoColorsMapOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -594,6 +654,11 @@ class MeshVS_DataMapIteratorOfDataMapOfTwoColorsMapOfInteger : public TCollectio
 };
 
 
+%extend MeshVS_DataMapIteratorOfDataMapOfTwoColorsMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfColorMapOfInteger;
 class MeshVS_DataMapNodeOfDataMapOfColorMapOfInteger : public TCollection_MapNode {
 	public:
@@ -664,6 +729,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfColorMapOfInteger : public Handle_TCol
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfColorMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfHArray1OfSequenceOfInteger;
 class MeshVS_DataMapNodeOfDataMapOfHArray1OfSequenceOfInteger : public TCollection_MapNode {
 	public:
@@ -743,6 +813,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfHArray1OfSequenceOfInteger : public Ha
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfHArray1OfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerAsciiString;
 class MeshVS_DataMapNodeOfDataMapOfIntegerAsciiString : public TCollection_MapNode {
 	public:
@@ -822,6 +897,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerAsciiString : public Handle_TCo
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerBoolean;
 class MeshVS_DataMapNodeOfDataMapOfIntegerBoolean : public TCollection_MapNode {
 	public:
@@ -910,6 +990,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerBoolean : public Handle_TCollec
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerColor;
 class MeshVS_DataMapNodeOfDataMapOfIntegerColor : public TCollection_MapNode {
 	public:
@@ -989,6 +1074,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerColor : public Handle_TCollecti
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerMaterial;
 class MeshVS_DataMapNodeOfDataMapOfIntegerMaterial : public TCollection_MapNode {
 	public:
@@ -1068,6 +1158,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerMaterial : public Handle_TColle
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerMaterial {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerMeshEntityOwner;
 class MeshVS_DataMapNodeOfDataMapOfIntegerMeshEntityOwner : public TCollection_MapNode {
 	public:
@@ -1147,6 +1242,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerMeshEntityOwner : public Handle
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerMeshEntityOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerOwner;
 class MeshVS_DataMapNodeOfDataMapOfIntegerOwner : public TCollection_MapNode {
 	public:
@@ -1226,6 +1326,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerOwner : public Handle_TCollecti
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerTwoColors;
 class MeshVS_DataMapNodeOfDataMapOfIntegerTwoColors : public TCollection_MapNode {
 	public:
@@ -1305,6 +1410,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerTwoColors : public Handle_TColl
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerTwoColors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfIntegerVector;
 class MeshVS_DataMapNodeOfDataMapOfIntegerVector : public TCollection_MapNode {
 	public:
@@ -1384,6 +1494,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfIntegerVector : public Handle_TCollect
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfIntegerVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapNodeOfDataMapOfTwoColorsMapOfInteger;
 class MeshVS_DataMapNodeOfDataMapOfTwoColorsMapOfInteger : public TCollection_MapNode {
 	public:
@@ -1454,6 +1569,11 @@ class Handle_MeshVS_DataMapNodeOfDataMapOfTwoColorsMapOfInteger : public Handle_
     }
 };
 
+%extend MeshVS_DataMapNodeOfDataMapOfTwoColorsMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfColorMapOfInteger;
 class MeshVS_DataMapOfColorMapOfInteger : public TCollection_BasicMap {
 	public:
@@ -1532,6 +1652,11 @@ class MeshVS_DataMapOfColorMapOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfColorMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfHArray1OfSequenceOfInteger;
 class MeshVS_DataMapOfHArray1OfSequenceOfInteger : public TCollection_BasicMap {
 	public:
@@ -1610,6 +1735,11 @@ class MeshVS_DataMapOfHArray1OfSequenceOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfHArray1OfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerAsciiString;
 class MeshVS_DataMapOfIntegerAsciiString : public TCollection_BasicMap {
 	public:
@@ -1688,6 +1818,11 @@ class MeshVS_DataMapOfIntegerAsciiString : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerBoolean;
 class MeshVS_DataMapOfIntegerBoolean : public TCollection_BasicMap {
 	public:
@@ -1766,6 +1901,11 @@ class MeshVS_DataMapOfIntegerBoolean : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerColor;
 class MeshVS_DataMapOfIntegerColor : public TCollection_BasicMap {
 	public:
@@ -1844,6 +1984,11 @@ class MeshVS_DataMapOfIntegerColor : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerMaterial;
 class MeshVS_DataMapOfIntegerMaterial : public TCollection_BasicMap {
 	public:
@@ -1922,6 +2067,11 @@ class MeshVS_DataMapOfIntegerMaterial : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerMaterial {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerMeshEntityOwner;
 class MeshVS_DataMapOfIntegerMeshEntityOwner : public TCollection_BasicMap {
 	public:
@@ -2000,6 +2150,11 @@ class MeshVS_DataMapOfIntegerMeshEntityOwner : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerMeshEntityOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerOwner;
 class MeshVS_DataMapOfIntegerOwner : public TCollection_BasicMap {
 	public:
@@ -2078,6 +2233,11 @@ class MeshVS_DataMapOfIntegerOwner : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerTwoColors;
 class MeshVS_DataMapOfIntegerTwoColors : public TCollection_BasicMap {
 	public:
@@ -2156,6 +2316,11 @@ class MeshVS_DataMapOfIntegerTwoColors : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerTwoColors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfIntegerVector;
 class MeshVS_DataMapOfIntegerVector : public TCollection_BasicMap {
 	public:
@@ -2234,6 +2399,11 @@ class MeshVS_DataMapOfIntegerVector : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfIntegerVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataMapOfTwoColorsMapOfInteger;
 class MeshVS_DataMapOfTwoColorsMapOfInteger : public TCollection_BasicMap {
 	public:
@@ -2312,6 +2482,11 @@ class MeshVS_DataMapOfTwoColorsMapOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_DataMapOfTwoColorsMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataSource;
 class MeshVS_DataSource : public MMgt_TShared {
 	public:
@@ -2596,6 +2771,11 @@ class Handle_MeshVS_DataSource : public Handle_MMgt_TShared {
     }
 };
 
+%extend MeshVS_DataSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_Drawer;
 class MeshVS_Drawer : public MMgt_TShared {
 	public:
@@ -2788,6 +2968,11 @@ class Handle_MeshVS_Drawer : public Handle_MMgt_TShared {
     }
 };
 
+%extend MeshVS_Drawer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DummySensitiveEntity;
 class MeshVS_DummySensitiveEntity : public SelectBasics_SensitiveEntity {
 	public:
@@ -2898,6 +3083,11 @@ class Handle_MeshVS_DummySensitiveEntity : public Handle_SelectBasics_SensitiveE
     }
 };
 
+%extend MeshVS_DummySensitiveEntity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_HArray1OfSequenceOfInteger;
 class MeshVS_HArray1OfSequenceOfInteger : public MMgt_TShared {
 	public:
@@ -3014,6 +3204,11 @@ class Handle_MeshVS_HArray1OfSequenceOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend MeshVS_HArray1OfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_MapIteratorOfMapOfTwoNodes;
 class MeshVS_MapIteratorOfMapOfTwoNodes : public TCollection_BasicMapIterator {
 	public:
@@ -3040,6 +3235,11 @@ class MeshVS_MapIteratorOfMapOfTwoNodes : public TCollection_BasicMapIterator {
 };
 
 
+%extend MeshVS_MapIteratorOfMapOfTwoNodes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_MapOfTwoNodes;
 class MeshVS_MapOfTwoNodes : public TCollection_BasicMap {
 	public:
@@ -3098,6 +3298,11 @@ class MeshVS_MapOfTwoNodes : public TCollection_BasicMap {
 };
 
 
+%extend MeshVS_MapOfTwoNodes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_Mesh;
 class MeshVS_Mesh : public AIS_InteractiveObject {
 	public:
@@ -3442,6 +3647,11 @@ class Handle_MeshVS_Mesh : public Handle_AIS_InteractiveObject {
     }
 };
 
+%extend MeshVS_Mesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_MeshEntityOwner;
 class MeshVS_MeshEntityOwner : public SelectMgr_EntityOwner {
 	public:
@@ -3590,6 +3800,11 @@ class Handle_MeshVS_MeshEntityOwner : public Handle_SelectMgr_EntityOwner {
     }
 };
 
+%extend MeshVS_MeshEntityOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_MeshOwner;
 class MeshVS_MeshOwner : public SelectMgr_EntityOwner {
 	public:
@@ -3728,6 +3943,11 @@ class Handle_MeshVS_MeshOwner : public Handle_SelectMgr_EntityOwner {
     }
 };
 
+%extend MeshVS_MeshOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_PrsBuilder;
 class MeshVS_PrsBuilder : public MMgt_TShared {
 	public:
@@ -3902,6 +4122,11 @@ class Handle_MeshVS_PrsBuilder : public Handle_MMgt_TShared {
     }
 };
 
+%extend MeshVS_PrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SensitiveFace;
 class MeshVS_SensitiveFace : public Select3D_SensitiveFace {
 	public:
@@ -3994,6 +4219,11 @@ class Handle_MeshVS_SensitiveFace : public Handle_Select3D_SensitiveFace {
     }
 };
 
+%extend MeshVS_SensitiveFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SensitiveMesh;
 class MeshVS_SensitiveMesh : public Select3D_SensitiveEntity {
 	public:
@@ -4110,6 +4340,11 @@ class Handle_MeshVS_SensitiveMesh : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend MeshVS_SensitiveMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SensitivePolyhedron;
 class MeshVS_SensitivePolyhedron : public Select3D_SensitiveEntity {
 	public:
@@ -4230,6 +4465,11 @@ class Handle_MeshVS_SensitivePolyhedron : public Handle_Select3D_SensitiveEntity
     }
 };
 
+%extend MeshVS_SensitivePolyhedron {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SensitiveSegment;
 class MeshVS_SensitiveSegment : public Select3D_SensitiveSegment {
 	public:
@@ -4324,6 +4564,11 @@ class Handle_MeshVS_SensitiveSegment : public Handle_Select3D_SensitiveSegment {
     }
 };
 
+%extend MeshVS_SensitiveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SequenceNodeOfSequenceOfPrsBuilder;
 class MeshVS_SequenceNodeOfSequenceOfPrsBuilder : public TCollection_SeqNode {
 	public:
@@ -4390,6 +4635,11 @@ class Handle_MeshVS_SequenceNodeOfSequenceOfPrsBuilder : public Handle_TCollecti
     }
 };
 
+%extend MeshVS_SequenceNodeOfSequenceOfPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SequenceOfPrsBuilder;
 class MeshVS_SequenceOfPrsBuilder : public TCollection_BaseSequence {
 	public:
@@ -4528,6 +4778,11 @@ class MeshVS_SequenceOfPrsBuilder : public TCollection_BaseSequence {
 };
 
 
+%extend MeshVS_SequenceOfPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_StdMapNodeOfMapOfTwoNodes;
 class MeshVS_StdMapNodeOfMapOfTwoNodes : public TCollection_MapNode {
 	public:
@@ -4592,6 +4847,11 @@ class Handle_MeshVS_StdMapNodeOfMapOfTwoNodes : public Handle_TCollection_MapNod
     }
 };
 
+%extend MeshVS_StdMapNodeOfMapOfTwoNodes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_SymmetricPairHasher;
 class MeshVS_SymmetricPairHasher {
 	public:
@@ -4614,6 +4874,11 @@ class MeshVS_SymmetricPairHasher {
 };
 
 
+%extend MeshVS_SymmetricPairHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class MeshVS_Tool {
 	public:
 		%feature("compactdefaultargs") CreateAspectFillArea3d;
@@ -4691,6 +4956,11 @@ class MeshVS_Tool {
 };
 
 
+%extend MeshVS_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_TwoColors;
 class MeshVS_TwoColors {
 	public:
@@ -4703,6 +4973,11 @@ class MeshVS_TwoColors {
 };
 
 
+%extend MeshVS_TwoColors {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class MeshVS_TwoColorsHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -4724,6 +4999,11 @@ class MeshVS_TwoColorsHasher {
 };
 
 
+%extend MeshVS_TwoColorsHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_TwoNodes;
 class MeshVS_TwoNodes {
 	public:
@@ -4740,6 +5020,11 @@ class MeshVS_TwoNodes {
 };
 
 
+%extend MeshVS_TwoNodes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class MeshVS_TwoNodesHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -4761,6 +5046,11 @@ class MeshVS_TwoNodesHasher {
 };
 
 
+%extend MeshVS_TwoNodesHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DataSource3D;
 class MeshVS_DataSource3D : public MeshVS_DataSource {
 	public:
@@ -4837,6 +5127,11 @@ class Handle_MeshVS_DataSource3D : public Handle_MeshVS_DataSource {
     }
 };
 
+%extend MeshVS_DataSource3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_DeformedDataSource;
 class MeshVS_DeformedDataSource : public MeshVS_DataSource {
 	public:
@@ -5017,6 +5312,11 @@ class Handle_MeshVS_DeformedDataSource : public Handle_MeshVS_DataSource {
     }
 };
 
+%extend MeshVS_DeformedDataSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_ElementalColorPrsBuilder;
 class MeshVS_ElementalColorPrsBuilder : public MeshVS_PrsBuilder {
 	public:
@@ -5205,6 +5505,11 @@ class Handle_MeshVS_ElementalColorPrsBuilder : public Handle_MeshVS_PrsBuilder {
     }
 };
 
+%extend MeshVS_ElementalColorPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_MeshPrsBuilder;
 class MeshVS_MeshPrsBuilder : public MeshVS_PrsBuilder {
 	public:
@@ -5369,6 +5674,11 @@ class Handle_MeshVS_MeshPrsBuilder : public Handle_MeshVS_PrsBuilder {
     }
 };
 
+%extend MeshVS_MeshPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_NodalColorPrsBuilder;
 class MeshVS_NodalColorPrsBuilder : public MeshVS_PrsBuilder {
 	public:
@@ -5587,6 +5897,11 @@ class Handle_MeshVS_NodalColorPrsBuilder : public Handle_MeshVS_PrsBuilder {
     }
 };
 
+%extend MeshVS_NodalColorPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_TextPrsBuilder;
 class MeshVS_TextPrsBuilder : public MeshVS_PrsBuilder {
 	public:
@@ -5723,6 +6038,11 @@ class Handle_MeshVS_TextPrsBuilder : public Handle_MeshVS_PrsBuilder {
     }
 };
 
+%extend MeshVS_TextPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor MeshVS_VectorPrsBuilder;
 class MeshVS_VectorPrsBuilder : public MeshVS_PrsBuilder {
 	public:
@@ -5925,3 +6245,8 @@ class Handle_MeshVS_VectorPrsBuilder : public Handle_MeshVS_PrsBuilder {
     }
 };
 
+%extend MeshVS_VectorPrsBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Message.i
+++ b/src/SWIG_files/wrapper/Message.i
@@ -231,6 +231,11 @@ class Message {
 };
 
 
+%extend Message {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_Algorithm;
 class Message_Algorithm : public MMgt_TShared {
 	public:
@@ -485,6 +490,11 @@ class Handle_Message_Algorithm : public Handle_MMgt_TShared {
     }
 };
 
+%extend Message_Algorithm {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ListIteratorOfListOfMsg;
 class Message_ListIteratorOfListOfMsg {
 	public:
@@ -519,6 +529,11 @@ class Message_ListIteratorOfListOfMsg {
 };
 
 
+%extend Message_ListIteratorOfListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ListNodeOfListOfMsg;
 class Message_ListNodeOfListOfMsg : public TCollection_MapNode {
 	public:
@@ -583,6 +598,11 @@ class Handle_Message_ListNodeOfListOfMsg : public Handle_TCollection_MapNode {
     }
 };
 
+%extend Message_ListNodeOfListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ListOfMsg;
 class Message_ListOfMsg {
 	public:
@@ -713,6 +733,11 @@ class Message_ListOfMsg {
 };
 
 
+%extend Message_ListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_Messenger;
 class Message_Messenger : public MMgt_TShared {
 	public:
@@ -851,6 +876,11 @@ class Handle_Message_Messenger : public Handle_MMgt_TShared {
     }
 };
 
+%extend Message_Messenger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Message_MsgFile {
 	public:
 		%feature("compactdefaultargs") Load;
@@ -918,6 +948,11 @@ class Message_MsgFile {
 };
 
 
+%extend Message_MsgFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_Printer;
 class Message_Printer : public MMgt_TShared {
 	public:
@@ -1020,6 +1055,11 @@ class Handle_Message_Printer : public Handle_MMgt_TShared {
     }
 };
 
+%extend Message_Printer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ProgressIndicator;
 class Message_ProgressIndicator : public MMgt_TShared {
 	public:
@@ -1270,6 +1310,11 @@ class Handle_Message_ProgressIndicator : public Handle_MMgt_TShared {
     }
 };
 
+%extend Message_ProgressIndicator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ProgressScale;
 class Message_ProgressScale {
 	public:
@@ -1416,6 +1461,11 @@ class Message_ProgressScale {
 };
 
 
+%extend Message_ProgressScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_ProgressSentry;
 class Message_ProgressSentry {
 	public:
@@ -1502,6 +1552,11 @@ class Message_ProgressSentry {
 };
 
 
+%extend Message_ProgressSentry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_SequenceNodeOfSequenceOfPrinters;
 class Message_SequenceNodeOfSequenceOfPrinters : public TCollection_SeqNode {
 	public:
@@ -1568,6 +1623,11 @@ class Handle_Message_SequenceNodeOfSequenceOfPrinters : public Handle_TCollectio
     }
 };
 
+%extend Message_SequenceNodeOfSequenceOfPrinters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_SequenceNodeOfSequenceOfProgressScale;
 class Message_SequenceNodeOfSequenceOfProgressScale : public TCollection_SeqNode {
 	public:
@@ -1634,6 +1694,11 @@ class Handle_Message_SequenceNodeOfSequenceOfProgressScale : public Handle_TColl
     }
 };
 
+%extend Message_SequenceNodeOfSequenceOfProgressScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_SequenceOfPrinters;
 class Message_SequenceOfPrinters : public TCollection_BaseSequence {
 	public:
@@ -1772,6 +1837,11 @@ class Message_SequenceOfPrinters : public TCollection_BaseSequence {
 };
 
 
+%extend Message_SequenceOfPrinters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_SequenceOfProgressScale;
 class Message_SequenceOfProgressScale : public TCollection_BaseSequence {
 	public:
@@ -1910,6 +1980,11 @@ class Message_SequenceOfProgressScale : public TCollection_BaseSequence {
 };
 
 
+%extend Message_SequenceOfProgressScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Message_PrinterOStream;
 class Message_PrinterOStream : public Message_Printer {
 	public:
@@ -2044,3 +2119,8 @@ class Handle_Message_PrinterOStream : public Handle_Message_Printer {
     }
 };
 
+%extend Message_PrinterOStream {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/NLPlate.i
+++ b/src/SWIG_files/wrapper/NLPlate.i
@@ -218,6 +218,11 @@ class Handle_NLPlate_HGPPConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend NLPlate_HGPPConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_ListIteratorOfStackOfPlate;
 class NLPlate_ListIteratorOfStackOfPlate {
 	public:
@@ -252,6 +257,11 @@ class NLPlate_ListIteratorOfStackOfPlate {
 };
 
 
+%extend NLPlate_ListIteratorOfStackOfPlate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_ListNodeOfStackOfPlate;
 class NLPlate_ListNodeOfStackOfPlate : public TCollection_MapNode {
 	public:
@@ -316,6 +326,11 @@ class Handle_NLPlate_ListNodeOfStackOfPlate : public Handle_TCollection_MapNode 
     }
 };
 
+%extend NLPlate_ListNodeOfStackOfPlate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_NLPlate;
 class NLPlate_NLPlate {
 	public:
@@ -408,6 +423,11 @@ class NLPlate_NLPlate {
 };
 
 
+%extend NLPlate_NLPlate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_SequenceNodeOfSequenceOfHGPPConstraint;
 class NLPlate_SequenceNodeOfSequenceOfHGPPConstraint : public TCollection_SeqNode {
 	public:
@@ -474,6 +494,11 @@ class Handle_NLPlate_SequenceNodeOfSequenceOfHGPPConstraint : public Handle_TCol
     }
 };
 
+%extend NLPlate_SequenceNodeOfSequenceOfHGPPConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_SequenceOfHGPPConstraint;
 class NLPlate_SequenceOfHGPPConstraint : public TCollection_BaseSequence {
 	public:
@@ -612,6 +637,11 @@ class NLPlate_SequenceOfHGPPConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend NLPlate_SequenceOfHGPPConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_StackOfPlate;
 class NLPlate_StackOfPlate {
 	public:
@@ -742,6 +772,11 @@ class NLPlate_StackOfPlate {
 };
 
 
+%extend NLPlate_StackOfPlate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG0Constraint;
 class NLPlate_HPG0Constraint : public NLPlate_HGPPConstraint {
 	public:
@@ -834,6 +869,11 @@ class Handle_NLPlate_HPG0Constraint : public Handle_NLPlate_HGPPConstraint {
     }
 };
 
+%extend NLPlate_HPG0Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG1Constraint;
 class NLPlate_HPG1Constraint : public NLPlate_HGPPConstraint {
 	public:
@@ -926,6 +966,11 @@ class Handle_NLPlate_HPG1Constraint : public Handle_NLPlate_HGPPConstraint {
     }
 };
 
+%extend NLPlate_HPG1Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG0G1Constraint;
 class NLPlate_HPG0G1Constraint : public NLPlate_HPG0Constraint {
 	public:
@@ -1006,6 +1051,11 @@ class Handle_NLPlate_HPG0G1Constraint : public Handle_NLPlate_HPG0Constraint {
     }
 };
 
+%extend NLPlate_HPG0G1Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG2Constraint;
 class NLPlate_HPG2Constraint : public NLPlate_HPG1Constraint {
 	public:
@@ -1076,6 +1126,11 @@ class Handle_NLPlate_HPG2Constraint : public Handle_NLPlate_HPG1Constraint {
     }
 };
 
+%extend NLPlate_HPG2Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG0G2Constraint;
 class NLPlate_HPG0G2Constraint : public NLPlate_HPG0G1Constraint {
 	public:
@@ -1148,6 +1203,11 @@ class Handle_NLPlate_HPG0G2Constraint : public Handle_NLPlate_HPG0G1Constraint {
     }
 };
 
+%extend NLPlate_HPG0G2Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG3Constraint;
 class NLPlate_HPG3Constraint : public NLPlate_HPG2Constraint {
 	public:
@@ -1220,6 +1280,11 @@ class Handle_NLPlate_HPG3Constraint : public Handle_NLPlate_HPG2Constraint {
     }
 };
 
+%extend NLPlate_HPG3Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor NLPlate_HPG0G3Constraint;
 class NLPlate_HPG0G3Constraint : public NLPlate_HPG0G2Constraint {
 	public:
@@ -1294,3 +1359,8 @@ class Handle_NLPlate_HPG0G3Constraint : public Handle_NLPlate_HPG0G2Constraint {
     }
 };
 
+%extend NLPlate_HPG0G3Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/PLib.i
+++ b/src/SWIG_files/wrapper/PLib.i
@@ -548,6 +548,11 @@ class PLib {
 };
 
 
+%extend PLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PLib_Base;
 class PLib_Base : public MMgt_TShared {
 	public:
@@ -690,6 +695,11 @@ class Handle_PLib_Base : public Handle_MMgt_TShared {
     }
 };
 
+%extend PLib_Base {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PLib_DoubleJacobiPolynomial;
 class PLib_DoubleJacobiPolynomial {
 	public:
@@ -834,6 +844,11 @@ class PLib_DoubleJacobiPolynomial {
 };
 
 
+%extend PLib_DoubleJacobiPolynomial {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PLib_HermitJacobi;
 class PLib_HermitJacobi : public PLib_Base {
 	public:
@@ -1014,6 +1029,11 @@ class Handle_PLib_HermitJacobi : public Handle_PLib_Base {
     }
 };
 
+%extend PLib_HermitJacobi {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PLib_JacobiPolynomial;
 class PLib_JacobiPolynomial : public PLib_Base {
 	public:
@@ -1222,3 +1242,8 @@ class Handle_PLib_JacobiPolynomial : public Handle_PLib_Base {
     }
 };
 
+%extend PLib_JacobiPolynomial {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Plate.i
+++ b/src/SWIG_files/wrapper/Plate.i
@@ -138,6 +138,11 @@ class Plate_Array1OfPinpointConstraint {
 };
 
 
+%extend Plate_Array1OfPinpointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_D1;
 class Plate_D1 {
 	public:
@@ -166,6 +171,11 @@ class Plate_D1 {
 };
 
 
+%extend Plate_D1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_D2;
 class Plate_D2 {
 	public:
@@ -188,6 +198,11 @@ class Plate_D2 {
 };
 
 
+%extend Plate_D2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_D3;
 class Plate_D3 {
 	public:
@@ -212,6 +227,11 @@ class Plate_D3 {
 };
 
 
+%extend Plate_D3 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_FreeGtoCConstraint;
 class Plate_FreeGtoCConstraint {
 	public:
@@ -292,6 +312,11 @@ class Plate_FreeGtoCConstraint {
 };
 
 
+%extend Plate_FreeGtoCConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_GlobalTranslationConstraint;
 class Plate_GlobalTranslationConstraint {
 	public:
@@ -308,6 +333,11 @@ class Plate_GlobalTranslationConstraint {
 };
 
 
+%extend Plate_GlobalTranslationConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_GtoCConstraint;
 class Plate_GtoCConstraint {
 	public:
@@ -424,6 +454,11 @@ class Plate_GtoCConstraint {
 };
 
 
+%extend Plate_GtoCConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_HArray1OfPinpointConstraint;
 class Plate_HArray1OfPinpointConstraint : public MMgt_TShared {
 	public:
@@ -540,6 +575,11 @@ class Handle_Plate_HArray1OfPinpointConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend Plate_HArray1OfPinpointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_LineConstraint;
 class Plate_LineConstraint {
 	public:
@@ -562,6 +602,11 @@ class Plate_LineConstraint {
 };
 
 
+%extend Plate_LineConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_LinearScalarConstraint;
 class Plate_LinearScalarConstraint {
 	public:
@@ -634,6 +679,11 @@ class Plate_LinearScalarConstraint {
 };
 
 
+%extend Plate_LinearScalarConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_LinearXYZConstraint;
 class Plate_LinearXYZConstraint {
 	public:
@@ -698,6 +748,11 @@ class Plate_LinearXYZConstraint {
 };
 
 
+%extend Plate_LinearXYZConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_PinpointConstraint;
 class Plate_PinpointConstraint {
 	public:
@@ -736,6 +791,11 @@ class Plate_PinpointConstraint {
 };
 
 
+%extend Plate_PinpointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_PlaneConstraint;
 class Plate_PlaneConstraint {
 	public:
@@ -758,6 +818,11 @@ class Plate_PlaneConstraint {
 };
 
 
+%extend Plate_PlaneConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_Plate;
 class Plate_Plate {
 	public:
@@ -914,6 +979,11 @@ class Plate_Plate {
 };
 
 
+%extend Plate_Plate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SampledCurveConstraint;
 class Plate_SampledCurveConstraint {
 	public:
@@ -932,6 +1002,11 @@ class Plate_SampledCurveConstraint {
 };
 
 
+%extend Plate_SampledCurveConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceNodeOfSequenceOfLinearScalarConstraint;
 class Plate_SequenceNodeOfSequenceOfLinearScalarConstraint : public TCollection_SeqNode {
 	public:
@@ -998,6 +1073,11 @@ class Handle_Plate_SequenceNodeOfSequenceOfLinearScalarConstraint : public Handl
     }
 };
 
+%extend Plate_SequenceNodeOfSequenceOfLinearScalarConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceNodeOfSequenceOfLinearXYZConstraint;
 class Plate_SequenceNodeOfSequenceOfLinearXYZConstraint : public TCollection_SeqNode {
 	public:
@@ -1064,6 +1144,11 @@ class Handle_Plate_SequenceNodeOfSequenceOfLinearXYZConstraint : public Handle_T
     }
 };
 
+%extend Plate_SequenceNodeOfSequenceOfLinearXYZConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceNodeOfSequenceOfPinpointConstraint;
 class Plate_SequenceNodeOfSequenceOfPinpointConstraint : public TCollection_SeqNode {
 	public:
@@ -1130,6 +1215,11 @@ class Handle_Plate_SequenceNodeOfSequenceOfPinpointConstraint : public Handle_TC
     }
 };
 
+%extend Plate_SequenceNodeOfSequenceOfPinpointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceOfLinearScalarConstraint;
 class Plate_SequenceOfLinearScalarConstraint : public TCollection_BaseSequence {
 	public:
@@ -1268,6 +1358,11 @@ class Plate_SequenceOfLinearScalarConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend Plate_SequenceOfLinearScalarConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceOfLinearXYZConstraint;
 class Plate_SequenceOfLinearXYZConstraint : public TCollection_BaseSequence {
 	public:
@@ -1406,6 +1501,11 @@ class Plate_SequenceOfLinearXYZConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend Plate_SequenceOfLinearXYZConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Plate_SequenceOfPinpointConstraint;
 class Plate_SequenceOfPinpointConstraint : public TCollection_BaseSequence {
 	public:
@@ -1544,3 +1644,8 @@ class Plate_SequenceOfPinpointConstraint : public TCollection_BaseSequence {
 };
 
 
+%extend Plate_SequenceOfPinpointConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Poly.i
+++ b/src/SWIG_files/wrapper/Poly.i
@@ -185,6 +185,11 @@ class Poly {
 };
 
 
+%extend Poly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Array1OfTriangle;
 class Poly_Array1OfTriangle {
 	public:
@@ -267,6 +272,11 @@ class Poly_Array1OfTriangle {
 };
 
 
+%extend Poly_Array1OfTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_CoherentLink;
 class Poly_CoherentLink {
 	public:
@@ -341,6 +351,11 @@ class Poly_CoherentLink {
 };
 
 
+%extend Poly_CoherentLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_CoherentNode;
 class Poly_CoherentNode : public gp_XYZ {
 	public:
@@ -465,6 +480,11 @@ class Poly_CoherentNode : public gp_XYZ {
         };
 
 
+%extend Poly_CoherentNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_CoherentTriangle;
 class Poly_CoherentTriangle {
 	public:
@@ -575,6 +595,11 @@ class Poly_CoherentTriangle {
 };
 
 
+%extend Poly_CoherentTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Connect;
 class Poly_Connect {
 	public:
@@ -657,6 +682,11 @@ class Poly_Connect {
 };
 
 
+%extend Poly_Connect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_HArray1OfTriangle;
 class Poly_HArray1OfTriangle : public MMgt_TShared {
 	public:
@@ -773,6 +803,11 @@ class Handle_Poly_HArray1OfTriangle : public Handle_MMgt_TShared {
     }
 };
 
+%extend Poly_HArray1OfTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Polygon2D;
 class Poly_Polygon2D : public MMgt_TShared {
 	public:
@@ -859,6 +894,11 @@ class Handle_Poly_Polygon2D : public Handle_MMgt_TShared {
     }
 };
 
+%extend Poly_Polygon2D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Polygon3D;
 class Poly_Polygon3D : public MMgt_TShared {
 	public:
@@ -973,6 +1013,11 @@ class Handle_Poly_Polygon3D : public Handle_MMgt_TShared {
     }
 };
 
+%extend Poly_Polygon3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_PolygonOnTriangulation;
 class Poly_PolygonOnTriangulation : public MMgt_TShared {
 	public:
@@ -1081,6 +1126,11 @@ class Handle_Poly_PolygonOnTriangulation : public Handle_MMgt_TShared {
     }
 };
 
+%extend Poly_PolygonOnTriangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Triangle;
 class Poly_Triangle {
 	public:
@@ -1155,6 +1205,11 @@ class Poly_Triangle {
 };
 
 
+%extend Poly_Triangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Poly_Triangulation;
 class Poly_Triangulation : public MMgt_TShared {
 	public:
@@ -1335,3 +1390,8 @@ class Handle_Poly_Triangulation : public Handle_MMgt_TShared {
     }
 };
 
+%extend Poly_Triangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Precision.i
+++ b/src/SWIG_files/wrapper/Precision.i
@@ -182,3 +182,8 @@ class Precision {
 };
 
 
+%extend Precision {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ProjLib.i
+++ b/src/SWIG_files/wrapper/ProjLib.i
@@ -190,6 +190,11 @@ class ProjLib {
 };
 
 
+%extend ProjLib {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_CompProjectedCurve;
 class ProjLib_CompProjectedCurve : public Adaptor2d_Curve2d {
 	public:
@@ -430,6 +435,11 @@ class ProjLib_CompProjectedCurve : public Adaptor2d_Curve2d {
 };
 
 
+%extend ProjLib_CompProjectedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_ComputeApprox;
 class ProjLib_ComputeApprox {
 	public:
@@ -462,6 +472,11 @@ class ProjLib_ComputeApprox {
 };
 
 
+%extend ProjLib_ComputeApprox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_ComputeApproxOnPolarSurface;
 class ProjLib_ComputeApproxOnPolarSurface {
 	public:
@@ -548,6 +563,11 @@ class ProjLib_ComputeApproxOnPolarSurface {
 };
 
 
+%extend ProjLib_ComputeApproxOnPolarSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_HCompProjectedCurve;
 class ProjLib_HCompProjectedCurve : public Adaptor2d_HCurve2d {
 	public:
@@ -624,6 +644,11 @@ class Handle_ProjLib_HCompProjectedCurve : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend ProjLib_HCompProjectedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_HProjectedCurve;
 class ProjLib_HProjectedCurve : public Adaptor2d_HCurve2d {
 	public:
@@ -700,6 +725,11 @@ class Handle_ProjLib_HProjectedCurve : public Handle_Adaptor2d_HCurve2d {
     }
 };
 
+%extend ProjLib_HProjectedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_HSequenceOfHSequenceOfPnt;
 class ProjLib_HSequenceOfHSequenceOfPnt : public MMgt_TShared {
 	public:
@@ -884,6 +914,11 @@ class Handle_ProjLib_HSequenceOfHSequenceOfPnt : public Handle_MMgt_TShared {
     }
 };
 
+%extend ProjLib_HSequenceOfHSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_PrjFunc;
 class ProjLib_PrjFunc : public math_FunctionSetWithDerivatives {
 	public:
@@ -952,6 +987,11 @@ class ProjLib_PrjFunc : public math_FunctionSetWithDerivatives {
 };
 
 
+%extend ProjLib_PrjFunc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_PrjResolve;
 class ProjLib_PrjResolve {
 	public:
@@ -1002,6 +1042,11 @@ class ProjLib_PrjResolve {
 };
 
 
+%extend ProjLib_PrjResolve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_ProjectOnPlane;
 class ProjLib_ProjectOnPlane : public Adaptor3d_Curve {
 	public:
@@ -1242,6 +1287,11 @@ class ProjLib_ProjectOnPlane : public Adaptor3d_Curve {
 };
 
 
+%extend ProjLib_ProjectOnPlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_ProjectOnSurface;
 class ProjLib_ProjectOnSurface {
 	public:
@@ -1274,6 +1324,11 @@ class ProjLib_ProjectOnSurface {
 };
 
 
+%extend ProjLib_ProjectOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_ProjectedCurve;
 class ProjLib_ProjectedCurve : public Adaptor2d_Curve2d {
 	public:
@@ -1508,6 +1563,11 @@ class ProjLib_ProjectedCurve : public Adaptor2d_Curve2d {
 };
 
 
+%extend ProjLib_ProjectedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Projector;
 class ProjLib_Projector {
 	public:
@@ -1650,6 +1710,11 @@ class ProjLib_Projector {
 };
 
 
+%extend ProjLib_Projector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_SequenceNodeOfSequenceOfHSequenceOfPnt;
 class ProjLib_SequenceNodeOfSequenceOfHSequenceOfPnt : public TCollection_SeqNode {
 	public:
@@ -1716,6 +1781,11 @@ class Handle_ProjLib_SequenceNodeOfSequenceOfHSequenceOfPnt : public Handle_TCol
     }
 };
 
+%extend ProjLib_SequenceNodeOfSequenceOfHSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_SequenceOfHSequenceOfPnt;
 class ProjLib_SequenceOfHSequenceOfPnt : public TCollection_BaseSequence {
 	public:
@@ -1854,6 +1924,11 @@ class ProjLib_SequenceOfHSequenceOfPnt : public TCollection_BaseSequence {
 };
 
 
+%extend ProjLib_SequenceOfHSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Cone;
 class ProjLib_Cone : public ProjLib_Projector {
 	public:
@@ -1930,6 +2005,11 @@ class ProjLib_Cone : public ProjLib_Projector {
 };
 
 
+%extend ProjLib_Cone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Cylinder;
 class ProjLib_Cylinder : public ProjLib_Projector {
 	public:
@@ -2016,6 +2096,11 @@ class ProjLib_Cylinder : public ProjLib_Projector {
 };
 
 
+%extend ProjLib_Cylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Plane;
 class ProjLib_Plane : public ProjLib_Projector {
 	public:
@@ -2122,6 +2207,11 @@ class ProjLib_Plane : public ProjLib_Projector {
 };
 
 
+%extend ProjLib_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Sphere;
 class ProjLib_Sphere : public ProjLib_Projector {
 	public:
@@ -2196,6 +2286,11 @@ class ProjLib_Sphere : public ProjLib_Projector {
 };
 
 
+%extend ProjLib_Sphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ProjLib_Torus;
 class ProjLib_Torus : public ProjLib_Projector {
 	public:
@@ -2262,3 +2357,8 @@ class ProjLib_Torus : public ProjLib_Projector {
 };
 
 
+%extend ProjLib_Torus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Prs3d.i
+++ b/src/SWIG_files/wrapper/Prs3d.i
@@ -130,6 +130,11 @@ class Prs3d {
 };
 
 
+%extend Prs3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_BasicAspect;
 class Prs3d_BasicAspect : public MMgt_TShared {
 	public:
@@ -182,6 +187,11 @@ class Handle_Prs3d_BasicAspect : public Handle_MMgt_TShared {
     }
 };
 
+%extend Prs3d_BasicAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_DimensionUnits;
 class Prs3d_DimensionUnits {
 	public:
@@ -228,6 +238,11 @@ class Prs3d_DimensionUnits {
 };
 
 
+%extend Prs3d_DimensionUnits {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_Drawer;
 class Prs3d_Drawer : public MMgt_TShared {
 	public:
@@ -844,6 +859,11 @@ class Handle_Prs3d_Drawer : public Handle_MMgt_TShared {
     }
 };
 
+%extend Prs3d_Drawer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_PlaneSet;
 class Prs3d_PlaneSet : public MMgt_TShared {
 	public:
@@ -968,6 +988,11 @@ class Handle_Prs3d_PlaneSet : public Handle_MMgt_TShared {
     }
 };
 
+%extend Prs3d_PlaneSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_Presentation;
 class Prs3d_Presentation : public Graphic3d_Structure {
 	public:
@@ -1174,6 +1199,11 @@ class Handle_Prs3d_Presentation : public Handle_Graphic3d_Structure {
     }
 };
 
+%extend Prs3d_Presentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_Projector;
 class Prs3d_Projector : public MMgt_TShared {
 	public:
@@ -1266,6 +1296,11 @@ class Handle_Prs3d_Projector : public Handle_MMgt_TShared {
     }
 };
 
+%extend Prs3d_Projector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") CurrentGroup;
@@ -1287,6 +1322,11 @@ class Prs3d_Root {
 };
 
 
+%extend Prs3d_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_ShapeTool;
 class Prs3d_ShapeTool {
 	public:
@@ -1401,6 +1441,11 @@ class Prs3d_ShapeTool {
 };
 
 
+%extend Prs3d_ShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Prs3d_Arrow : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Draw;
@@ -1438,6 +1483,11 @@ class Prs3d_Arrow : public Prs3d_Root {
 };
 
 
+%extend Prs3d_Arrow {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_ArrowAspect;
 class Prs3d_ArrowAspect : public Prs3d_BasicAspect {
 	public:
@@ -1550,6 +1600,11 @@ class Handle_Prs3d_ArrowAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_ArrowAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_DatumAspect;
 class Prs3d_DatumAspect : public Prs3d_BasicAspect {
 	public:
@@ -1684,6 +1739,11 @@ class Handle_Prs3d_DatumAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_DatumAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_DimensionAspect;
 class Prs3d_DimensionAspect : public Prs3d_BasicAspect {
 	public:
@@ -1932,6 +1992,11 @@ class Handle_Prs3d_DimensionAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_DimensionAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_LineAspect;
 class Prs3d_LineAspect : public Prs3d_BasicAspect {
 	public:
@@ -2042,6 +2107,11 @@ class Handle_Prs3d_LineAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_LineAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_PlaneAspect;
 class Prs3d_PlaneAspect : public Prs3d_BasicAspect {
 	public:
@@ -2244,6 +2314,11 @@ class Handle_Prs3d_PlaneAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_PlaneAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_PointAspect;
 class Prs3d_PointAspect : public Prs3d_BasicAspect {
 	public:
@@ -2380,6 +2455,11 @@ class Handle_Prs3d_PointAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_PointAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_PresentationShadow;
 class Prs3d_PresentationShadow : public Prs3d_Presentation {
 	public:
@@ -2442,6 +2522,11 @@ class Handle_Prs3d_PresentationShadow : public Handle_Prs3d_Presentation {
     }
 };
 
+%extend Prs3d_PresentationShadow {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_ShadingAspect;
 class Prs3d_ShadingAspect : public Prs3d_BasicAspect {
 	public:
@@ -2586,6 +2671,11 @@ class Handle_Prs3d_ShadingAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_ShadingAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Prs3d_Text : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Draw;
@@ -2619,6 +2709,11 @@ class Prs3d_Text : public Prs3d_Root {
 };
 
 
+%extend Prs3d_Text {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_TextAspect;
 class Prs3d_TextAspect : public Prs3d_BasicAspect {
 	public:
@@ -2791,6 +2886,11 @@ class Handle_Prs3d_TextAspect : public Handle_Prs3d_BasicAspect {
     }
 };
 
+%extend Prs3d_TextAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Prs3d_IsoAspect;
 class Prs3d_IsoAspect : public Prs3d_LineAspect {
 	public:
@@ -2883,3 +2983,8 @@ class Handle_Prs3d_IsoAspect : public Handle_Prs3d_LineAspect {
     }
 };
 
+%extend Prs3d_IsoAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/PrsMgr.i
+++ b/src/SWIG_files/wrapper/PrsMgr.i
@@ -94,6 +94,11 @@ class PrsMgr_ModedPresentation {
 };
 
 
+%extend PrsMgr_ModedPresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PrsMgr_Presentation;
 class PrsMgr_Presentation : public MMgt_TShared {
 	public:
@@ -172,6 +177,11 @@ class Handle_PrsMgr_Presentation : public Handle_MMgt_TShared {
     }
 };
 
+%extend PrsMgr_Presentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PrsMgr_PresentationManager;
 class PrsMgr_PresentationManager : public MMgt_TShared {
 	public:
@@ -494,6 +504,11 @@ class Handle_PrsMgr_PresentationManager : public Handle_MMgt_TShared {
     }
 };
 
+%extend PrsMgr_PresentationManager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PrsMgr_Presentations;
 class PrsMgr_Presentations : public TCollection_BaseSequence {
 	public:
@@ -632,6 +647,11 @@ class PrsMgr_Presentations : public TCollection_BaseSequence {
 };
 
 
+%extend PrsMgr_Presentations {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PrsMgr_Prs;
 class PrsMgr_Prs : public Prs3d_Presentation {
 	public:
@@ -736,6 +756,11 @@ class Handle_PrsMgr_Prs : public Handle_Prs3d_Presentation {
     }
 };
 
+%extend PrsMgr_Prs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor PrsMgr_SequenceNodeOfPresentations;
 class PrsMgr_SequenceNodeOfPresentations : public TCollection_SeqNode {
 	public:
@@ -802,3 +827,8 @@ class Handle_PrsMgr_SequenceNodeOfPresentations : public Handle_TCollection_SeqN
     }
 };
 
+%extend PrsMgr_SequenceNodeOfPresentations {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Quantity.i
+++ b/src/SWIG_files/wrapper/Quantity.i
@@ -813,6 +813,11 @@ class Quantity_Array1OfCoefficient {
 };
 
 
+%extend Quantity_Array1OfCoefficient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Array1OfColor;
 class Quantity_Array1OfColor {
 	public:
@@ -895,6 +900,11 @@ class Quantity_Array1OfColor {
 };
 
 
+%extend Quantity_Array1OfColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Array2OfColor;
 class Quantity_Array2OfColor {
 	public:
@@ -999,6 +1009,11 @@ class Quantity_Array2OfColor {
 };
 
 
+%extend Quantity_Array2OfColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Color;
 class Quantity_Color {
 	public:
@@ -1349,6 +1364,11 @@ class Quantity_Color {
 };
 
 
+%extend Quantity_Color {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Convert;
 class Quantity_Convert {
 	public:
@@ -1401,6 +1421,11 @@ class Quantity_Convert {
 };
 
 
+%extend Quantity_Convert {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Date;
 class Quantity_Date {
 	public:
@@ -1663,6 +1688,11 @@ class Quantity_Date {
 };
 
 
+%extend Quantity_Date {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_HArray1OfColor;
 class Quantity_HArray1OfColor : public MMgt_TShared {
 	public:
@@ -1779,6 +1809,11 @@ class Handle_Quantity_HArray1OfColor : public Handle_MMgt_TShared {
     }
 };
 
+%extend Quantity_HArray1OfColor {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Quantity_Period;
 class Quantity_Period {
 	public:
@@ -1999,3 +2034,8 @@ class Quantity_Period {
 };
 
 
+%extend Quantity_Period {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepAP203.i
+++ b/src/SWIG_files/wrapper/RWStepAP203.i
@@ -102,6 +102,11 @@ class RWStepAP203_RWCcDesignApproval {
 };
 
 
+%extend RWStepAP203_RWCcDesignApproval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignCertification;
 class RWStepAP203_RWCcDesignCertification {
 	public:
@@ -148,6 +153,11 @@ class RWStepAP203_RWCcDesignCertification {
 };
 
 
+%extend RWStepAP203_RWCcDesignCertification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignContract;
 class RWStepAP203_RWCcDesignContract {
 	public:
@@ -194,6 +204,11 @@ class RWStepAP203_RWCcDesignContract {
 };
 
 
+%extend RWStepAP203_RWCcDesignContract {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignDateAndTimeAssignment;
 class RWStepAP203_RWCcDesignDateAndTimeAssignment {
 	public:
@@ -240,6 +255,11 @@ class RWStepAP203_RWCcDesignDateAndTimeAssignment {
 };
 
 
+%extend RWStepAP203_RWCcDesignDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignPersonAndOrganizationAssignment;
 class RWStepAP203_RWCcDesignPersonAndOrganizationAssignment {
 	public:
@@ -286,6 +306,11 @@ class RWStepAP203_RWCcDesignPersonAndOrganizationAssignment {
 };
 
 
+%extend RWStepAP203_RWCcDesignPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignSecurityClassification;
 class RWStepAP203_RWCcDesignSecurityClassification {
 	public:
@@ -332,6 +357,11 @@ class RWStepAP203_RWCcDesignSecurityClassification {
 };
 
 
+%extend RWStepAP203_RWCcDesignSecurityClassification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWCcDesignSpecificationReference;
 class RWStepAP203_RWCcDesignSpecificationReference {
 	public:
@@ -378,6 +408,11 @@ class RWStepAP203_RWCcDesignSpecificationReference {
 };
 
 
+%extend RWStepAP203_RWCcDesignSpecificationReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWChange;
 class RWStepAP203_RWChange {
 	public:
@@ -424,6 +459,11 @@ class RWStepAP203_RWChange {
 };
 
 
+%extend RWStepAP203_RWChange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWChangeRequest;
 class RWStepAP203_RWChangeRequest {
 	public:
@@ -470,6 +510,11 @@ class RWStepAP203_RWChangeRequest {
 };
 
 
+%extend RWStepAP203_RWChangeRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWStartRequest;
 class RWStepAP203_RWStartRequest {
 	public:
@@ -516,6 +561,11 @@ class RWStepAP203_RWStartRequest {
 };
 
 
+%extend RWStepAP203_RWStartRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP203_RWStartWork;
 class RWStepAP203_RWStartWork {
 	public:
@@ -562,3 +612,8 @@ class RWStepAP203_RWStartWork {
 };
 
 
+%extend RWStepAP203_RWStartWork {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepAP214.i
+++ b/src/SWIG_files/wrapper/RWStepAP214.i
@@ -68,6 +68,11 @@ class RWStepAP214 {
 };
 
 
+%extend RWStepAP214 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_GeneralModule;
 class RWStepAP214_GeneralModule : public StepData_GeneralModule {
 	public:
@@ -196,6 +201,11 @@ class Handle_RWStepAP214_GeneralModule : public Handle_StepData_GeneralModule {
     }
 };
 
+%extend RWStepAP214_GeneralModule {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedApprovalAssignment;
 class RWStepAP214_RWAppliedApprovalAssignment {
 	public:
@@ -234,6 +244,11 @@ class RWStepAP214_RWAppliedApprovalAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedApprovalAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedDateAndTimeAssignment;
 class RWStepAP214_RWAppliedDateAndTimeAssignment {
 	public:
@@ -272,6 +287,11 @@ class RWStepAP214_RWAppliedDateAndTimeAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedDateAssignment;
 class RWStepAP214_RWAppliedDateAssignment {
 	public:
@@ -310,6 +330,11 @@ class RWStepAP214_RWAppliedDateAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedDocumentReference;
 class RWStepAP214_RWAppliedDocumentReference {
 	public:
@@ -348,6 +373,11 @@ class RWStepAP214_RWAppliedDocumentReference {
 };
 
 
+%extend RWStepAP214_RWAppliedDocumentReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedExternalIdentificationAssignment;
 class RWStepAP214_RWAppliedExternalIdentificationAssignment {
 	public:
@@ -394,6 +424,11 @@ class RWStepAP214_RWAppliedExternalIdentificationAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedExternalIdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedGroupAssignment;
 class RWStepAP214_RWAppliedGroupAssignment {
 	public:
@@ -440,6 +475,11 @@ class RWStepAP214_RWAppliedGroupAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedGroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedOrganizationAssignment;
 class RWStepAP214_RWAppliedOrganizationAssignment {
 	public:
@@ -478,6 +518,11 @@ class RWStepAP214_RWAppliedOrganizationAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedPersonAndOrganizationAssignment;
 class RWStepAP214_RWAppliedPersonAndOrganizationAssignment {
 	public:
@@ -516,6 +561,11 @@ class RWStepAP214_RWAppliedPersonAndOrganizationAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedPresentedItem;
 class RWStepAP214_RWAppliedPresentedItem {
 	public:
@@ -554,6 +604,11 @@ class RWStepAP214_RWAppliedPresentedItem {
 };
 
 
+%extend RWStepAP214_RWAppliedPresentedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAppliedSecurityClassificationAssignment;
 class RWStepAP214_RWAppliedSecurityClassificationAssignment {
 	public:
@@ -592,6 +647,11 @@ class RWStepAP214_RWAppliedSecurityClassificationAssignment {
 };
 
 
+%extend RWStepAP214_RWAppliedSecurityClassificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignActualDateAndTimeAssignment;
 class RWStepAP214_RWAutoDesignActualDateAndTimeAssignment {
 	public:
@@ -630,6 +690,11 @@ class RWStepAP214_RWAutoDesignActualDateAndTimeAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignActualDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignActualDateAssignment;
 class RWStepAP214_RWAutoDesignActualDateAssignment {
 	public:
@@ -668,6 +733,11 @@ class RWStepAP214_RWAutoDesignActualDateAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignActualDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignApprovalAssignment;
 class RWStepAP214_RWAutoDesignApprovalAssignment {
 	public:
@@ -706,6 +776,11 @@ class RWStepAP214_RWAutoDesignApprovalAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignApprovalAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignDateAndPersonAssignment;
 class RWStepAP214_RWAutoDesignDateAndPersonAssignment {
 	public:
@@ -744,6 +819,11 @@ class RWStepAP214_RWAutoDesignDateAndPersonAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignDateAndPersonAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignDocumentReference;
 class RWStepAP214_RWAutoDesignDocumentReference {
 	public:
@@ -782,6 +862,11 @@ class RWStepAP214_RWAutoDesignDocumentReference {
 };
 
 
+%extend RWStepAP214_RWAutoDesignDocumentReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignGroupAssignment;
 class RWStepAP214_RWAutoDesignGroupAssignment {
 	public:
@@ -820,6 +905,11 @@ class RWStepAP214_RWAutoDesignGroupAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignGroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignNominalDateAndTimeAssignment;
 class RWStepAP214_RWAutoDesignNominalDateAndTimeAssignment {
 	public:
@@ -858,6 +948,11 @@ class RWStepAP214_RWAutoDesignNominalDateAndTimeAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignNominalDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignNominalDateAssignment;
 class RWStepAP214_RWAutoDesignNominalDateAssignment {
 	public:
@@ -896,6 +991,11 @@ class RWStepAP214_RWAutoDesignNominalDateAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignNominalDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignOrganizationAssignment;
 class RWStepAP214_RWAutoDesignOrganizationAssignment {
 	public:
@@ -934,6 +1034,11 @@ class RWStepAP214_RWAutoDesignOrganizationAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignPersonAndOrganizationAssignment;
 class RWStepAP214_RWAutoDesignPersonAndOrganizationAssignment {
 	public:
@@ -972,6 +1077,11 @@ class RWStepAP214_RWAutoDesignPersonAndOrganizationAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignPresentedItem;
 class RWStepAP214_RWAutoDesignPresentedItem {
 	public:
@@ -1010,6 +1120,11 @@ class RWStepAP214_RWAutoDesignPresentedItem {
 };
 
 
+%extend RWStepAP214_RWAutoDesignPresentedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWAutoDesignSecurityClassificationAssignment;
 class RWStepAP214_RWAutoDesignSecurityClassificationAssignment {
 	public:
@@ -1048,6 +1163,11 @@ class RWStepAP214_RWAutoDesignSecurityClassificationAssignment {
 };
 
 
+%extend RWStepAP214_RWAutoDesignSecurityClassificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWClass;
 class RWStepAP214_RWClass {
 	public:
@@ -1094,6 +1214,11 @@ class RWStepAP214_RWClass {
 };
 
 
+%extend RWStepAP214_RWClass {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWExternallyDefinedClass;
 class RWStepAP214_RWExternallyDefinedClass {
 	public:
@@ -1140,6 +1265,11 @@ class RWStepAP214_RWExternallyDefinedClass {
 };
 
 
+%extend RWStepAP214_RWExternallyDefinedClass {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWExternallyDefinedGeneralProperty;
 class RWStepAP214_RWExternallyDefinedGeneralProperty {
 	public:
@@ -1186,6 +1316,11 @@ class RWStepAP214_RWExternallyDefinedGeneralProperty {
 };
 
 
+%extend RWStepAP214_RWExternallyDefinedGeneralProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_RWRepItemGroup;
 class RWStepAP214_RWRepItemGroup {
 	public:
@@ -1232,6 +1367,11 @@ class RWStepAP214_RWRepItemGroup {
 };
 
 
+%extend RWStepAP214_RWRepItemGroup {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepAP214_ReadWriteModule;
 class RWStepAP214_ReadWriteModule : public StepData_ReadWriteModule {
 	public:
@@ -1352,3 +1492,8 @@ class Handle_RWStepAP214_ReadWriteModule : public Handle_StepData_ReadWriteModul
     }
 };
 
+%extend RWStepAP214_ReadWriteModule {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepBasic.i
+++ b/src/SWIG_files/wrapper/RWStepBasic.i
@@ -102,6 +102,11 @@ class RWStepBasic_RWAction {
 };
 
 
+%extend RWStepBasic_RWAction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWActionAssignment;
 class RWStepBasic_RWActionAssignment {
 	public:
@@ -148,6 +153,11 @@ class RWStepBasic_RWActionAssignment {
 };
 
 
+%extend RWStepBasic_RWActionAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWActionMethod;
 class RWStepBasic_RWActionMethod {
 	public:
@@ -194,6 +204,11 @@ class RWStepBasic_RWActionMethod {
 };
 
 
+%extend RWStepBasic_RWActionMethod {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWActionRequestAssignment;
 class RWStepBasic_RWActionRequestAssignment {
 	public:
@@ -240,6 +255,11 @@ class RWStepBasic_RWActionRequestAssignment {
 };
 
 
+%extend RWStepBasic_RWActionRequestAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWActionRequestSolution;
 class RWStepBasic_RWActionRequestSolution {
 	public:
@@ -286,6 +306,11 @@ class RWStepBasic_RWActionRequestSolution {
 };
 
 
+%extend RWStepBasic_RWActionRequestSolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWAddress;
 class RWStepBasic_RWAddress {
 	public:
@@ -316,6 +341,11 @@ class RWStepBasic_RWAddress {
 };
 
 
+%extend RWStepBasic_RWAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApplicationContext;
 class RWStepBasic_RWApplicationContext {
 	public:
@@ -346,6 +376,11 @@ class RWStepBasic_RWApplicationContext {
 };
 
 
+%extend RWStepBasic_RWApplicationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApplicationContextElement;
 class RWStepBasic_RWApplicationContextElement {
 	public:
@@ -384,6 +419,11 @@ class RWStepBasic_RWApplicationContextElement {
 };
 
 
+%extend RWStepBasic_RWApplicationContextElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApplicationProtocolDefinition;
 class RWStepBasic_RWApplicationProtocolDefinition {
 	public:
@@ -422,6 +462,11 @@ class RWStepBasic_RWApplicationProtocolDefinition {
 };
 
 
+%extend RWStepBasic_RWApplicationProtocolDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApproval;
 class RWStepBasic_RWApproval {
 	public:
@@ -460,6 +505,11 @@ class RWStepBasic_RWApproval {
 };
 
 
+%extend RWStepBasic_RWApproval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApprovalDateTime;
 class RWStepBasic_RWApprovalDateTime {
 	public:
@@ -498,6 +548,11 @@ class RWStepBasic_RWApprovalDateTime {
 };
 
 
+%extend RWStepBasic_RWApprovalDateTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApprovalPersonOrganization;
 class RWStepBasic_RWApprovalPersonOrganization {
 	public:
@@ -536,6 +591,11 @@ class RWStepBasic_RWApprovalPersonOrganization {
 };
 
 
+%extend RWStepBasic_RWApprovalPersonOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApprovalRelationship;
 class RWStepBasic_RWApprovalRelationship {
 	public:
@@ -574,6 +634,11 @@ class RWStepBasic_RWApprovalRelationship {
 };
 
 
+%extend RWStepBasic_RWApprovalRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApprovalRole;
 class RWStepBasic_RWApprovalRole {
 	public:
@@ -604,6 +669,11 @@ class RWStepBasic_RWApprovalRole {
 };
 
 
+%extend RWStepBasic_RWApprovalRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWApprovalStatus;
 class RWStepBasic_RWApprovalStatus {
 	public:
@@ -634,6 +704,11 @@ class RWStepBasic_RWApprovalStatus {
 };
 
 
+%extend RWStepBasic_RWApprovalStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCalendarDate;
 class RWStepBasic_RWCalendarDate {
 	public:
@@ -664,6 +739,11 @@ class RWStepBasic_RWCalendarDate {
 };
 
 
+%extend RWStepBasic_RWCalendarDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCertification;
 class RWStepBasic_RWCertification {
 	public:
@@ -710,6 +790,11 @@ class RWStepBasic_RWCertification {
 };
 
 
+%extend RWStepBasic_RWCertification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCertificationAssignment;
 class RWStepBasic_RWCertificationAssignment {
 	public:
@@ -756,6 +841,11 @@ class RWStepBasic_RWCertificationAssignment {
 };
 
 
+%extend RWStepBasic_RWCertificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCertificationType;
 class RWStepBasic_RWCertificationType {
 	public:
@@ -802,6 +892,11 @@ class RWStepBasic_RWCertificationType {
 };
 
 
+%extend RWStepBasic_RWCertificationType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCharacterizedObject;
 class RWStepBasic_RWCharacterizedObject {
 	public:
@@ -848,6 +943,11 @@ class RWStepBasic_RWCharacterizedObject {
 };
 
 
+%extend RWStepBasic_RWCharacterizedObject {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWContract;
 class RWStepBasic_RWContract {
 	public:
@@ -894,6 +994,11 @@ class RWStepBasic_RWContract {
 };
 
 
+%extend RWStepBasic_RWContract {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWContractAssignment;
 class RWStepBasic_RWContractAssignment {
 	public:
@@ -940,6 +1045,11 @@ class RWStepBasic_RWContractAssignment {
 };
 
 
+%extend RWStepBasic_RWContractAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWContractType;
 class RWStepBasic_RWContractType {
 	public:
@@ -986,6 +1096,11 @@ class RWStepBasic_RWContractType {
 };
 
 
+%extend RWStepBasic_RWContractType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnit;
 class RWStepBasic_RWConversionBasedUnit {
 	public:
@@ -1024,6 +1139,11 @@ class RWStepBasic_RWConversionBasedUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndAreaUnit;
 class RWStepBasic_RWConversionBasedUnitAndAreaUnit {
 	public:
@@ -1062,6 +1182,11 @@ class RWStepBasic_RWConversionBasedUnitAndAreaUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndAreaUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndLengthUnit;
 class RWStepBasic_RWConversionBasedUnitAndLengthUnit {
 	public:
@@ -1100,6 +1225,11 @@ class RWStepBasic_RWConversionBasedUnitAndLengthUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndLengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndMassUnit;
 class RWStepBasic_RWConversionBasedUnitAndMassUnit {
 	public:
@@ -1138,6 +1268,11 @@ class RWStepBasic_RWConversionBasedUnitAndMassUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndMassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndPlaneAngleUnit;
 class RWStepBasic_RWConversionBasedUnitAndPlaneAngleUnit {
 	public:
@@ -1176,6 +1311,11 @@ class RWStepBasic_RWConversionBasedUnitAndPlaneAngleUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndPlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndRatioUnit;
 class RWStepBasic_RWConversionBasedUnitAndRatioUnit {
 	public:
@@ -1214,6 +1354,11 @@ class RWStepBasic_RWConversionBasedUnitAndRatioUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndRatioUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndSolidAngleUnit;
 class RWStepBasic_RWConversionBasedUnitAndSolidAngleUnit {
 	public:
@@ -1252,6 +1397,11 @@ class RWStepBasic_RWConversionBasedUnitAndSolidAngleUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndSolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndTimeUnit;
 class RWStepBasic_RWConversionBasedUnitAndTimeUnit {
 	public:
@@ -1290,6 +1440,11 @@ class RWStepBasic_RWConversionBasedUnitAndTimeUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndTimeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWConversionBasedUnitAndVolumeUnit;
 class RWStepBasic_RWConversionBasedUnitAndVolumeUnit {
 	public:
@@ -1328,6 +1483,11 @@ class RWStepBasic_RWConversionBasedUnitAndVolumeUnit {
 };
 
 
+%extend RWStepBasic_RWConversionBasedUnitAndVolumeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWCoordinatedUniversalTimeOffset;
 class RWStepBasic_RWCoordinatedUniversalTimeOffset {
 	public:
@@ -1358,6 +1518,11 @@ class RWStepBasic_RWCoordinatedUniversalTimeOffset {
 };
 
 
+%extend RWStepBasic_RWCoordinatedUniversalTimeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDate;
 class RWStepBasic_RWDate {
 	public:
@@ -1388,6 +1553,11 @@ class RWStepBasic_RWDate {
 };
 
 
+%extend RWStepBasic_RWDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDateAndTime;
 class RWStepBasic_RWDateAndTime {
 	public:
@@ -1426,6 +1596,11 @@ class RWStepBasic_RWDateAndTime {
 };
 
 
+%extend RWStepBasic_RWDateAndTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDateRole;
 class RWStepBasic_RWDateRole {
 	public:
@@ -1456,6 +1631,11 @@ class RWStepBasic_RWDateRole {
 };
 
 
+%extend RWStepBasic_RWDateRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDateTimeRole;
 class RWStepBasic_RWDateTimeRole {
 	public:
@@ -1486,6 +1666,11 @@ class RWStepBasic_RWDateTimeRole {
 };
 
 
+%extend RWStepBasic_RWDateTimeRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDerivedUnit;
 class RWStepBasic_RWDerivedUnit {
 	public:
@@ -1524,6 +1709,11 @@ class RWStepBasic_RWDerivedUnit {
 };
 
 
+%extend RWStepBasic_RWDerivedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDerivedUnitElement;
 class RWStepBasic_RWDerivedUnitElement {
 	public:
@@ -1562,6 +1752,11 @@ class RWStepBasic_RWDerivedUnitElement {
 };
 
 
+%extend RWStepBasic_RWDerivedUnitElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDimensionalExponents;
 class RWStepBasic_RWDimensionalExponents {
 	public:
@@ -1592,6 +1787,11 @@ class RWStepBasic_RWDimensionalExponents {
 };
 
 
+%extend RWStepBasic_RWDimensionalExponents {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocument;
 class RWStepBasic_RWDocument {
 	public:
@@ -1638,6 +1838,11 @@ class RWStepBasic_RWDocument {
 };
 
 
+%extend RWStepBasic_RWDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentFile;
 class RWStepBasic_RWDocumentFile {
 	public:
@@ -1684,6 +1889,11 @@ class RWStepBasic_RWDocumentFile {
 };
 
 
+%extend RWStepBasic_RWDocumentFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentProductAssociation;
 class RWStepBasic_RWDocumentProductAssociation {
 	public:
@@ -1730,6 +1940,11 @@ class RWStepBasic_RWDocumentProductAssociation {
 };
 
 
+%extend RWStepBasic_RWDocumentProductAssociation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentProductEquivalence;
 class RWStepBasic_RWDocumentProductEquivalence {
 	public:
@@ -1776,6 +1991,11 @@ class RWStepBasic_RWDocumentProductEquivalence {
 };
 
 
+%extend RWStepBasic_RWDocumentProductEquivalence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentRelationship;
 class RWStepBasic_RWDocumentRelationship {
 	public:
@@ -1814,6 +2034,11 @@ class RWStepBasic_RWDocumentRelationship {
 };
 
 
+%extend RWStepBasic_RWDocumentRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentRepresentationType;
 class RWStepBasic_RWDocumentRepresentationType {
 	public:
@@ -1860,6 +2085,11 @@ class RWStepBasic_RWDocumentRepresentationType {
 };
 
 
+%extend RWStepBasic_RWDocumentRepresentationType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentType;
 class RWStepBasic_RWDocumentType {
 	public:
@@ -1898,6 +2128,11 @@ class RWStepBasic_RWDocumentType {
 };
 
 
+%extend RWStepBasic_RWDocumentType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWDocumentUsageConstraint;
 class RWStepBasic_RWDocumentUsageConstraint {
 	public:
@@ -1936,6 +2171,11 @@ class RWStepBasic_RWDocumentUsageConstraint {
 };
 
 
+%extend RWStepBasic_RWDocumentUsageConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWEffectivity;
 class RWStepBasic_RWEffectivity {
 	public:
@@ -1974,6 +2214,11 @@ class RWStepBasic_RWEffectivity {
 };
 
 
+%extend RWStepBasic_RWEffectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWEffectivityAssignment;
 class RWStepBasic_RWEffectivityAssignment {
 	public:
@@ -2020,6 +2265,11 @@ class RWStepBasic_RWEffectivityAssignment {
 };
 
 
+%extend RWStepBasic_RWEffectivityAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWEulerAngles;
 class RWStepBasic_RWEulerAngles {
 	public:
@@ -2066,6 +2316,11 @@ class RWStepBasic_RWEulerAngles {
 };
 
 
+%extend RWStepBasic_RWEulerAngles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWExternalIdentificationAssignment;
 class RWStepBasic_RWExternalIdentificationAssignment {
 	public:
@@ -2112,6 +2367,11 @@ class RWStepBasic_RWExternalIdentificationAssignment {
 };
 
 
+%extend RWStepBasic_RWExternalIdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWExternalSource;
 class RWStepBasic_RWExternalSource {
 	public:
@@ -2158,6 +2418,11 @@ class RWStepBasic_RWExternalSource {
 };
 
 
+%extend RWStepBasic_RWExternalSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWExternallyDefinedItem;
 class RWStepBasic_RWExternallyDefinedItem {
 	public:
@@ -2204,6 +2469,11 @@ class RWStepBasic_RWExternallyDefinedItem {
 };
 
 
+%extend RWStepBasic_RWExternallyDefinedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWGeneralProperty;
 class RWStepBasic_RWGeneralProperty {
 	public:
@@ -2250,6 +2520,11 @@ class RWStepBasic_RWGeneralProperty {
 };
 
 
+%extend RWStepBasic_RWGeneralProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWGroup;
 class RWStepBasic_RWGroup {
 	public:
@@ -2296,6 +2571,11 @@ class RWStepBasic_RWGroup {
 };
 
 
+%extend RWStepBasic_RWGroup {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWGroupAssignment;
 class RWStepBasic_RWGroupAssignment {
 	public:
@@ -2342,6 +2622,11 @@ class RWStepBasic_RWGroupAssignment {
 };
 
 
+%extend RWStepBasic_RWGroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWGroupRelationship;
 class RWStepBasic_RWGroupRelationship {
 	public:
@@ -2388,6 +2673,11 @@ class RWStepBasic_RWGroupRelationship {
 };
 
 
+%extend RWStepBasic_RWGroupRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWIdentificationAssignment;
 class RWStepBasic_RWIdentificationAssignment {
 	public:
@@ -2434,6 +2724,11 @@ class RWStepBasic_RWIdentificationAssignment {
 };
 
 
+%extend RWStepBasic_RWIdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWIdentificationRole;
 class RWStepBasic_RWIdentificationRole {
 	public:
@@ -2480,6 +2775,11 @@ class RWStepBasic_RWIdentificationRole {
 };
 
 
+%extend RWStepBasic_RWIdentificationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWLengthMeasureWithUnit;
 class RWStepBasic_RWLengthMeasureWithUnit {
 	public:
@@ -2518,6 +2818,11 @@ class RWStepBasic_RWLengthMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWLengthMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWLengthUnit;
 class RWStepBasic_RWLengthUnit {
 	public:
@@ -2556,6 +2861,11 @@ class RWStepBasic_RWLengthUnit {
 };
 
 
+%extend RWStepBasic_RWLengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWLocalTime;
 class RWStepBasic_RWLocalTime {
 	public:
@@ -2594,6 +2904,11 @@ class RWStepBasic_RWLocalTime {
 };
 
 
+%extend RWStepBasic_RWLocalTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWMassMeasureWithUnit;
 class RWStepBasic_RWMassMeasureWithUnit {
 	public:
@@ -2632,6 +2947,11 @@ class RWStepBasic_RWMassMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWMassMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWMassUnit;
 class RWStepBasic_RWMassUnit {
 	public:
@@ -2678,6 +2998,11 @@ class RWStepBasic_RWMassUnit {
 };
 
 
+%extend RWStepBasic_RWMassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWMeasureWithUnit;
 class RWStepBasic_RWMeasureWithUnit {
 	public:
@@ -2716,6 +3041,11 @@ class RWStepBasic_RWMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWMechanicalContext;
 class RWStepBasic_RWMechanicalContext {
 	public:
@@ -2754,6 +3084,11 @@ class RWStepBasic_RWMechanicalContext {
 };
 
 
+%extend RWStepBasic_RWMechanicalContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWNameAssignment;
 class RWStepBasic_RWNameAssignment {
 	public:
@@ -2800,6 +3135,11 @@ class RWStepBasic_RWNameAssignment {
 };
 
 
+%extend RWStepBasic_RWNameAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWNamedUnit;
 class RWStepBasic_RWNamedUnit {
 	public:
@@ -2838,6 +3178,11 @@ class RWStepBasic_RWNamedUnit {
 };
 
 
+%extend RWStepBasic_RWNamedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWObjectRole;
 class RWStepBasic_RWObjectRole {
 	public:
@@ -2884,6 +3229,11 @@ class RWStepBasic_RWObjectRole {
 };
 
 
+%extend RWStepBasic_RWObjectRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWOrdinalDate;
 class RWStepBasic_RWOrdinalDate {
 	public:
@@ -2914,6 +3264,11 @@ class RWStepBasic_RWOrdinalDate {
 };
 
 
+%extend RWStepBasic_RWOrdinalDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWOrganization;
 class RWStepBasic_RWOrganization {
 	public:
@@ -2944,6 +3299,11 @@ class RWStepBasic_RWOrganization {
 };
 
 
+%extend RWStepBasic_RWOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWOrganizationRole;
 class RWStepBasic_RWOrganizationRole {
 	public:
@@ -2974,6 +3334,11 @@ class RWStepBasic_RWOrganizationRole {
 };
 
 
+%extend RWStepBasic_RWOrganizationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWOrganizationalAddress;
 class RWStepBasic_RWOrganizationalAddress {
 	public:
@@ -3012,6 +3377,11 @@ class RWStepBasic_RWOrganizationalAddress {
 };
 
 
+%extend RWStepBasic_RWOrganizationalAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPerson;
 class RWStepBasic_RWPerson {
 	public:
@@ -3042,6 +3412,11 @@ class RWStepBasic_RWPerson {
 };
 
 
+%extend RWStepBasic_RWPerson {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPersonAndOrganization;
 class RWStepBasic_RWPersonAndOrganization {
 	public:
@@ -3080,6 +3455,11 @@ class RWStepBasic_RWPersonAndOrganization {
 };
 
 
+%extend RWStepBasic_RWPersonAndOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPersonAndOrganizationRole;
 class RWStepBasic_RWPersonAndOrganizationRole {
 	public:
@@ -3110,6 +3490,11 @@ class RWStepBasic_RWPersonAndOrganizationRole {
 };
 
 
+%extend RWStepBasic_RWPersonAndOrganizationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPersonalAddress;
 class RWStepBasic_RWPersonalAddress {
 	public:
@@ -3148,6 +3533,11 @@ class RWStepBasic_RWPersonalAddress {
 };
 
 
+%extend RWStepBasic_RWPersonalAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPlaneAngleMeasureWithUnit;
 class RWStepBasic_RWPlaneAngleMeasureWithUnit {
 	public:
@@ -3186,6 +3576,11 @@ class RWStepBasic_RWPlaneAngleMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWPlaneAngleMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWPlaneAngleUnit;
 class RWStepBasic_RWPlaneAngleUnit {
 	public:
@@ -3224,6 +3619,11 @@ class RWStepBasic_RWPlaneAngleUnit {
 };
 
 
+%extend RWStepBasic_RWPlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProduct;
 class RWStepBasic_RWProduct {
 	public:
@@ -3262,6 +3662,11 @@ class RWStepBasic_RWProduct {
 };
 
 
+%extend RWStepBasic_RWProduct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductCategory;
 class RWStepBasic_RWProductCategory {
 	public:
@@ -3292,6 +3697,11 @@ class RWStepBasic_RWProductCategory {
 };
 
 
+%extend RWStepBasic_RWProductCategory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductCategoryRelationship;
 class RWStepBasic_RWProductCategoryRelationship {
 	public:
@@ -3338,6 +3748,11 @@ class RWStepBasic_RWProductCategoryRelationship {
 };
 
 
+%extend RWStepBasic_RWProductCategoryRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductConceptContext;
 class RWStepBasic_RWProductConceptContext {
 	public:
@@ -3384,6 +3799,11 @@ class RWStepBasic_RWProductConceptContext {
 };
 
 
+%extend RWStepBasic_RWProductConceptContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductContext;
 class RWStepBasic_RWProductContext {
 	public:
@@ -3422,6 +3842,11 @@ class RWStepBasic_RWProductContext {
 };
 
 
+%extend RWStepBasic_RWProductContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinition;
 class RWStepBasic_RWProductDefinition {
 	public:
@@ -3460,6 +3885,11 @@ class RWStepBasic_RWProductDefinition {
 };
 
 
+%extend RWStepBasic_RWProductDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionContext;
 class RWStepBasic_RWProductDefinitionContext {
 	public:
@@ -3498,6 +3928,11 @@ class RWStepBasic_RWProductDefinitionContext {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionEffectivity;
 class RWStepBasic_RWProductDefinitionEffectivity {
 	public:
@@ -3536,6 +3971,11 @@ class RWStepBasic_RWProductDefinitionEffectivity {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionEffectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionFormation;
 class RWStepBasic_RWProductDefinitionFormation {
 	public:
@@ -3574,6 +4014,11 @@ class RWStepBasic_RWProductDefinitionFormation {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionFormation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionFormationRelationship;
 class RWStepBasic_RWProductDefinitionFormationRelationship {
 	public:
@@ -3620,6 +4065,11 @@ class RWStepBasic_RWProductDefinitionFormationRelationship {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionFormationRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource;
 class RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource {
 	public:
@@ -3658,6 +4108,11 @@ class RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionRelationship;
 class RWStepBasic_RWProductDefinitionRelationship {
 	public:
@@ -3704,6 +4159,11 @@ class RWStepBasic_RWProductDefinitionRelationship {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductDefinitionWithAssociatedDocuments;
 class RWStepBasic_RWProductDefinitionWithAssociatedDocuments {
 	public:
@@ -3742,6 +4202,11 @@ class RWStepBasic_RWProductDefinitionWithAssociatedDocuments {
 };
 
 
+%extend RWStepBasic_RWProductDefinitionWithAssociatedDocuments {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductRelatedProductCategory;
 class RWStepBasic_RWProductRelatedProductCategory {
 	public:
@@ -3780,6 +4245,11 @@ class RWStepBasic_RWProductRelatedProductCategory {
 };
 
 
+%extend RWStepBasic_RWProductRelatedProductCategory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWProductType;
 class RWStepBasic_RWProductType {
 	public:
@@ -3818,6 +4288,11 @@ class RWStepBasic_RWProductType {
 };
 
 
+%extend RWStepBasic_RWProductType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWRatioMeasureWithUnit;
 class RWStepBasic_RWRatioMeasureWithUnit {
 	public:
@@ -3856,6 +4331,11 @@ class RWStepBasic_RWRatioMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWRatioMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWRoleAssociation;
 class RWStepBasic_RWRoleAssociation {
 	public:
@@ -3902,6 +4382,11 @@ class RWStepBasic_RWRoleAssociation {
 };
 
 
+%extend RWStepBasic_RWRoleAssociation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSecurityClassification;
 class RWStepBasic_RWSecurityClassification {
 	public:
@@ -3940,6 +4425,11 @@ class RWStepBasic_RWSecurityClassification {
 };
 
 
+%extend RWStepBasic_RWSecurityClassification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSecurityClassificationLevel;
 class RWStepBasic_RWSecurityClassificationLevel {
 	public:
@@ -3970,6 +4460,11 @@ class RWStepBasic_RWSecurityClassificationLevel {
 };
 
 
+%extend RWStepBasic_RWSecurityClassificationLevel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnit;
 class RWStepBasic_RWSiUnit {
 	public:
@@ -4028,6 +4523,11 @@ class RWStepBasic_RWSiUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndAreaUnit;
 class RWStepBasic_RWSiUnitAndAreaUnit {
 	public:
@@ -4058,6 +4558,11 @@ class RWStepBasic_RWSiUnitAndAreaUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndAreaUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndLengthUnit;
 class RWStepBasic_RWSiUnitAndLengthUnit {
 	public:
@@ -4088,6 +4593,11 @@ class RWStepBasic_RWSiUnitAndLengthUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndLengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndMassUnit;
 class RWStepBasic_RWSiUnitAndMassUnit {
 	public:
@@ -4118,6 +4628,11 @@ class RWStepBasic_RWSiUnitAndMassUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndMassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndPlaneAngleUnit;
 class RWStepBasic_RWSiUnitAndPlaneAngleUnit {
 	public:
@@ -4148,6 +4663,11 @@ class RWStepBasic_RWSiUnitAndPlaneAngleUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndPlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndRatioUnit;
 class RWStepBasic_RWSiUnitAndRatioUnit {
 	public:
@@ -4178,6 +4698,11 @@ class RWStepBasic_RWSiUnitAndRatioUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndRatioUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndSolidAngleUnit;
 class RWStepBasic_RWSiUnitAndSolidAngleUnit {
 	public:
@@ -4208,6 +4733,11 @@ class RWStepBasic_RWSiUnitAndSolidAngleUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndSolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit;
 class RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit {
 	public:
@@ -4238,6 +4768,11 @@ class RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndTimeUnit;
 class RWStepBasic_RWSiUnitAndTimeUnit {
 	public:
@@ -4268,6 +4803,11 @@ class RWStepBasic_RWSiUnitAndTimeUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndTimeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSiUnitAndVolumeUnit;
 class RWStepBasic_RWSiUnitAndVolumeUnit {
 	public:
@@ -4298,6 +4838,11 @@ class RWStepBasic_RWSiUnitAndVolumeUnit {
 };
 
 
+%extend RWStepBasic_RWSiUnitAndVolumeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSolidAngleMeasureWithUnit;
 class RWStepBasic_RWSolidAngleMeasureWithUnit {
 	public:
@@ -4336,6 +4881,11 @@ class RWStepBasic_RWSolidAngleMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWSolidAngleMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWSolidAngleUnit;
 class RWStepBasic_RWSolidAngleUnit {
 	public:
@@ -4374,6 +4924,11 @@ class RWStepBasic_RWSolidAngleUnit {
 };
 
 
+%extend RWStepBasic_RWSolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWThermodynamicTemperatureUnit;
 class RWStepBasic_RWThermodynamicTemperatureUnit {
 	public:
@@ -4420,6 +4975,11 @@ class RWStepBasic_RWThermodynamicTemperatureUnit {
 };
 
 
+%extend RWStepBasic_RWThermodynamicTemperatureUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWUncertaintyMeasureWithUnit;
 class RWStepBasic_RWUncertaintyMeasureWithUnit {
 	public:
@@ -4458,6 +5018,11 @@ class RWStepBasic_RWUncertaintyMeasureWithUnit {
 };
 
 
+%extend RWStepBasic_RWUncertaintyMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWVersionedActionRequest;
 class RWStepBasic_RWVersionedActionRequest {
 	public:
@@ -4504,6 +5069,11 @@ class RWStepBasic_RWVersionedActionRequest {
 };
 
 
+%extend RWStepBasic_RWVersionedActionRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepBasic_RWWeekOfYearAndDayDate;
 class RWStepBasic_RWWeekOfYearAndDayDate {
 	public:
@@ -4534,3 +5104,8 @@ class RWStepBasic_RWWeekOfYearAndDayDate {
 };
 
 
+%extend RWStepBasic_RWWeekOfYearAndDayDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepGeom.i
+++ b/src/SWIG_files/wrapper/RWStepGeom.i
@@ -94,6 +94,11 @@ class RWStepGeom_RWAxis1Placement {
 };
 
 
+%extend RWStepGeom_RWAxis1Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWAxis2Placement2d;
 class RWStepGeom_RWAxis2Placement2d {
 	public:
@@ -132,6 +137,11 @@ class RWStepGeom_RWAxis2Placement2d {
 };
 
 
+%extend RWStepGeom_RWAxis2Placement2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWAxis2Placement3d;
 class RWStepGeom_RWAxis2Placement3d {
 	public:
@@ -170,6 +180,11 @@ class RWStepGeom_RWAxis2Placement3d {
 };
 
 
+%extend RWStepGeom_RWAxis2Placement3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineCurve;
 class RWStepGeom_RWBSplineCurve {
 	public:
@@ -208,6 +223,11 @@ class RWStepGeom_RWBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineCurveWithKnots;
 class RWStepGeom_RWBSplineCurveWithKnots {
 	public:
@@ -256,6 +276,11 @@ class RWStepGeom_RWBSplineCurveWithKnots {
 };
 
 
+%extend RWStepGeom_RWBSplineCurveWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve;
 class RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve {
 	public:
@@ -304,6 +329,11 @@ class RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineSurface;
 class RWStepGeom_RWBSplineSurface {
 	public:
@@ -342,6 +372,11 @@ class RWStepGeom_RWBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineSurfaceWithKnots;
 class RWStepGeom_RWBSplineSurfaceWithKnots {
 	public:
@@ -390,6 +425,11 @@ class RWStepGeom_RWBSplineSurfaceWithKnots {
 };
 
 
+%extend RWStepGeom_RWBSplineSurfaceWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface;
 class RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface {
 	public:
@@ -438,6 +478,11 @@ class RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBezierCurve;
 class RWStepGeom_RWBezierCurve {
 	public:
@@ -476,6 +521,11 @@ class RWStepGeom_RWBezierCurve {
 };
 
 
+%extend RWStepGeom_RWBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBezierCurveAndRationalBSplineCurve;
 class RWStepGeom_RWBezierCurveAndRationalBSplineCurve {
 	public:
@@ -514,6 +564,11 @@ class RWStepGeom_RWBezierCurveAndRationalBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWBezierCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBezierSurface;
 class RWStepGeom_RWBezierSurface {
 	public:
@@ -552,6 +607,11 @@ class RWStepGeom_RWBezierSurface {
 };
 
 
+%extend RWStepGeom_RWBezierSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface;
 class RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface {
 	public:
@@ -590,6 +650,11 @@ class RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBoundaryCurve;
 class RWStepGeom_RWBoundaryCurve {
 	public:
@@ -628,6 +693,11 @@ class RWStepGeom_RWBoundaryCurve {
 };
 
 
+%extend RWStepGeom_RWBoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBoundedCurve;
 class RWStepGeom_RWBoundedCurve {
 	public:
@@ -658,6 +728,11 @@ class RWStepGeom_RWBoundedCurve {
 };
 
 
+%extend RWStepGeom_RWBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWBoundedSurface;
 class RWStepGeom_RWBoundedSurface {
 	public:
@@ -688,6 +763,11 @@ class RWStepGeom_RWBoundedSurface {
 };
 
 
+%extend RWStepGeom_RWBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCartesianPoint;
 class RWStepGeom_RWCartesianPoint {
 	public:
@@ -718,6 +798,11 @@ class RWStepGeom_RWCartesianPoint {
 };
 
 
+%extend RWStepGeom_RWCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCartesianTransformationOperator;
 class RWStepGeom_RWCartesianTransformationOperator {
 	public:
@@ -756,6 +841,11 @@ class RWStepGeom_RWCartesianTransformationOperator {
 };
 
 
+%extend RWStepGeom_RWCartesianTransformationOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCartesianTransformationOperator3d;
 class RWStepGeom_RWCartesianTransformationOperator3d {
 	public:
@@ -794,6 +884,11 @@ class RWStepGeom_RWCartesianTransformationOperator3d {
 };
 
 
+%extend RWStepGeom_RWCartesianTransformationOperator3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCircle;
 class RWStepGeom_RWCircle {
 	public:
@@ -832,6 +927,11 @@ class RWStepGeom_RWCircle {
 };
 
 
+%extend RWStepGeom_RWCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCompositeCurve;
 class RWStepGeom_RWCompositeCurve {
 	public:
@@ -870,6 +970,11 @@ class RWStepGeom_RWCompositeCurve {
 };
 
 
+%extend RWStepGeom_RWCompositeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCompositeCurveOnSurface;
 class RWStepGeom_RWCompositeCurveOnSurface {
 	public:
@@ -908,6 +1013,11 @@ class RWStepGeom_RWCompositeCurveOnSurface {
 };
 
 
+%extend RWStepGeom_RWCompositeCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCompositeCurveSegment;
 class RWStepGeom_RWCompositeCurveSegment {
 	public:
@@ -946,6 +1056,11 @@ class RWStepGeom_RWCompositeCurveSegment {
 };
 
 
+%extend RWStepGeom_RWCompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWConic;
 class RWStepGeom_RWConic {
 	public:
@@ -984,6 +1099,11 @@ class RWStepGeom_RWConic {
 };
 
 
+%extend RWStepGeom_RWConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWConicalSurface;
 class RWStepGeom_RWConicalSurface {
 	public:
@@ -1022,6 +1142,11 @@ class RWStepGeom_RWConicalSurface {
 };
 
 
+%extend RWStepGeom_RWConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCurve;
 class RWStepGeom_RWCurve {
 	public:
@@ -1052,6 +1177,11 @@ class RWStepGeom_RWCurve {
 };
 
 
+%extend RWStepGeom_RWCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCurveBoundedSurface;
 class RWStepGeom_RWCurveBoundedSurface {
 	public:
@@ -1098,6 +1228,11 @@ class RWStepGeom_RWCurveBoundedSurface {
 };
 
 
+%extend RWStepGeom_RWCurveBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCurveReplica;
 class RWStepGeom_RWCurveReplica {
 	public:
@@ -1136,6 +1271,11 @@ class RWStepGeom_RWCurveReplica {
 };
 
 
+%extend RWStepGeom_RWCurveReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWCylindricalSurface;
 class RWStepGeom_RWCylindricalSurface {
 	public:
@@ -1174,6 +1314,11 @@ class RWStepGeom_RWCylindricalSurface {
 };
 
 
+%extend RWStepGeom_RWCylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWDegeneratePcurve;
 class RWStepGeom_RWDegeneratePcurve {
 	public:
@@ -1212,6 +1357,11 @@ class RWStepGeom_RWDegeneratePcurve {
 };
 
 
+%extend RWStepGeom_RWDegeneratePcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWDegenerateToroidalSurface;
 class RWStepGeom_RWDegenerateToroidalSurface {
 	public:
@@ -1250,6 +1400,11 @@ class RWStepGeom_RWDegenerateToroidalSurface {
 };
 
 
+%extend RWStepGeom_RWDegenerateToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWDirection;
 class RWStepGeom_RWDirection {
 	public:
@@ -1290,6 +1445,11 @@ class RWStepGeom_RWDirection {
 };
 
 
+%extend RWStepGeom_RWDirection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWElementarySurface;
 class RWStepGeom_RWElementarySurface {
 	public:
@@ -1328,6 +1488,11 @@ class RWStepGeom_RWElementarySurface {
 };
 
 
+%extend RWStepGeom_RWElementarySurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWEllipse;
 class RWStepGeom_RWEllipse {
 	public:
@@ -1376,6 +1541,11 @@ class RWStepGeom_RWEllipse {
 };
 
 
+%extend RWStepGeom_RWEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWEvaluatedDegeneratePcurve;
 class RWStepGeom_RWEvaluatedDegeneratePcurve {
 	public:
@@ -1414,6 +1584,11 @@ class RWStepGeom_RWEvaluatedDegeneratePcurve {
 };
 
 
+%extend RWStepGeom_RWEvaluatedDegeneratePcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWGeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx;
 class RWStepGeom_RWGeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx {
 	public:
@@ -1452,6 +1627,11 @@ class RWStepGeom_RWGeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx {
 };
 
 
+%extend RWStepGeom_RWGeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWGeometricRepresentationContext;
 class RWStepGeom_RWGeometricRepresentationContext {
 	public:
@@ -1482,6 +1662,11 @@ class RWStepGeom_RWGeometricRepresentationContext {
 };
 
 
+%extend RWStepGeom_RWGeometricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWGeometricRepresentationContextAndGlobalUnitAssignedContext;
 class RWStepGeom_RWGeometricRepresentationContextAndGlobalUnitAssignedContext {
 	public:
@@ -1520,6 +1705,11 @@ class RWStepGeom_RWGeometricRepresentationContextAndGlobalUnitAssignedContext {
 };
 
 
+%extend RWStepGeom_RWGeometricRepresentationContextAndGlobalUnitAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWGeometricRepresentationContextAndParametricRepresentationContext;
 class RWStepGeom_RWGeometricRepresentationContextAndParametricRepresentationContext {
 	public:
@@ -1558,6 +1748,11 @@ class RWStepGeom_RWGeometricRepresentationContextAndParametricRepresentationCont
 };
 
 
+%extend RWStepGeom_RWGeometricRepresentationContextAndParametricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWGeometricRepresentationItem;
 class RWStepGeom_RWGeometricRepresentationItem {
 	public:
@@ -1588,6 +1783,11 @@ class RWStepGeom_RWGeometricRepresentationItem {
 };
 
 
+%extend RWStepGeom_RWGeometricRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWHyperbola;
 class RWStepGeom_RWHyperbola {
 	public:
@@ -1626,6 +1826,11 @@ class RWStepGeom_RWHyperbola {
 };
 
 
+%extend RWStepGeom_RWHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWIntersectionCurve;
 class RWStepGeom_RWIntersectionCurve {
 	public:
@@ -1664,6 +1869,11 @@ class RWStepGeom_RWIntersectionCurve {
 };
 
 
+%extend RWStepGeom_RWIntersectionCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWLine;
 class RWStepGeom_RWLine {
 	public:
@@ -1702,6 +1912,11 @@ class RWStepGeom_RWLine {
 };
 
 
+%extend RWStepGeom_RWLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWOffsetCurve3d;
 class RWStepGeom_RWOffsetCurve3d {
 	public:
@@ -1740,6 +1955,11 @@ class RWStepGeom_RWOffsetCurve3d {
 };
 
 
+%extend RWStepGeom_RWOffsetCurve3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWOffsetSurface;
 class RWStepGeom_RWOffsetSurface {
 	public:
@@ -1778,6 +1998,11 @@ class RWStepGeom_RWOffsetSurface {
 };
 
 
+%extend RWStepGeom_RWOffsetSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWOrientedSurface;
 class RWStepGeom_RWOrientedSurface {
 	public:
@@ -1824,6 +2049,11 @@ class RWStepGeom_RWOrientedSurface {
 };
 
 
+%extend RWStepGeom_RWOrientedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWOuterBoundaryCurve;
 class RWStepGeom_RWOuterBoundaryCurve {
 	public:
@@ -1862,6 +2092,11 @@ class RWStepGeom_RWOuterBoundaryCurve {
 };
 
 
+%extend RWStepGeom_RWOuterBoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWParabola;
 class RWStepGeom_RWParabola {
 	public:
@@ -1900,6 +2135,11 @@ class RWStepGeom_RWParabola {
 };
 
 
+%extend RWStepGeom_RWParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPcurve;
 class RWStepGeom_RWPcurve {
 	public:
@@ -1938,6 +2178,11 @@ class RWStepGeom_RWPcurve {
 };
 
 
+%extend RWStepGeom_RWPcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPlacement;
 class RWStepGeom_RWPlacement {
 	public:
@@ -1976,6 +2221,11 @@ class RWStepGeom_RWPlacement {
 };
 
 
+%extend RWStepGeom_RWPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPlane;
 class RWStepGeom_RWPlane {
 	public:
@@ -2014,6 +2264,11 @@ class RWStepGeom_RWPlane {
 };
 
 
+%extend RWStepGeom_RWPlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPoint;
 class RWStepGeom_RWPoint {
 	public:
@@ -2044,6 +2299,11 @@ class RWStepGeom_RWPoint {
 };
 
 
+%extend RWStepGeom_RWPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPointOnCurve;
 class RWStepGeom_RWPointOnCurve {
 	public:
@@ -2082,6 +2342,11 @@ class RWStepGeom_RWPointOnCurve {
 };
 
 
+%extend RWStepGeom_RWPointOnCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPointOnSurface;
 class RWStepGeom_RWPointOnSurface {
 	public:
@@ -2120,6 +2385,11 @@ class RWStepGeom_RWPointOnSurface {
 };
 
 
+%extend RWStepGeom_RWPointOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPointReplica;
 class RWStepGeom_RWPointReplica {
 	public:
@@ -2158,6 +2428,11 @@ class RWStepGeom_RWPointReplica {
 };
 
 
+%extend RWStepGeom_RWPointReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWPolyline;
 class RWStepGeom_RWPolyline {
 	public:
@@ -2196,6 +2471,11 @@ class RWStepGeom_RWPolyline {
 };
 
 
+%extend RWStepGeom_RWPolyline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWQuasiUniformCurve;
 class RWStepGeom_RWQuasiUniformCurve {
 	public:
@@ -2234,6 +2514,11 @@ class RWStepGeom_RWQuasiUniformCurve {
 };
 
 
+%extend RWStepGeom_RWQuasiUniformCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve;
 class RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve {
 	public:
@@ -2272,6 +2557,11 @@ class RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWQuasiUniformSurface;
 class RWStepGeom_RWQuasiUniformSurface {
 	public:
@@ -2310,6 +2600,11 @@ class RWStepGeom_RWQuasiUniformSurface {
 };
 
 
+%extend RWStepGeom_RWQuasiUniformSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface;
 class RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface {
 	public:
@@ -2348,6 +2643,11 @@ class RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWRationalBSplineCurve;
 class RWStepGeom_RWRationalBSplineCurve {
 	public:
@@ -2396,6 +2696,11 @@ class RWStepGeom_RWRationalBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWRationalBSplineSurface;
 class RWStepGeom_RWRationalBSplineSurface {
 	public:
@@ -2444,6 +2749,11 @@ class RWStepGeom_RWRationalBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWRectangularCompositeSurface;
 class RWStepGeom_RWRectangularCompositeSurface {
 	public:
@@ -2482,6 +2792,11 @@ class RWStepGeom_RWRectangularCompositeSurface {
 };
 
 
+%extend RWStepGeom_RWRectangularCompositeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWRectangularTrimmedSurface;
 class RWStepGeom_RWRectangularTrimmedSurface {
 	public:
@@ -2520,6 +2835,11 @@ class RWStepGeom_RWRectangularTrimmedSurface {
 };
 
 
+%extend RWStepGeom_RWRectangularTrimmedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWReparametrisedCompositeCurveSegment;
 class RWStepGeom_RWReparametrisedCompositeCurveSegment {
 	public:
@@ -2558,6 +2878,11 @@ class RWStepGeom_RWReparametrisedCompositeCurveSegment {
 };
 
 
+%extend RWStepGeom_RWReparametrisedCompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSeamCurve;
 class RWStepGeom_RWSeamCurve {
 	public:
@@ -2596,6 +2921,11 @@ class RWStepGeom_RWSeamCurve {
 };
 
 
+%extend RWStepGeom_RWSeamCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSphericalSurface;
 class RWStepGeom_RWSphericalSurface {
 	public:
@@ -2634,6 +2964,11 @@ class RWStepGeom_RWSphericalSurface {
 };
 
 
+%extend RWStepGeom_RWSphericalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurface;
 class RWStepGeom_RWSurface {
 	public:
@@ -2664,6 +2999,11 @@ class RWStepGeom_RWSurface {
 };
 
 
+%extend RWStepGeom_RWSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfaceCurve;
 class RWStepGeom_RWSurfaceCurve {
 	public:
@@ -2702,6 +3042,11 @@ class RWStepGeom_RWSurfaceCurve {
 };
 
 
+%extend RWStepGeom_RWSurfaceCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfaceCurveAndBoundedCurve;
 class RWStepGeom_RWSurfaceCurveAndBoundedCurve {
 	public:
@@ -2740,6 +3085,11 @@ class RWStepGeom_RWSurfaceCurveAndBoundedCurve {
 };
 
 
+%extend RWStepGeom_RWSurfaceCurveAndBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfaceOfLinearExtrusion;
 class RWStepGeom_RWSurfaceOfLinearExtrusion {
 	public:
@@ -2778,6 +3128,11 @@ class RWStepGeom_RWSurfaceOfLinearExtrusion {
 };
 
 
+%extend RWStepGeom_RWSurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfaceOfRevolution;
 class RWStepGeom_RWSurfaceOfRevolution {
 	public:
@@ -2816,6 +3171,11 @@ class RWStepGeom_RWSurfaceOfRevolution {
 };
 
 
+%extend RWStepGeom_RWSurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfacePatch;
 class RWStepGeom_RWSurfacePatch {
 	public:
@@ -2854,6 +3214,11 @@ class RWStepGeom_RWSurfacePatch {
 };
 
 
+%extend RWStepGeom_RWSurfacePatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSurfaceReplica;
 class RWStepGeom_RWSurfaceReplica {
 	public:
@@ -2892,6 +3257,11 @@ class RWStepGeom_RWSurfaceReplica {
 };
 
 
+%extend RWStepGeom_RWSurfaceReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWSweptSurface;
 class RWStepGeom_RWSweptSurface {
 	public:
@@ -2930,6 +3300,11 @@ class RWStepGeom_RWSweptSurface {
 };
 
 
+%extend RWStepGeom_RWSweptSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWToroidalSurface;
 class RWStepGeom_RWToroidalSurface {
 	public:
@@ -2978,6 +3353,11 @@ class RWStepGeom_RWToroidalSurface {
 };
 
 
+%extend RWStepGeom_RWToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWTrimmedCurve;
 class RWStepGeom_RWTrimmedCurve {
 	public:
@@ -3016,6 +3396,11 @@ class RWStepGeom_RWTrimmedCurve {
 };
 
 
+%extend RWStepGeom_RWTrimmedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWUniformCurve;
 class RWStepGeom_RWUniformCurve {
 	public:
@@ -3054,6 +3439,11 @@ class RWStepGeom_RWUniformCurve {
 };
 
 
+%extend RWStepGeom_RWUniformCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWUniformCurveAndRationalBSplineCurve;
 class RWStepGeom_RWUniformCurveAndRationalBSplineCurve {
 	public:
@@ -3092,6 +3482,11 @@ class RWStepGeom_RWUniformCurveAndRationalBSplineCurve {
 };
 
 
+%extend RWStepGeom_RWUniformCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWUniformSurface;
 class RWStepGeom_RWUniformSurface {
 	public:
@@ -3130,6 +3525,11 @@ class RWStepGeom_RWUniformSurface {
 };
 
 
+%extend RWStepGeom_RWUniformSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface;
 class RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface {
 	public:
@@ -3168,6 +3568,11 @@ class RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface {
 };
 
 
+%extend RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepGeom_RWVector;
 class RWStepGeom_RWVector {
 	public:
@@ -3216,3 +3621,8 @@ class RWStepGeom_RWVector {
 };
 
 
+%extend RWStepGeom_RWVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepRepr.i
+++ b/src/SWIG_files/wrapper/RWStepRepr.i
@@ -102,6 +102,11 @@ class RWStepRepr_RWAssemblyComponentUsage {
 };
 
 
+%extend RWStepRepr_RWAssemblyComponentUsage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWAssemblyComponentUsageSubstitute;
 class RWStepRepr_RWAssemblyComponentUsageSubstitute {
 	public:
@@ -140,6 +145,11 @@ class RWStepRepr_RWAssemblyComponentUsageSubstitute {
 };
 
 
+%extend RWStepRepr_RWAssemblyComponentUsageSubstitute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWCompositeShapeAspect;
 class RWStepRepr_RWCompositeShapeAspect {
 	public:
@@ -186,6 +196,11 @@ class RWStepRepr_RWCompositeShapeAspect {
 };
 
 
+%extend RWStepRepr_RWCompositeShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWCompoundRepresentationItem;
 class RWStepRepr_RWCompoundRepresentationItem {
 	public:
@@ -226,6 +241,11 @@ class RWStepRepr_RWCompoundRepresentationItem {
 };
 
 
+%extend RWStepRepr_RWCompoundRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWConfigurationDesign;
 class RWStepRepr_RWConfigurationDesign {
 	public:
@@ -272,6 +292,11 @@ class RWStepRepr_RWConfigurationDesign {
 };
 
 
+%extend RWStepRepr_RWConfigurationDesign {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWConfigurationEffectivity;
 class RWStepRepr_RWConfigurationEffectivity {
 	public:
@@ -318,6 +343,11 @@ class RWStepRepr_RWConfigurationEffectivity {
 };
 
 
+%extend RWStepRepr_RWConfigurationEffectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWConfigurationItem;
 class RWStepRepr_RWConfigurationItem {
 	public:
@@ -364,6 +394,11 @@ class RWStepRepr_RWConfigurationItem {
 };
 
 
+%extend RWStepRepr_RWConfigurationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWDataEnvironment;
 class RWStepRepr_RWDataEnvironment {
 	public:
@@ -410,6 +445,11 @@ class RWStepRepr_RWDataEnvironment {
 };
 
 
+%extend RWStepRepr_RWDataEnvironment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWDefinitionalRepresentation;
 class RWStepRepr_RWDefinitionalRepresentation {
 	public:
@@ -448,6 +488,11 @@ class RWStepRepr_RWDefinitionalRepresentation {
 };
 
 
+%extend RWStepRepr_RWDefinitionalRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWDerivedShapeAspect;
 class RWStepRepr_RWDerivedShapeAspect {
 	public:
@@ -494,6 +539,11 @@ class RWStepRepr_RWDerivedShapeAspect {
 };
 
 
+%extend RWStepRepr_RWDerivedShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWDescriptiveRepresentationItem;
 class RWStepRepr_RWDescriptiveRepresentationItem {
 	public:
@@ -524,6 +574,11 @@ class RWStepRepr_RWDescriptiveRepresentationItem {
 };
 
 
+%extend RWStepRepr_RWDescriptiveRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWExtension;
 class RWStepRepr_RWExtension {
 	public:
@@ -570,6 +625,11 @@ class RWStepRepr_RWExtension {
 };
 
 
+%extend RWStepRepr_RWExtension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWFunctionallyDefinedTransformation;
 class RWStepRepr_RWFunctionallyDefinedTransformation {
 	public:
@@ -600,6 +660,11 @@ class RWStepRepr_RWFunctionallyDefinedTransformation {
 };
 
 
+%extend RWStepRepr_RWFunctionallyDefinedTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWGlobalUncertaintyAssignedContext;
 class RWStepRepr_RWGlobalUncertaintyAssignedContext {
 	public:
@@ -638,6 +703,11 @@ class RWStepRepr_RWGlobalUncertaintyAssignedContext {
 };
 
 
+%extend RWStepRepr_RWGlobalUncertaintyAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWGlobalUnitAssignedContext;
 class RWStepRepr_RWGlobalUnitAssignedContext {
 	public:
@@ -676,6 +746,11 @@ class RWStepRepr_RWGlobalUnitAssignedContext {
 };
 
 
+%extend RWStepRepr_RWGlobalUnitAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWItemDefinedTransformation;
 class RWStepRepr_RWItemDefinedTransformation {
 	public:
@@ -714,6 +789,11 @@ class RWStepRepr_RWItemDefinedTransformation {
 };
 
 
+%extend RWStepRepr_RWItemDefinedTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMakeFromUsageOption;
 class RWStepRepr_RWMakeFromUsageOption {
 	public:
@@ -760,6 +840,11 @@ class RWStepRepr_RWMakeFromUsageOption {
 };
 
 
+%extend RWStepRepr_RWMakeFromUsageOption {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMappedItem;
 class RWStepRepr_RWMappedItem {
 	public:
@@ -798,6 +883,11 @@ class RWStepRepr_RWMappedItem {
 };
 
 
+%extend RWStepRepr_RWMappedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMaterialDesignation;
 class RWStepRepr_RWMaterialDesignation {
 	public:
@@ -836,6 +926,11 @@ class RWStepRepr_RWMaterialDesignation {
 };
 
 
+%extend RWStepRepr_RWMaterialDesignation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMaterialProperty;
 class RWStepRepr_RWMaterialProperty {
 	public:
@@ -882,6 +977,11 @@ class RWStepRepr_RWMaterialProperty {
 };
 
 
+%extend RWStepRepr_RWMaterialProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMaterialPropertyRepresentation;
 class RWStepRepr_RWMaterialPropertyRepresentation {
 	public:
@@ -928,6 +1028,11 @@ class RWStepRepr_RWMaterialPropertyRepresentation {
 };
 
 
+%extend RWStepRepr_RWMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWMeasureRepresentationItem;
 class RWStepRepr_RWMeasureRepresentationItem {
 	public:
@@ -966,6 +1071,11 @@ class RWStepRepr_RWMeasureRepresentationItem {
 };
 
 
+%extend RWStepRepr_RWMeasureRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWParametricRepresentationContext;
 class RWStepRepr_RWParametricRepresentationContext {
 	public:
@@ -996,6 +1106,11 @@ class RWStepRepr_RWParametricRepresentationContext {
 };
 
 
+%extend RWStepRepr_RWParametricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWProductConcept;
 class RWStepRepr_RWProductConcept {
 	public:
@@ -1042,6 +1157,11 @@ class RWStepRepr_RWProductConcept {
 };
 
 
+%extend RWStepRepr_RWProductConcept {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWProductDefinitionShape;
 class RWStepRepr_RWProductDefinitionShape {
 	public:
@@ -1088,6 +1208,11 @@ class RWStepRepr_RWProductDefinitionShape {
 };
 
 
+%extend RWStepRepr_RWProductDefinitionShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWPropertyDefinition;
 class RWStepRepr_RWPropertyDefinition {
 	public:
@@ -1134,6 +1259,11 @@ class RWStepRepr_RWPropertyDefinition {
 };
 
 
+%extend RWStepRepr_RWPropertyDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWPropertyDefinitionRelationship;
 class RWStepRepr_RWPropertyDefinitionRelationship {
 	public:
@@ -1180,6 +1310,11 @@ class RWStepRepr_RWPropertyDefinitionRelationship {
 };
 
 
+%extend RWStepRepr_RWPropertyDefinitionRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWPropertyDefinitionRepresentation;
 class RWStepRepr_RWPropertyDefinitionRepresentation {
 	public:
@@ -1226,6 +1361,11 @@ class RWStepRepr_RWPropertyDefinitionRepresentation {
 };
 
 
+%extend RWStepRepr_RWPropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWQuantifiedAssemblyComponentUsage;
 class RWStepRepr_RWQuantifiedAssemblyComponentUsage {
 	public:
@@ -1272,6 +1412,11 @@ class RWStepRepr_RWQuantifiedAssemblyComponentUsage {
 };
 
 
+%extend RWStepRepr_RWQuantifiedAssemblyComponentUsage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWReprItemAndLengthMeasureWithUnit;
 class RWStepRepr_RWReprItemAndLengthMeasureWithUnit {
 	public:
@@ -1302,6 +1447,11 @@ class RWStepRepr_RWReprItemAndLengthMeasureWithUnit {
 };
 
 
+%extend RWStepRepr_RWReprItemAndLengthMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentation;
 class RWStepRepr_RWRepresentation {
 	public:
@@ -1340,6 +1490,11 @@ class RWStepRepr_RWRepresentation {
 };
 
 
+%extend RWStepRepr_RWRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentationContext;
 class RWStepRepr_RWRepresentationContext {
 	public:
@@ -1370,6 +1525,11 @@ class RWStepRepr_RWRepresentationContext {
 };
 
 
+%extend RWStepRepr_RWRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentationItem;
 class RWStepRepr_RWRepresentationItem {
 	public:
@@ -1400,6 +1560,11 @@ class RWStepRepr_RWRepresentationItem {
 };
 
 
+%extend RWStepRepr_RWRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentationMap;
 class RWStepRepr_RWRepresentationMap {
 	public:
@@ -1438,6 +1603,11 @@ class RWStepRepr_RWRepresentationMap {
 };
 
 
+%extend RWStepRepr_RWRepresentationMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentationRelationship;
 class RWStepRepr_RWRepresentationRelationship {
 	public:
@@ -1476,6 +1646,11 @@ class RWStepRepr_RWRepresentationRelationship {
 };
 
 
+%extend RWStepRepr_RWRepresentationRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWRepresentationRelationshipWithTransformation;
 class RWStepRepr_RWRepresentationRelationshipWithTransformation {
 	public:
@@ -1514,6 +1689,11 @@ class RWStepRepr_RWRepresentationRelationshipWithTransformation {
 };
 
 
+%extend RWStepRepr_RWRepresentationRelationshipWithTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWShapeAspect;
 class RWStepRepr_RWShapeAspect {
 	public:
@@ -1552,6 +1732,11 @@ class RWStepRepr_RWShapeAspect {
 };
 
 
+%extend RWStepRepr_RWShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWShapeAspectDerivingRelationship;
 class RWStepRepr_RWShapeAspectDerivingRelationship {
 	public:
@@ -1598,6 +1783,11 @@ class RWStepRepr_RWShapeAspectDerivingRelationship {
 };
 
 
+%extend RWStepRepr_RWShapeAspectDerivingRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWShapeAspectRelationship;
 class RWStepRepr_RWShapeAspectRelationship {
 	public:
@@ -1644,6 +1834,11 @@ class RWStepRepr_RWShapeAspectRelationship {
 };
 
 
+%extend RWStepRepr_RWShapeAspectRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWShapeAspectTransition;
 class RWStepRepr_RWShapeAspectTransition {
 	public:
@@ -1690,6 +1885,11 @@ class RWStepRepr_RWShapeAspectTransition {
 };
 
 
+%extend RWStepRepr_RWShapeAspectTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWShapeRepresentationRelationshipWithTransformation;
 class RWStepRepr_RWShapeRepresentationRelationshipWithTransformation {
 	public:
@@ -1728,6 +1928,11 @@ class RWStepRepr_RWShapeRepresentationRelationshipWithTransformation {
 };
 
 
+%extend RWStepRepr_RWShapeRepresentationRelationshipWithTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWSpecifiedHigherUsageOccurrence;
 class RWStepRepr_RWSpecifiedHigherUsageOccurrence {
 	public:
@@ -1774,6 +1979,11 @@ class RWStepRepr_RWSpecifiedHigherUsageOccurrence {
 };
 
 
+%extend RWStepRepr_RWSpecifiedHigherUsageOccurrence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWStructuralResponseProperty;
 class RWStepRepr_RWStructuralResponseProperty {
 	public:
@@ -1820,6 +2030,11 @@ class RWStepRepr_RWStructuralResponseProperty {
 };
 
 
+%extend RWStepRepr_RWStructuralResponseProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepRepr_RWStructuralResponsePropertyDefinitionRepresentation;
 class RWStepRepr_RWStructuralResponsePropertyDefinitionRepresentation {
 	public:
@@ -1866,3 +2081,8 @@ class RWStepRepr_RWStructuralResponsePropertyDefinitionRepresentation {
 };
 
 
+%extend RWStepRepr_RWStructuralResponsePropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStepShape.i
+++ b/src/SWIG_files/wrapper/RWStepShape.i
@@ -94,6 +94,11 @@ class RWStepShape_RWAdvancedBrepShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWAdvancedBrepShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWAdvancedFace;
 class RWStepShape_RWAdvancedFace {
 	public:
@@ -132,6 +137,11 @@ class RWStepShape_RWAdvancedFace {
 };
 
 
+%extend RWStepShape_RWAdvancedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWAngularLocation;
 class RWStepShape_RWAngularLocation {
 	public:
@@ -178,6 +188,11 @@ class RWStepShape_RWAngularLocation {
 };
 
 
+%extend RWStepShape_RWAngularLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWAngularSize;
 class RWStepShape_RWAngularSize {
 	public:
@@ -224,6 +239,11 @@ class RWStepShape_RWAngularSize {
 };
 
 
+%extend RWStepShape_RWAngularSize {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWBlock;
 class RWStepShape_RWBlock {
 	public:
@@ -262,6 +282,11 @@ class RWStepShape_RWBlock {
 };
 
 
+%extend RWStepShape_RWBlock {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWBooleanResult;
 class RWStepShape_RWBooleanResult {
 	public:
@@ -300,6 +325,11 @@ class RWStepShape_RWBooleanResult {
 };
 
 
+%extend RWStepShape_RWBooleanResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWBoxDomain;
 class RWStepShape_RWBoxDomain {
 	public:
@@ -338,6 +368,11 @@ class RWStepShape_RWBoxDomain {
 };
 
 
+%extend RWStepShape_RWBoxDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWBoxedHalfSpace;
 class RWStepShape_RWBoxedHalfSpace {
 	public:
@@ -376,6 +411,11 @@ class RWStepShape_RWBoxedHalfSpace {
 };
 
 
+%extend RWStepShape_RWBoxedHalfSpace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWBrepWithVoids;
 class RWStepShape_RWBrepWithVoids {
 	public:
@@ -424,6 +464,11 @@ class RWStepShape_RWBrepWithVoids {
 };
 
 
+%extend RWStepShape_RWBrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWClosedShell;
 class RWStepShape_RWClosedShell {
 	public:
@@ -462,6 +507,11 @@ class RWStepShape_RWClosedShell {
 };
 
 
+%extend RWStepShape_RWClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWCompoundShapeRepresentation;
 class RWStepShape_RWCompoundShapeRepresentation {
 	public:
@@ -508,6 +558,11 @@ class RWStepShape_RWCompoundShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWCompoundShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWConnectedEdgeSet;
 class RWStepShape_RWConnectedEdgeSet {
 	public:
@@ -554,6 +609,11 @@ class RWStepShape_RWConnectedEdgeSet {
 };
 
 
+%extend RWStepShape_RWConnectedEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWConnectedFaceSet;
 class RWStepShape_RWConnectedFaceSet {
 	public:
@@ -592,6 +652,11 @@ class RWStepShape_RWConnectedFaceSet {
 };
 
 
+%extend RWStepShape_RWConnectedFaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWConnectedFaceShapeRepresentation;
 class RWStepShape_RWConnectedFaceShapeRepresentation {
 	public:
@@ -638,6 +703,11 @@ class RWStepShape_RWConnectedFaceShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWConnectedFaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWConnectedFaceSubSet;
 class RWStepShape_RWConnectedFaceSubSet {
 	public:
@@ -684,6 +754,11 @@ class RWStepShape_RWConnectedFaceSubSet {
 };
 
 
+%extend RWStepShape_RWConnectedFaceSubSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWContextDependentShapeRepresentation;
 class RWStepShape_RWContextDependentShapeRepresentation {
 	public:
@@ -722,6 +797,11 @@ class RWStepShape_RWContextDependentShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWContextDependentShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWCsgShapeRepresentation;
 class RWStepShape_RWCsgShapeRepresentation {
 	public:
@@ -760,6 +840,11 @@ class RWStepShape_RWCsgShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWCsgShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWCsgSolid;
 class RWStepShape_RWCsgSolid {
 	public:
@@ -798,6 +883,11 @@ class RWStepShape_RWCsgSolid {
 };
 
 
+%extend RWStepShape_RWCsgSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDefinitionalRepresentationAndShapeRepresentation;
 class RWStepShape_RWDefinitionalRepresentationAndShapeRepresentation {
 	public:
@@ -836,6 +926,11 @@ class RWStepShape_RWDefinitionalRepresentationAndShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWDefinitionalRepresentationAndShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDimensionalCharacteristicRepresentation;
 class RWStepShape_RWDimensionalCharacteristicRepresentation {
 	public:
@@ -882,6 +977,11 @@ class RWStepShape_RWDimensionalCharacteristicRepresentation {
 };
 
 
+%extend RWStepShape_RWDimensionalCharacteristicRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDimensionalLocation;
 class RWStepShape_RWDimensionalLocation {
 	public:
@@ -928,6 +1028,11 @@ class RWStepShape_RWDimensionalLocation {
 };
 
 
+%extend RWStepShape_RWDimensionalLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDimensionalLocationWithPath;
 class RWStepShape_RWDimensionalLocationWithPath {
 	public:
@@ -974,6 +1079,11 @@ class RWStepShape_RWDimensionalLocationWithPath {
 };
 
 
+%extend RWStepShape_RWDimensionalLocationWithPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDimensionalSize;
 class RWStepShape_RWDimensionalSize {
 	public:
@@ -1020,6 +1130,11 @@ class RWStepShape_RWDimensionalSize {
 };
 
 
+%extend RWStepShape_RWDimensionalSize {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWDimensionalSizeWithPath;
 class RWStepShape_RWDimensionalSizeWithPath {
 	public:
@@ -1066,6 +1181,11 @@ class RWStepShape_RWDimensionalSizeWithPath {
 };
 
 
+%extend RWStepShape_RWDimensionalSizeWithPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWEdge;
 class RWStepShape_RWEdge {
 	public:
@@ -1104,6 +1224,11 @@ class RWStepShape_RWEdge {
 };
 
 
+%extend RWStepShape_RWEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWEdgeBasedWireframeModel;
 class RWStepShape_RWEdgeBasedWireframeModel {
 	public:
@@ -1150,6 +1275,11 @@ class RWStepShape_RWEdgeBasedWireframeModel {
 };
 
 
+%extend RWStepShape_RWEdgeBasedWireframeModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWEdgeBasedWireframeShapeRepresentation;
 class RWStepShape_RWEdgeBasedWireframeShapeRepresentation {
 	public:
@@ -1196,6 +1326,11 @@ class RWStepShape_RWEdgeBasedWireframeShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWEdgeBasedWireframeShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWEdgeCurve;
 class RWStepShape_RWEdgeCurve {
 	public:
@@ -1244,6 +1379,11 @@ class RWStepShape_RWEdgeCurve {
 };
 
 
+%extend RWStepShape_RWEdgeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWEdgeLoop;
 class RWStepShape_RWEdgeLoop {
 	public:
@@ -1292,6 +1432,11 @@ class RWStepShape_RWEdgeLoop {
 };
 
 
+%extend RWStepShape_RWEdgeLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWExtrudedAreaSolid;
 class RWStepShape_RWExtrudedAreaSolid {
 	public:
@@ -1330,6 +1475,11 @@ class RWStepShape_RWExtrudedAreaSolid {
 };
 
 
+%extend RWStepShape_RWExtrudedAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWExtrudedFaceSolid;
 class RWStepShape_RWExtrudedFaceSolid {
 	public:
@@ -1368,6 +1518,11 @@ class RWStepShape_RWExtrudedFaceSolid {
 };
 
 
+%extend RWStepShape_RWExtrudedFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFace;
 class RWStepShape_RWFace {
 	public:
@@ -1406,6 +1561,11 @@ class RWStepShape_RWFace {
 };
 
 
+%extend RWStepShape_RWFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFaceBasedSurfaceModel;
 class RWStepShape_RWFaceBasedSurfaceModel {
 	public:
@@ -1452,6 +1612,11 @@ class RWStepShape_RWFaceBasedSurfaceModel {
 };
 
 
+%extend RWStepShape_RWFaceBasedSurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFaceBound;
 class RWStepShape_RWFaceBound {
 	public:
@@ -1500,6 +1665,11 @@ class RWStepShape_RWFaceBound {
 };
 
 
+%extend RWStepShape_RWFaceBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFaceOuterBound;
 class RWStepShape_RWFaceOuterBound {
 	public:
@@ -1538,6 +1708,11 @@ class RWStepShape_RWFaceOuterBound {
 };
 
 
+%extend RWStepShape_RWFaceOuterBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFaceSurface;
 class RWStepShape_RWFaceSurface {
 	public:
@@ -1576,6 +1751,11 @@ class RWStepShape_RWFaceSurface {
 };
 
 
+%extend RWStepShape_RWFaceSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFacetedBrep;
 class RWStepShape_RWFacetedBrep {
 	public:
@@ -1614,6 +1794,11 @@ class RWStepShape_RWFacetedBrep {
 };
 
 
+%extend RWStepShape_RWFacetedBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFacetedBrepAndBrepWithVoids;
 class RWStepShape_RWFacetedBrepAndBrepWithVoids {
 	public:
@@ -1652,6 +1837,11 @@ class RWStepShape_RWFacetedBrepAndBrepWithVoids {
 };
 
 
+%extend RWStepShape_RWFacetedBrepAndBrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWFacetedBrepShapeRepresentation;
 class RWStepShape_RWFacetedBrepShapeRepresentation {
 	public:
@@ -1690,6 +1880,11 @@ class RWStepShape_RWFacetedBrepShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWFacetedBrepShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWGeometricCurveSet;
 class RWStepShape_RWGeometricCurveSet {
 	public:
@@ -1728,6 +1923,11 @@ class RWStepShape_RWGeometricCurveSet {
 };
 
 
+%extend RWStepShape_RWGeometricCurveSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWGeometricSet;
 class RWStepShape_RWGeometricSet {
 	public:
@@ -1766,6 +1966,11 @@ class RWStepShape_RWGeometricSet {
 };
 
 
+%extend RWStepShape_RWGeometricSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWGeometricallyBoundedSurfaceShapeRepresentation;
 class RWStepShape_RWGeometricallyBoundedSurfaceShapeRepresentation {
 	public:
@@ -1804,6 +2009,11 @@ class RWStepShape_RWGeometricallyBoundedSurfaceShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWGeometricallyBoundedSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWGeometricallyBoundedWireframeShapeRepresentation;
 class RWStepShape_RWGeometricallyBoundedWireframeShapeRepresentation {
 	public:
@@ -1842,6 +2052,11 @@ class RWStepShape_RWGeometricallyBoundedWireframeShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWGeometricallyBoundedWireframeShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWHalfSpaceSolid;
 class RWStepShape_RWHalfSpaceSolid {
 	public:
@@ -1880,6 +2095,11 @@ class RWStepShape_RWHalfSpaceSolid {
 };
 
 
+%extend RWStepShape_RWHalfSpaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWLimitsAndFits;
 class RWStepShape_RWLimitsAndFits {
 	public:
@@ -1910,6 +2130,11 @@ class RWStepShape_RWLimitsAndFits {
 };
 
 
+%extend RWStepShape_RWLimitsAndFits {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWLoop;
 class RWStepShape_RWLoop {
 	public:
@@ -1940,6 +2165,11 @@ class RWStepShape_RWLoop {
 };
 
 
+%extend RWStepShape_RWLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWLoopAndPath;
 class RWStepShape_RWLoopAndPath {
 	public:
@@ -1978,6 +2208,11 @@ class RWStepShape_RWLoopAndPath {
 };
 
 
+%extend RWStepShape_RWLoopAndPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWManifoldSolidBrep;
 class RWStepShape_RWManifoldSolidBrep {
 	public:
@@ -2016,6 +2251,11 @@ class RWStepShape_RWManifoldSolidBrep {
 };
 
 
+%extend RWStepShape_RWManifoldSolidBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWManifoldSurfaceShapeRepresentation;
 class RWStepShape_RWManifoldSurfaceShapeRepresentation {
 	public:
@@ -2054,6 +2294,11 @@ class RWStepShape_RWManifoldSurfaceShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWManifoldSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWMeasureQualification;
 class RWStepShape_RWMeasureQualification {
 	public:
@@ -2092,6 +2337,11 @@ class RWStepShape_RWMeasureQualification {
 };
 
 
+%extend RWStepShape_RWMeasureQualification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWMeasureRepresentationItemAndQualifiedRepresentationItem;
 class RWStepShape_RWMeasureRepresentationItemAndQualifiedRepresentationItem {
 	public:
@@ -2130,6 +2380,11 @@ class RWStepShape_RWMeasureRepresentationItemAndQualifiedRepresentationItem {
 };
 
 
+%extend RWStepShape_RWMeasureRepresentationItemAndQualifiedRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWNonManifoldSurfaceShapeRepresentation;
 class RWStepShape_RWNonManifoldSurfaceShapeRepresentation {
 	public:
@@ -2176,6 +2431,11 @@ class RWStepShape_RWNonManifoldSurfaceShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWNonManifoldSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOpenShell;
 class RWStepShape_RWOpenShell {
 	public:
@@ -2214,6 +2474,11 @@ class RWStepShape_RWOpenShell {
 };
 
 
+%extend RWStepShape_RWOpenShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOrientedClosedShell;
 class RWStepShape_RWOrientedClosedShell {
 	public:
@@ -2252,6 +2517,11 @@ class RWStepShape_RWOrientedClosedShell {
 };
 
 
+%extend RWStepShape_RWOrientedClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOrientedEdge;
 class RWStepShape_RWOrientedEdge {
 	public:
@@ -2290,6 +2560,11 @@ class RWStepShape_RWOrientedEdge {
 };
 
 
+%extend RWStepShape_RWOrientedEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOrientedFace;
 class RWStepShape_RWOrientedFace {
 	public:
@@ -2328,6 +2603,11 @@ class RWStepShape_RWOrientedFace {
 };
 
 
+%extend RWStepShape_RWOrientedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOrientedOpenShell;
 class RWStepShape_RWOrientedOpenShell {
 	public:
@@ -2366,6 +2646,11 @@ class RWStepShape_RWOrientedOpenShell {
 };
 
 
+%extend RWStepShape_RWOrientedOpenShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWOrientedPath;
 class RWStepShape_RWOrientedPath {
 	public:
@@ -2404,6 +2689,11 @@ class RWStepShape_RWOrientedPath {
 };
 
 
+%extend RWStepShape_RWOrientedPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWPath;
 class RWStepShape_RWPath {
 	public:
@@ -2442,6 +2732,11 @@ class RWStepShape_RWPath {
 };
 
 
+%extend RWStepShape_RWPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWPlusMinusTolerance;
 class RWStepShape_RWPlusMinusTolerance {
 	public:
@@ -2480,6 +2775,11 @@ class RWStepShape_RWPlusMinusTolerance {
 };
 
 
+%extend RWStepShape_RWPlusMinusTolerance {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWPointRepresentation;
 class RWStepShape_RWPointRepresentation {
 	public:
@@ -2526,6 +2826,11 @@ class RWStepShape_RWPointRepresentation {
 };
 
 
+%extend RWStepShape_RWPointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWPolyLoop;
 class RWStepShape_RWPolyLoop {
 	public:
@@ -2564,6 +2869,11 @@ class RWStepShape_RWPolyLoop {
 };
 
 
+%extend RWStepShape_RWPolyLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWPrecisionQualifier;
 class RWStepShape_RWPrecisionQualifier {
 	public:
@@ -2594,6 +2904,11 @@ class RWStepShape_RWPrecisionQualifier {
 };
 
 
+%extend RWStepShape_RWPrecisionQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWQualifiedRepresentationItem;
 class RWStepShape_RWQualifiedRepresentationItem {
 	public:
@@ -2632,6 +2947,11 @@ class RWStepShape_RWQualifiedRepresentationItem {
 };
 
 
+%extend RWStepShape_RWQualifiedRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWRevolvedAreaSolid;
 class RWStepShape_RWRevolvedAreaSolid {
 	public:
@@ -2670,6 +2990,11 @@ class RWStepShape_RWRevolvedAreaSolid {
 };
 
 
+%extend RWStepShape_RWRevolvedAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWRevolvedFaceSolid;
 class RWStepShape_RWRevolvedFaceSolid {
 	public:
@@ -2708,6 +3033,11 @@ class RWStepShape_RWRevolvedFaceSolid {
 };
 
 
+%extend RWStepShape_RWRevolvedFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWRightAngularWedge;
 class RWStepShape_RWRightAngularWedge {
 	public:
@@ -2746,6 +3076,11 @@ class RWStepShape_RWRightAngularWedge {
 };
 
 
+%extend RWStepShape_RWRightAngularWedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWRightCircularCone;
 class RWStepShape_RWRightCircularCone {
 	public:
@@ -2784,6 +3119,11 @@ class RWStepShape_RWRightCircularCone {
 };
 
 
+%extend RWStepShape_RWRightCircularCone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWRightCircularCylinder;
 class RWStepShape_RWRightCircularCylinder {
 	public:
@@ -2822,6 +3162,11 @@ class RWStepShape_RWRightCircularCylinder {
 };
 
 
+%extend RWStepShape_RWRightCircularCylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSeamEdge;
 class RWStepShape_RWSeamEdge {
 	public:
@@ -2868,6 +3213,11 @@ class RWStepShape_RWSeamEdge {
 };
 
 
+%extend RWStepShape_RWSeamEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWShapeDefinitionRepresentation;
 class RWStepShape_RWShapeDefinitionRepresentation {
 	public:
@@ -2914,6 +3264,11 @@ class RWStepShape_RWShapeDefinitionRepresentation {
 };
 
 
+%extend RWStepShape_RWShapeDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWShapeDimensionRepresentation;
 class RWStepShape_RWShapeDimensionRepresentation {
 	public:
@@ -2960,6 +3315,11 @@ class RWStepShape_RWShapeDimensionRepresentation {
 };
 
 
+%extend RWStepShape_RWShapeDimensionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWShapeRepresentation;
 class RWStepShape_RWShapeRepresentation {
 	public:
@@ -2998,6 +3358,11 @@ class RWStepShape_RWShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWShapeRepresentationWithParameters;
 class RWStepShape_RWShapeRepresentationWithParameters {
 	public:
@@ -3044,6 +3409,11 @@ class RWStepShape_RWShapeRepresentationWithParameters {
 };
 
 
+%extend RWStepShape_RWShapeRepresentationWithParameters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWShellBasedSurfaceModel;
 class RWStepShape_RWShellBasedSurfaceModel {
 	public:
@@ -3082,6 +3452,11 @@ class RWStepShape_RWShellBasedSurfaceModel {
 };
 
 
+%extend RWStepShape_RWShellBasedSurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSolidModel;
 class RWStepShape_RWSolidModel {
 	public:
@@ -3112,6 +3487,11 @@ class RWStepShape_RWSolidModel {
 };
 
 
+%extend RWStepShape_RWSolidModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSolidReplica;
 class RWStepShape_RWSolidReplica {
 	public:
@@ -3150,6 +3530,11 @@ class RWStepShape_RWSolidReplica {
 };
 
 
+%extend RWStepShape_RWSolidReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSphere;
 class RWStepShape_RWSphere {
 	public:
@@ -3188,6 +3573,11 @@ class RWStepShape_RWSphere {
 };
 
 
+%extend RWStepShape_RWSphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSubedge;
 class RWStepShape_RWSubedge {
 	public:
@@ -3234,6 +3624,11 @@ class RWStepShape_RWSubedge {
 };
 
 
+%extend RWStepShape_RWSubedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSubface;
 class RWStepShape_RWSubface {
 	public:
@@ -3280,6 +3675,11 @@ class RWStepShape_RWSubface {
 };
 
 
+%extend RWStepShape_RWSubface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSweptAreaSolid;
 class RWStepShape_RWSweptAreaSolid {
 	public:
@@ -3318,6 +3718,11 @@ class RWStepShape_RWSweptAreaSolid {
 };
 
 
+%extend RWStepShape_RWSweptAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWSweptFaceSolid;
 class RWStepShape_RWSweptFaceSolid {
 	public:
@@ -3356,6 +3761,11 @@ class RWStepShape_RWSweptFaceSolid {
 };
 
 
+%extend RWStepShape_RWSweptFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWToleranceValue;
 class RWStepShape_RWToleranceValue {
 	public:
@@ -3394,6 +3804,11 @@ class RWStepShape_RWToleranceValue {
 };
 
 
+%extend RWStepShape_RWToleranceValue {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWTopologicalRepresentationItem;
 class RWStepShape_RWTopologicalRepresentationItem {
 	public:
@@ -3424,6 +3839,11 @@ class RWStepShape_RWTopologicalRepresentationItem {
 };
 
 
+%extend RWStepShape_RWTopologicalRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWTorus;
 class RWStepShape_RWTorus {
 	public:
@@ -3462,6 +3882,11 @@ class RWStepShape_RWTorus {
 };
 
 
+%extend RWStepShape_RWTorus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWTransitionalShapeRepresentation;
 class RWStepShape_RWTransitionalShapeRepresentation {
 	public:
@@ -3500,6 +3925,11 @@ class RWStepShape_RWTransitionalShapeRepresentation {
 };
 
 
+%extend RWStepShape_RWTransitionalShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWTypeQualifier;
 class RWStepShape_RWTypeQualifier {
 	public:
@@ -3530,6 +3960,11 @@ class RWStepShape_RWTypeQualifier {
 };
 
 
+%extend RWStepShape_RWTypeQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWVertex;
 class RWStepShape_RWVertex {
 	public:
@@ -3560,6 +3995,11 @@ class RWStepShape_RWVertex {
 };
 
 
+%extend RWStepShape_RWVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWVertexLoop;
 class RWStepShape_RWVertexLoop {
 	public:
@@ -3598,6 +4038,11 @@ class RWStepShape_RWVertexLoop {
 };
 
 
+%extend RWStepShape_RWVertexLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor RWStepShape_RWVertexPoint;
 class RWStepShape_RWVertexPoint {
 	public:
@@ -3636,3 +4081,8 @@ class RWStepShape_RWVertexPoint {
 };
 
 
+%extend RWStepShape_RWVertexPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/RWStl.i
+++ b/src/SWIG_files/wrapper/RWStl.i
@@ -116,3 +116,8 @@ class RWStl {
 };
 
 
+%extend RWStl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Resource.i
+++ b/src/SWIG_files/wrapper/Resource.i
@@ -93,6 +93,11 @@ class Resource_DataMapIteratorOfDataMapOfAsciiStringAsciiString : public TCollec
 };
 
 
+%extend Resource_DataMapIteratorOfDataMapOfAsciiStringAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_DataMapIteratorOfDataMapOfAsciiStringExtendedString;
 class Resource_DataMapIteratorOfDataMapOfAsciiStringExtendedString : public TCollection_BasicMapIterator {
 	public:
@@ -123,6 +128,11 @@ class Resource_DataMapIteratorOfDataMapOfAsciiStringExtendedString : public TCol
 };
 
 
+%extend Resource_DataMapIteratorOfDataMapOfAsciiStringExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_DataMapNodeOfDataMapOfAsciiStringAsciiString;
 class Resource_DataMapNodeOfDataMapOfAsciiStringAsciiString : public TCollection_MapNode {
 	public:
@@ -193,6 +203,11 @@ class Handle_Resource_DataMapNodeOfDataMapOfAsciiStringAsciiString : public Hand
     }
 };
 
+%extend Resource_DataMapNodeOfDataMapOfAsciiStringAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_DataMapNodeOfDataMapOfAsciiStringExtendedString;
 class Resource_DataMapNodeOfDataMapOfAsciiStringExtendedString : public TCollection_MapNode {
 	public:
@@ -263,6 +278,11 @@ class Handle_Resource_DataMapNodeOfDataMapOfAsciiStringExtendedString : public H
     }
 };
 
+%extend Resource_DataMapNodeOfDataMapOfAsciiStringExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_DataMapOfAsciiStringAsciiString;
 class Resource_DataMapOfAsciiStringAsciiString : public TCollection_BasicMap {
 	public:
@@ -341,6 +361,11 @@ class Resource_DataMapOfAsciiStringAsciiString : public TCollection_BasicMap {
 };
 
 
+%extend Resource_DataMapOfAsciiStringAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_DataMapOfAsciiStringExtendedString;
 class Resource_DataMapOfAsciiStringExtendedString : public TCollection_BasicMap {
 	public:
@@ -419,6 +444,11 @@ class Resource_DataMapOfAsciiStringExtendedString : public TCollection_BasicMap 
 };
 
 
+%extend Resource_DataMapOfAsciiStringExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_LexicalCompare;
 class Resource_LexicalCompare {
 	public:
@@ -439,6 +469,11 @@ class Resource_LexicalCompare {
 };
 
 
+%extend Resource_LexicalCompare {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Resource_Manager;
 class Resource_Manager : public MMgt_TShared {
 	public:
@@ -599,6 +634,11 @@ class Handle_Resource_Manager : public Handle_MMgt_TShared {
     }
 };
 
+%extend Resource_Manager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Resource_QuickSortOfArray1 {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -612,6 +652,11 @@ class Resource_QuickSortOfArray1 {
 };
 
 
+%extend Resource_QuickSortOfArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Resource_Unicode {
 	public:
 		%feature("compactdefaultargs") ConvertSJISToUnicode;
@@ -747,3 +792,8 @@ class Resource_Unicode {
 };
 
 
+%extend Resource_Unicode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/STEPCAFControl.i
+++ b/src/SWIG_files/wrapper/STEPCAFControl.i
@@ -142,6 +142,11 @@ class Handle_STEPCAFControl_ActorWrite : public Handle_STEPControl_ActorWrite {
     }
 };
 
+%extend STEPCAFControl_ActorWrite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_Controller;
 class STEPCAFControl_Controller : public STEPControl_Controller {
 	public:
@@ -206,6 +211,11 @@ class Handle_STEPCAFControl_Controller : public Handle_STEPControl_Controller {
     }
 };
 
+%extend STEPCAFControl_Controller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfLabelExternFile;
 class STEPCAFControl_DataMapIteratorOfDataMapOfLabelExternFile : public TCollection_BasicMapIterator {
 	public:
@@ -236,6 +246,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfLabelExternFile : public TCollect
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfLabelExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfLabelShape;
 class STEPCAFControl_DataMapIteratorOfDataMapOfLabelShape : public TCollection_BasicMapIterator {
 	public:
@@ -266,6 +281,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfLabelShape : public TCollection_B
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfLabelShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfPDExternFile;
 class STEPCAFControl_DataMapIteratorOfDataMapOfPDExternFile : public TCollection_BasicMapIterator {
 	public:
@@ -296,6 +316,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfPDExternFile : public TCollection
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfPDExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfSDRExternFile;
 class STEPCAFControl_DataMapIteratorOfDataMapOfSDRExternFile : public TCollection_BasicMapIterator {
 	public:
@@ -326,6 +351,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfSDRExternFile : public TCollectio
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfSDRExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfShapePD;
 class STEPCAFControl_DataMapIteratorOfDataMapOfShapePD : public TCollection_BasicMapIterator {
 	public:
@@ -356,6 +386,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfShapePD : public TCollection_Basi
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfShapePD {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapIteratorOfDataMapOfShapeSDR;
 class STEPCAFControl_DataMapIteratorOfDataMapOfShapeSDR : public TCollection_BasicMapIterator {
 	public:
@@ -386,6 +421,11 @@ class STEPCAFControl_DataMapIteratorOfDataMapOfShapeSDR : public TCollection_Bas
 };
 
 
+%extend STEPCAFControl_DataMapIteratorOfDataMapOfShapeSDR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfLabelExternFile;
 class STEPCAFControl_DataMapNodeOfDataMapOfLabelExternFile : public TCollection_MapNode {
 	public:
@@ -456,6 +496,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfLabelExternFile : public Handl
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfLabelExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfLabelShape;
 class STEPCAFControl_DataMapNodeOfDataMapOfLabelShape : public TCollection_MapNode {
 	public:
@@ -526,6 +571,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfLabelShape : public Handle_TCo
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfLabelShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfPDExternFile;
 class STEPCAFControl_DataMapNodeOfDataMapOfPDExternFile : public TCollection_MapNode {
 	public:
@@ -596,6 +646,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfPDExternFile : public Handle_T
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfPDExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfSDRExternFile;
 class STEPCAFControl_DataMapNodeOfDataMapOfSDRExternFile : public TCollection_MapNode {
 	public:
@@ -666,6 +721,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfSDRExternFile : public Handle_
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfSDRExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfShapePD;
 class STEPCAFControl_DataMapNodeOfDataMapOfShapePD : public TCollection_MapNode {
 	public:
@@ -736,6 +796,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfShapePD : public Handle_TColle
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfShapePD {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapNodeOfDataMapOfShapeSDR;
 class STEPCAFControl_DataMapNodeOfDataMapOfShapeSDR : public TCollection_MapNode {
 	public:
@@ -806,6 +871,11 @@ class Handle_STEPCAFControl_DataMapNodeOfDataMapOfShapeSDR : public Handle_TColl
     }
 };
 
+%extend STEPCAFControl_DataMapNodeOfDataMapOfShapeSDR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfLabelExternFile;
 class STEPCAFControl_DataMapOfLabelExternFile : public TCollection_BasicMap {
 	public:
@@ -884,6 +954,11 @@ class STEPCAFControl_DataMapOfLabelExternFile : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfLabelExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfLabelShape;
 class STEPCAFControl_DataMapOfLabelShape : public TCollection_BasicMap {
 	public:
@@ -962,6 +1037,11 @@ class STEPCAFControl_DataMapOfLabelShape : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfLabelShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfPDExternFile;
 class STEPCAFControl_DataMapOfPDExternFile : public TCollection_BasicMap {
 	public:
@@ -1040,6 +1120,11 @@ class STEPCAFControl_DataMapOfPDExternFile : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfPDExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfSDRExternFile;
 class STEPCAFControl_DataMapOfSDRExternFile : public TCollection_BasicMap {
 	public:
@@ -1118,6 +1203,11 @@ class STEPCAFControl_DataMapOfSDRExternFile : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfSDRExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfShapePD;
 class STEPCAFControl_DataMapOfShapePD : public TCollection_BasicMap {
 	public:
@@ -1196,6 +1286,11 @@ class STEPCAFControl_DataMapOfShapePD : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfShapePD {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DataMapOfShapeSDR;
 class STEPCAFControl_DataMapOfShapeSDR : public TCollection_BasicMap {
 	public:
@@ -1274,6 +1369,11 @@ class STEPCAFControl_DataMapOfShapeSDR : public TCollection_BasicMap {
 };
 
 
+%extend STEPCAFControl_DataMapOfShapeSDR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_DictionaryOfExternFile;
 class STEPCAFControl_DictionaryOfExternFile : public MMgt_TShared {
 	public:
@@ -1464,6 +1564,11 @@ class Handle_STEPCAFControl_DictionaryOfExternFile : public Handle_MMgt_TShared 
     }
 };
 
+%extend STEPCAFControl_DictionaryOfExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_ExternFile;
 class STEPCAFControl_ExternFile : public MMgt_TShared {
 	public:
@@ -1582,6 +1687,11 @@ class Handle_STEPCAFControl_ExternFile : public Handle_MMgt_TShared {
     }
 };
 
+%extend STEPCAFControl_ExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_IteratorOfDictionaryOfExternFile;
 class STEPCAFControl_IteratorOfDictionaryOfExternFile {
 	public:
@@ -1630,6 +1740,11 @@ class STEPCAFControl_IteratorOfDictionaryOfExternFile {
 };
 
 
+%extend STEPCAFControl_IteratorOfDictionaryOfExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_Reader;
 class STEPCAFControl_Reader {
 	public:
@@ -1840,6 +1955,11 @@ class STEPCAFControl_Reader {
 };
 
 
+%extend STEPCAFControl_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_StackItemOfDictionaryOfExternFile;
 class STEPCAFControl_StackItemOfDictionaryOfExternFile : public MMgt_TShared {
 	public:
@@ -1916,6 +2036,11 @@ class Handle_STEPCAFControl_StackItemOfDictionaryOfExternFile : public Handle_MM
     }
 };
 
+%extend STEPCAFControl_StackItemOfDictionaryOfExternFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPCAFControl_Writer;
 class STEPCAFControl_Writer {
 	public:
@@ -2118,3 +2243,8 @@ class STEPCAFControl_Writer {
 };
 
 
+%extend STEPCAFControl_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/STEPConstruct.i
+++ b/src/SWIG_files/wrapper/STEPConstruct.i
@@ -106,6 +106,11 @@ class STEPConstruct {
 };
 
 
+%extend STEPConstruct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_AP203Context;
 class STEPConstruct_AP203Context {
 	public:
@@ -306,6 +311,11 @@ class STEPConstruct_AP203Context {
 };
 
 
+%extend STEPConstruct_AP203Context {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_Assembly;
 class STEPConstruct_Assembly {
 	public:
@@ -364,6 +374,11 @@ class STEPConstruct_Assembly {
 };
 
 
+%extend STEPConstruct_Assembly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_ContextTool;
 class STEPConstruct_ContextTool {
 	public:
@@ -528,6 +543,11 @@ class STEPConstruct_ContextTool {
 };
 
 
+%extend STEPConstruct_ContextTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapIteratorOfDataMapOfAsciiStringTransient;
 class STEPConstruct_DataMapIteratorOfDataMapOfAsciiStringTransient : public TCollection_BasicMapIterator {
 	public:
@@ -558,6 +578,11 @@ class STEPConstruct_DataMapIteratorOfDataMapOfAsciiStringTransient : public TCol
 };
 
 
+%extend STEPConstruct_DataMapIteratorOfDataMapOfAsciiStringTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapIteratorOfDataMapOfPointTransient;
 class STEPConstruct_DataMapIteratorOfDataMapOfPointTransient : public TCollection_BasicMapIterator {
 	public:
@@ -588,6 +613,11 @@ class STEPConstruct_DataMapIteratorOfDataMapOfPointTransient : public TCollectio
 };
 
 
+%extend STEPConstruct_DataMapIteratorOfDataMapOfPointTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapNodeOfDataMapOfAsciiStringTransient;
 class STEPConstruct_DataMapNodeOfDataMapOfAsciiStringTransient : public TCollection_MapNode {
 	public:
@@ -658,6 +688,11 @@ class Handle_STEPConstruct_DataMapNodeOfDataMapOfAsciiStringTransient : public H
     }
 };
 
+%extend STEPConstruct_DataMapNodeOfDataMapOfAsciiStringTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapNodeOfDataMapOfPointTransient;
 class STEPConstruct_DataMapNodeOfDataMapOfPointTransient : public TCollection_MapNode {
 	public:
@@ -728,6 +763,11 @@ class Handle_STEPConstruct_DataMapNodeOfDataMapOfPointTransient : public Handle_
     }
 };
 
+%extend STEPConstruct_DataMapNodeOfDataMapOfPointTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapOfAsciiStringTransient;
 class STEPConstruct_DataMapOfAsciiStringTransient : public TCollection_BasicMap {
 	public:
@@ -806,6 +846,11 @@ class STEPConstruct_DataMapOfAsciiStringTransient : public TCollection_BasicMap 
 };
 
 
+%extend STEPConstruct_DataMapOfAsciiStringTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_DataMapOfPointTransient;
 class STEPConstruct_DataMapOfPointTransient : public TCollection_BasicMap {
 	public:
@@ -884,6 +929,11 @@ class STEPConstruct_DataMapOfPointTransient : public TCollection_BasicMap {
 };
 
 
+%extend STEPConstruct_DataMapOfPointTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_Part;
 class STEPConstruct_Part {
 	public:
@@ -1108,6 +1158,11 @@ class STEPConstruct_Part {
 };
 
 
+%extend STEPConstruct_Part {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class STEPConstruct_PointHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -1133,6 +1188,11 @@ class STEPConstruct_PointHasher {
 };
 
 
+%extend STEPConstruct_PointHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_Tool;
 class STEPConstruct_Tool {
 	public:
@@ -1185,6 +1245,11 @@ class STEPConstruct_Tool {
 };
 
 
+%extend STEPConstruct_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_UnitContext;
 class STEPConstruct_UnitContext {
 	public:
@@ -1327,6 +1392,11 @@ class STEPConstruct_UnitContext {
 };
 
 
+%extend STEPConstruct_UnitContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_ExternRefs;
 class STEPConstruct_ExternRefs : public STEPConstruct_Tool {
 	public:
@@ -1437,6 +1507,11 @@ class STEPConstruct_ExternRefs : public STEPConstruct_Tool {
 };
 
 
+%extend STEPConstruct_ExternRefs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_Styles;
 class STEPConstruct_Styles : public STEPConstruct_Tool {
 	public:
@@ -1631,6 +1706,11 @@ class STEPConstruct_Styles : public STEPConstruct_Tool {
 };
 
 
+%extend STEPConstruct_Styles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPConstruct_ValidationProps;
 class STEPConstruct_ValidationProps : public STEPConstruct_Tool {
 	public:
@@ -1805,3 +1885,8 @@ class STEPConstruct_ValidationProps : public STEPConstruct_Tool {
 };
 
 
+%extend STEPConstruct_ValidationProps {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/STEPControl.i
+++ b/src/SWIG_files/wrapper/STEPControl.i
@@ -193,6 +193,11 @@ class Handle_STEPControl_ActorRead : public Handle_Transfer_ActorOfTransientProc
     }
 };
 
+%extend STEPControl_ActorRead {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPControl_ActorWrite;
 class STEPControl_ActorWrite : public Transfer_ActorOfFinderProcess {
 	public:
@@ -337,6 +342,11 @@ class Handle_STEPControl_ActorWrite : public Handle_Transfer_ActorOfFinderProces
     }
 };
 
+%extend STEPControl_ActorWrite {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPControl_Controller;
 class STEPControl_Controller : public XSControl_Controller {
 	public:
@@ -435,6 +445,11 @@ class Handle_STEPControl_Controller : public Handle_XSControl_Controller {
     }
 };
 
+%extend STEPControl_Controller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPControl_Reader;
 class STEPControl_Reader : public XSControl_Reader {
 	public:
@@ -489,6 +504,11 @@ class STEPControl_Reader : public XSControl_Reader {
 };
 
 
+%extend STEPControl_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPControl_Writer;
 class STEPControl_Writer {
 	public:
@@ -579,3 +599,8 @@ class STEPControl_Writer {
 };
 
 
+%extend STEPControl_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/STEPEdit.i
+++ b/src/SWIG_files/wrapper/STEPEdit.i
@@ -98,6 +98,11 @@ class STEPEdit {
 };
 
 
+%extend STEPEdit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPEdit_EditContext;
 class STEPEdit_EditContext : public IFSelect_Editor {
 	public:
@@ -192,6 +197,11 @@ class Handle_STEPEdit_EditContext : public Handle_IFSelect_Editor {
     }
 };
 
+%extend STEPEdit_EditContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPEdit_EditSDR;
 class STEPEdit_EditSDR : public IFSelect_Editor {
 	public:
@@ -286,3 +296,8 @@ class Handle_STEPEdit_EditSDR : public Handle_IFSelect_Editor {
     }
 };
 
+%extend STEPEdit_EditSDR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/STEPSelections.i
+++ b/src/SWIG_files/wrapper/STEPSelections.i
@@ -140,6 +140,11 @@ class Handle_STEPSelections_AssemblyComponent : public Handle_MMgt_TShared {
     }
 };
 
+%extend STEPSelections_AssemblyComponent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_AssemblyExplorer;
 class STEPSelections_AssemblyExplorer {
 	public:
@@ -198,6 +203,11 @@ class STEPSelections_AssemblyExplorer {
 };
 
 
+%extend STEPSelections_AssemblyExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_AssemblyLink;
 class STEPSelections_AssemblyLink : public MMgt_TShared {
 	public:
@@ -294,6 +304,11 @@ class Handle_STEPSelections_AssemblyLink : public Handle_MMgt_TShared {
     }
 };
 
+%extend STEPSelections_AssemblyLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_Counter;
 class STEPSelections_Counter {
 	public:
@@ -356,6 +371,11 @@ class STEPSelections_Counter {
 };
 
 
+%extend STEPSelections_Counter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_HSequenceOfAssemblyLink;
 class STEPSelections_HSequenceOfAssemblyLink : public MMgt_TShared {
 	public:
@@ -540,6 +560,11 @@ class Handle_STEPSelections_HSequenceOfAssemblyLink : public Handle_MMgt_TShared
     }
 };
 
+%extend STEPSelections_HSequenceOfAssemblyLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectAssembly;
 class STEPSelections_SelectAssembly : public IFSelect_SelectExplore {
 	public:
@@ -616,6 +641,11 @@ class Handle_STEPSelections_SelectAssembly : public Handle_IFSelect_SelectExplor
     }
 };
 
+%extend STEPSelections_SelectAssembly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectDerived;
 class STEPSelections_SelectDerived : public StepSelect_StepType {
 	public:
@@ -684,6 +714,11 @@ class Handle_STEPSelections_SelectDerived : public Handle_StepSelect_StepType {
     }
 };
 
+%extend STEPSelections_SelectDerived {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectFaces;
 class STEPSelections_SelectFaces : public IFSelect_SelectExplore {
 	public:
@@ -760,6 +795,11 @@ class Handle_STEPSelections_SelectFaces : public Handle_IFSelect_SelectExplore {
     }
 };
 
+%extend STEPSelections_SelectFaces {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectForTransfer;
 class STEPSelections_SelectForTransfer : public XSControl_SelectForTransfer {
 	public:
@@ -828,6 +868,11 @@ class Handle_STEPSelections_SelectForTransfer : public Handle_XSControl_SelectFo
     }
 };
 
+%extend STEPSelections_SelectForTransfer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectGSCurves;
 class STEPSelections_SelectGSCurves : public IFSelect_SelectExplore {
 	public:
@@ -902,6 +947,11 @@ class Handle_STEPSelections_SelectGSCurves : public Handle_IFSelect_SelectExplor
     }
 };
 
+%extend STEPSelections_SelectGSCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SelectInstances;
 class STEPSelections_SelectInstances : public IFSelect_SelectExplore {
 	public:
@@ -982,6 +1032,11 @@ class Handle_STEPSelections_SelectInstances : public Handle_IFSelect_SelectExplo
     }
 };
 
+%extend STEPSelections_SelectInstances {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SequenceNodeOfSequenceOfAssemblyComponent;
 class STEPSelections_SequenceNodeOfSequenceOfAssemblyComponent : public TCollection_SeqNode {
 	public:
@@ -1048,6 +1103,11 @@ class Handle_STEPSelections_SequenceNodeOfSequenceOfAssemblyComponent : public H
     }
 };
 
+%extend STEPSelections_SequenceNodeOfSequenceOfAssemblyComponent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SequenceNodeOfSequenceOfAssemblyLink;
 class STEPSelections_SequenceNodeOfSequenceOfAssemblyLink : public TCollection_SeqNode {
 	public:
@@ -1114,6 +1174,11 @@ class Handle_STEPSelections_SequenceNodeOfSequenceOfAssemblyLink : public Handle
     }
 };
 
+%extend STEPSelections_SequenceNodeOfSequenceOfAssemblyLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SequenceOfAssemblyComponent;
 class STEPSelections_SequenceOfAssemblyComponent : public TCollection_BaseSequence {
 	public:
@@ -1252,6 +1317,11 @@ class STEPSelections_SequenceOfAssemblyComponent : public TCollection_BaseSequen
 };
 
 
+%extend STEPSelections_SequenceOfAssemblyComponent {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor STEPSelections_SequenceOfAssemblyLink;
 class STEPSelections_SequenceOfAssemblyLink : public TCollection_BaseSequence {
 	public:
@@ -1390,3 +1460,8 @@ class STEPSelections_SequenceOfAssemblyLink : public TCollection_BaseSequence {
 };
 
 
+%extend STEPSelections_SequenceOfAssemblyLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Select3D.i
+++ b/src/SWIG_files/wrapper/Select3D.i
@@ -105,6 +105,11 @@ class Select3D_Box2d {
 };
 
 
+%extend Select3D_Box2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListIteratorOfListOfSensitive;
 class Select3D_ListIteratorOfListOfSensitive {
 	public:
@@ -139,6 +144,11 @@ class Select3D_ListIteratorOfListOfSensitive {
 };
 
 
+%extend Select3D_ListIteratorOfListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListIteratorOfListOfSensitiveTriangle;
 class Select3D_ListIteratorOfListOfSensitiveTriangle {
 	public:
@@ -173,6 +183,11 @@ class Select3D_ListIteratorOfListOfSensitiveTriangle {
 };
 
 
+%extend Select3D_ListIteratorOfListOfSensitiveTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListNodeOfListOfSensitive;
 class Select3D_ListNodeOfListOfSensitive : public TCollection_MapNode {
 	public:
@@ -237,6 +252,11 @@ class Handle_Select3D_ListNodeOfListOfSensitive : public Handle_TCollection_MapN
     }
 };
 
+%extend Select3D_ListNodeOfListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListNodeOfListOfSensitiveTriangle;
 class Select3D_ListNodeOfListOfSensitiveTriangle : public TCollection_MapNode {
 	public:
@@ -301,6 +321,11 @@ class Handle_Select3D_ListNodeOfListOfSensitiveTriangle : public Handle_TCollect
     }
 };
 
+%extend Select3D_ListNodeOfListOfSensitiveTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListOfSensitive;
 class Select3D_ListOfSensitive {
 	public:
@@ -431,6 +456,11 @@ class Select3D_ListOfSensitive {
 };
 
 
+%extend Select3D_ListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_ListOfSensitiveTriangle;
 class Select3D_ListOfSensitiveTriangle {
 	public:
@@ -561,6 +591,11 @@ class Select3D_ListOfSensitiveTriangle {
 };
 
 
+%extend Select3D_ListOfSensitiveTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_Pnt;
 class Select3D_Pnt {
 	public:
@@ -584,6 +619,11 @@ class Select3D_Pnt {
 };
 
 
+%extend Select3D_Pnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_Pnt2d;
 class Select3D_Pnt2d {
 	public:
@@ -606,6 +646,11 @@ class Select3D_Pnt2d {
 };
 
 
+%extend Select3D_Pnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_PointData;
 class Select3D_PointData {
 	public:
@@ -666,6 +711,11 @@ class Select3D_PointData {
 };
 
 
+%extend Select3D_PointData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_Projector;
 class Select3D_Projector : public Standard_Transient {
 	public:
@@ -938,6 +988,11 @@ class Handle_Select3D_Projector : public Handle_Standard_Transient {
     }
 };
 
+%extend Select3D_Projector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveEntity;
 class Select3D_SensitiveEntity : public SelectBasics_SensitiveEntity {
 	public:
@@ -1098,6 +1153,11 @@ class Handle_Select3D_SensitiveEntity : public Handle_SelectBasics_SensitiveEnti
     }
 };
 
+%extend Select3D_SensitiveEntity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveEntitySequence;
 class Select3D_SensitiveEntitySequence : public TCollection_BaseSequence {
 	public:
@@ -1236,6 +1296,11 @@ class Select3D_SensitiveEntitySequence : public TCollection_BaseSequence {
 };
 
 
+%extend Select3D_SensitiveEntitySequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SequenceNodeOfSensitiveEntitySequence;
 class Select3D_SequenceNodeOfSensitiveEntitySequence : public TCollection_SeqNode {
 	public:
@@ -1302,6 +1367,11 @@ class Handle_Select3D_SequenceNodeOfSensitiveEntitySequence : public Handle_TCol
     }
 };
 
+%extend Select3D_SequenceNodeOfSensitiveEntitySequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveBox;
 class Select3D_SensitiveBox : public Select3D_SensitiveEntity {
 	public:
@@ -1462,6 +1532,11 @@ class Handle_Select3D_SensitiveBox : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend Select3D_SensitiveBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveGroup;
 class Select3D_SensitiveGroup : public Select3D_SensitiveEntity {
 	public:
@@ -1676,6 +1751,11 @@ class Handle_Select3D_SensitiveGroup : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend Select3D_SensitiveGroup {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitivePoint;
 class Select3D_SensitivePoint : public Select3D_SensitiveEntity {
 	public:
@@ -1816,6 +1896,11 @@ class Handle_Select3D_SensitivePoint : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend Select3D_SensitivePoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitivePoly;
 class Select3D_SensitivePoly : public Select3D_SensitiveEntity {
 	public:
@@ -1900,6 +1985,11 @@ class Handle_Select3D_SensitivePoly : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend Select3D_SensitivePoly {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveSegment;
 class Select3D_SensitiveSegment : public Select3D_SensitiveEntity {
 	public:
@@ -2092,6 +2182,11 @@ class Handle_Select3D_SensitiveSegment : public Handle_Select3D_SensitiveEntity 
     }
 };
 
+%extend Select3D_SensitiveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveWire;
 class Select3D_SensitiveWire : public Select3D_SensitiveEntity {
 	public:
@@ -2270,6 +2365,11 @@ class Handle_Select3D_SensitiveWire : public Handle_Select3D_SensitiveEntity {
     }
 };
 
+%extend Select3D_SensitiveWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveCircle;
 class Select3D_SensitiveCircle : public Select3D_SensitivePoly {
 	public:
@@ -2460,6 +2560,11 @@ class Handle_Select3D_SensitiveCircle : public Handle_Select3D_SensitivePoly {
     }
 };
 
+%extend Select3D_SensitiveCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveCurve;
 class Select3D_SensitiveCurve : public Select3D_SensitivePoly {
 	public:
@@ -2612,6 +2717,11 @@ class Handle_Select3D_SensitiveCurve : public Handle_Select3D_SensitivePoly {
     }
 };
 
+%extend Select3D_SensitiveCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveFace;
 class Select3D_SensitiveFace : public Select3D_SensitivePoly {
 	public:
@@ -2752,6 +2862,11 @@ class Handle_Select3D_SensitiveFace : public Handle_Select3D_SensitivePoly {
     }
 };
 
+%extend Select3D_SensitiveFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Select3D_SensitiveTriangle;
 class Select3D_SensitiveTriangle : public Select3D_SensitivePoly {
 	public:
@@ -2932,3 +3047,8 @@ class Handle_Select3D_SensitiveTriangle : public Handle_Select3D_SensitivePoly {
     }
 };
 
+%extend Select3D_SensitiveTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/SelectBasics.i
+++ b/src/SWIG_files/wrapper/SelectBasics.i
@@ -72,6 +72,11 @@ class SelectBasics {
 };
 
 
+%extend SelectBasics {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SelectBasics_BasicTool {
 	public:
 		%feature("compactdefaultargs") MatchSegments;
@@ -133,6 +138,11 @@ class SelectBasics_BasicTool {
 };
 
 
+%extend SelectBasics_BasicTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_EntityOwner;
 class SelectBasics_EntityOwner : public MMgt_TShared {
 	public:
@@ -215,6 +225,11 @@ class Handle_SelectBasics_EntityOwner : public Handle_MMgt_TShared {
     }
 };
 
+%extend SelectBasics_EntityOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListIteratorOfListOfBox2d;
 class SelectBasics_ListIteratorOfListOfBox2d {
 	public:
@@ -249,6 +264,11 @@ class SelectBasics_ListIteratorOfListOfBox2d {
 };
 
 
+%extend SelectBasics_ListIteratorOfListOfBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListIteratorOfListOfSensitive;
 class SelectBasics_ListIteratorOfListOfSensitive {
 	public:
@@ -283,6 +303,11 @@ class SelectBasics_ListIteratorOfListOfSensitive {
 };
 
 
+%extend SelectBasics_ListIteratorOfListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListNodeOfListOfBox2d;
 class SelectBasics_ListNodeOfListOfBox2d : public TCollection_MapNode {
 	public:
@@ -347,6 +372,11 @@ class Handle_SelectBasics_ListNodeOfListOfBox2d : public Handle_TCollection_MapN
     }
 };
 
+%extend SelectBasics_ListNodeOfListOfBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListNodeOfListOfSensitive;
 class SelectBasics_ListNodeOfListOfSensitive : public TCollection_MapNode {
 	public:
@@ -411,6 +441,11 @@ class Handle_SelectBasics_ListNodeOfListOfSensitive : public Handle_TCollection_
     }
 };
 
+%extend SelectBasics_ListNodeOfListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListOfBox2d;
 class SelectBasics_ListOfBox2d {
 	public:
@@ -541,6 +576,11 @@ class SelectBasics_ListOfBox2d {
 };
 
 
+%extend SelectBasics_ListOfBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_ListOfSensitive;
 class SelectBasics_ListOfSensitive {
 	public:
@@ -671,6 +711,11 @@ class SelectBasics_ListOfSensitive {
 };
 
 
+%extend SelectBasics_ListOfSensitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_PickArgs;
 class SelectBasics_PickArgs {
 	public:
@@ -727,6 +772,11 @@ class SelectBasics_PickArgs {
 };
 
 
+%extend SelectBasics_PickArgs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_SensitiveEntity;
 class SelectBasics_SensitiveEntity : public MMgt_TShared {
 	public:
@@ -865,6 +915,11 @@ class Handle_SelectBasics_SensitiveEntity : public Handle_MMgt_TShared {
     }
 };
 
+%extend SelectBasics_SensitiveEntity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_SequenceNodeOfSequenceOfOwner;
 class SelectBasics_SequenceNodeOfSequenceOfOwner : public TCollection_SeqNode {
 	public:
@@ -931,6 +986,11 @@ class Handle_SelectBasics_SequenceNodeOfSequenceOfOwner : public Handle_TCollect
     }
 };
 
+%extend SelectBasics_SequenceNodeOfSequenceOfOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_SequenceOfOwner;
 class SelectBasics_SequenceOfOwner : public TCollection_BaseSequence {
 	public:
@@ -1069,6 +1129,11 @@ class SelectBasics_SequenceOfOwner : public TCollection_BaseSequence {
 };
 
 
+%extend SelectBasics_SequenceOfOwner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor SelectBasics_SortAlgo;
 class SelectBasics_SortAlgo {
 	public:
@@ -1141,3 +1206,8 @@ class SelectBasics_SortAlgo {
 };
 
 
+%extend SelectBasics_SortAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeAlgo.i
+++ b/src/SWIG_files/wrapper/ShapeAlgo.i
@@ -82,6 +82,11 @@ class ShapeAlgo {
 };
 
 
+%extend ShapeAlgo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAlgo_ToolContainer;
 class ShapeAlgo_ToolContainer : public MMgt_TShared {
 	public:
@@ -152,3 +157,8 @@ class Handle_ShapeAlgo_ToolContainer : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAlgo_ToolContainer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeAnalysis.i
+++ b/src/SWIG_files/wrapper/ShapeAnalysis.i
@@ -149,6 +149,11 @@ class ShapeAnalysis {
 };
 
 
+%extend ShapeAnalysis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_CheckSmallFace;
 class ShapeAnalysis_CheckSmallFace {
 	public:
@@ -379,6 +384,11 @@ class ShapeAnalysis_CheckSmallFace {
 };
 
 
+%extend ShapeAnalysis_CheckSmallFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeAnalysis_Curve {
 	public:
 		%feature("compactdefaultargs") Project;
@@ -618,6 +628,11 @@ class ShapeAnalysis_Curve {
 };
 
 
+%extend ShapeAnalysis_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_DataMapIteratorOfDataMapOfShapeListOfReal;
 class ShapeAnalysis_DataMapIteratorOfDataMapOfShapeListOfReal : public TCollection_BasicMapIterator {
 	public:
@@ -648,6 +663,11 @@ class ShapeAnalysis_DataMapIteratorOfDataMapOfShapeListOfReal : public TCollecti
 };
 
 
+%extend ShapeAnalysis_DataMapIteratorOfDataMapOfShapeListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_DataMapNodeOfDataMapOfShapeListOfReal;
 class ShapeAnalysis_DataMapNodeOfDataMapOfShapeListOfReal : public TCollection_MapNode {
 	public:
@@ -718,6 +738,11 @@ class Handle_ShapeAnalysis_DataMapNodeOfDataMapOfShapeListOfReal : public Handle
     }
 };
 
+%extend ShapeAnalysis_DataMapNodeOfDataMapOfShapeListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_DataMapOfShapeListOfReal;
 class ShapeAnalysis_DataMapOfShapeListOfReal : public TCollection_BasicMap {
 	public:
@@ -796,6 +821,11 @@ class ShapeAnalysis_DataMapOfShapeListOfReal : public TCollection_BasicMap {
 };
 
 
+%extend ShapeAnalysis_DataMapOfShapeListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_Edge;
 class ShapeAnalysis_Edge {
 	public:
@@ -1132,6 +1162,11 @@ class ShapeAnalysis_Edge {
 };
 
 
+%extend ShapeAnalysis_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_FreeBoundData;
 class ShapeAnalysis_FreeBoundData : public MMgt_TShared {
 	public:
@@ -1320,6 +1355,11 @@ class Handle_ShapeAnalysis_FreeBoundData : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAnalysis_FreeBoundData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_FreeBounds;
 class ShapeAnalysis_FreeBounds {
 	public:
@@ -1442,6 +1482,11 @@ class ShapeAnalysis_FreeBounds {
 };
 
 
+%extend ShapeAnalysis_FreeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_FreeBoundsProperties;
 class ShapeAnalysis_FreeBoundsProperties {
 	public:
@@ -1622,6 +1667,11 @@ class ShapeAnalysis_FreeBoundsProperties {
 };
 
 
+%extend ShapeAnalysis_FreeBoundsProperties {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeAnalysis_Geom {
 	public:
 		%feature("compactdefaultargs") NearestPlane;
@@ -1653,6 +1703,11 @@ class ShapeAnalysis_Geom {
 };
 
 
+%extend ShapeAnalysis_Geom {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_HSequenceOfFreeBounds;
 class ShapeAnalysis_HSequenceOfFreeBounds : public MMgt_TShared {
 	public:
@@ -1837,6 +1892,11 @@ class Handle_ShapeAnalysis_HSequenceOfFreeBounds : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAnalysis_HSequenceOfFreeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_SequenceNodeOfSequenceOfFreeBounds;
 class ShapeAnalysis_SequenceNodeOfSequenceOfFreeBounds : public TCollection_SeqNode {
 	public:
@@ -1903,6 +1963,11 @@ class Handle_ShapeAnalysis_SequenceNodeOfSequenceOfFreeBounds : public Handle_TC
     }
 };
 
+%extend ShapeAnalysis_SequenceNodeOfSequenceOfFreeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_SequenceOfFreeBounds;
 class ShapeAnalysis_SequenceOfFreeBounds : public TCollection_BaseSequence {
 	public:
@@ -2041,6 +2106,11 @@ class ShapeAnalysis_SequenceOfFreeBounds : public TCollection_BaseSequence {
 };
 
 
+%extend ShapeAnalysis_SequenceOfFreeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_ShapeContents;
 class ShapeAnalysis_ShapeContents {
 	public:
@@ -2307,6 +2377,11 @@ class ShapeAnalysis_ShapeContents {
 };
 
 
+%extend ShapeAnalysis_ShapeContents {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_ShapeTolerance;
 class ShapeAnalysis_ShapeTolerance {
 	public:
@@ -2381,6 +2456,11 @@ class ShapeAnalysis_ShapeTolerance {
 };
 
 
+%extend ShapeAnalysis_ShapeTolerance {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeAnalysis_Shell {
 	public:
 		%feature("compactdefaultargs") Clear;
@@ -2464,6 +2544,11 @@ class ShapeAnalysis_Shell {
 };
 
 
+%extend ShapeAnalysis_Shell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_Surface;
 class ShapeAnalysis_Surface : public MMgt_TShared {
 	public:
@@ -2824,6 +2909,11 @@ class Handle_ShapeAnalysis_Surface : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAnalysis_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_TransferParameters;
 class ShapeAnalysis_TransferParameters : public MMgt_TShared {
 	public:
@@ -2950,6 +3040,11 @@ class Handle_ShapeAnalysis_TransferParameters : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAnalysis_TransferParameters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_Wire;
 class ShapeAnalysis_Wire : public MMgt_TShared {
 	public:
@@ -3594,6 +3689,11 @@ class Handle_ShapeAnalysis_Wire : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeAnalysis_Wire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_WireOrder;
 class ShapeAnalysis_WireOrder {
 	public:
@@ -3789,6 +3889,11 @@ class ShapeAnalysis_WireOrder {
 };
 
 
+%extend ShapeAnalysis_WireOrder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_WireVertex;
 class ShapeAnalysis_WireVertex {
 	public:
@@ -3995,6 +4100,11 @@ class ShapeAnalysis_WireVertex {
 };
 
 
+%extend ShapeAnalysis_WireVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeAnalysis_TransferParametersProj;
 class ShapeAnalysis_TransferParametersProj : public ShapeAnalysis_TransferParameters {
 	public:
@@ -4146,3 +4256,8 @@ class Handle_ShapeAnalysis_TransferParametersProj : public Handle_ShapeAnalysis_
     }
 };
 
+%extend ShapeAnalysis_TransferParametersProj {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeBuild.i
+++ b/src/SWIG_files/wrapper/ShapeBuild.i
@@ -68,6 +68,11 @@ class ShapeBuild {
 };
 
 
+%extend ShapeBuild {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeBuild_Edge {
 	public:
 		%feature("compactdefaultargs") CopyReplaceVertices;
@@ -307,6 +312,11 @@ class ShapeBuild_Edge {
 };
 
 
+%extend ShapeBuild_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeBuild_ReShape;
 class ShapeBuild_ReShape : public BRepTools_ReShape {
 	public:
@@ -407,6 +417,11 @@ class Handle_ShapeBuild_ReShape : public Handle_BRepTools_ReShape {
     }
 };
 
+%extend ShapeBuild_ReShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeBuild_Vertex {
 	public:
 		%feature("compactdefaultargs") CombineVertex;
@@ -440,3 +455,8 @@ class ShapeBuild_Vertex {
 };
 
 
+%extend ShapeBuild_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeConstruct.i
+++ b/src/SWIG_files/wrapper/ShapeConstruct.i
@@ -192,6 +192,11 @@ class ShapeConstruct {
 };
 
 
+%extend ShapeConstruct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeConstruct_CompBezierCurves2dToBSplineCurve2d;
 class ShapeConstruct_CompBezierCurves2dToBSplineCurve2d {
 	public:
@@ -242,6 +247,11 @@ class ShapeConstruct_CompBezierCurves2dToBSplineCurve2d {
 };
 
 
+%extend ShapeConstruct_CompBezierCurves2dToBSplineCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeConstruct_CompBezierCurvesToBSplineCurve;
 class ShapeConstruct_CompBezierCurvesToBSplineCurve {
 	public:
@@ -292,6 +302,11 @@ class ShapeConstruct_CompBezierCurvesToBSplineCurve {
 };
 
 
+%extend ShapeConstruct_CompBezierCurvesToBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeConstruct_Curve {
 	public:
 		%feature("compactdefaultargs") AdjustCurve;
@@ -387,6 +402,11 @@ class ShapeConstruct_Curve {
 };
 
 
+%extend ShapeConstruct_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeConstruct_MakeTriangulation;
 class ShapeConstruct_MakeTriangulation : public BRepBuilderAPI_MakeShape {
 	public:
@@ -417,6 +437,11 @@ class ShapeConstruct_MakeTriangulation : public BRepBuilderAPI_MakeShape {
 };
 
 
+%extend ShapeConstruct_MakeTriangulation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeConstruct_ProjectCurveOnSurface;
 class ShapeConstruct_ProjectCurveOnSurface : public MMgt_TShared {
 	public:
@@ -607,3 +632,8 @@ class Handle_ShapeConstruct_ProjectCurveOnSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeConstruct_ProjectCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeCustom.i
+++ b/src/SWIG_files/wrapper/ShapeCustom.i
@@ -156,6 +156,11 @@ class ShapeCustom {
 };
 
 
+%extend ShapeCustom {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_ConvertToBSpline;
 class ShapeCustom_ConvertToBSpline : public BRepTools_Modification {
 	public:
@@ -338,6 +343,11 @@ class Handle_ShapeCustom_ConvertToBSpline : public Handle_BRepTools_Modification
     }
 };
 
+%extend ShapeCustom_ConvertToBSpline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_Curve;
 class ShapeCustom_Curve {
 	public:
@@ -370,6 +380,11 @@ class ShapeCustom_Curve {
 };
 
 
+%extend ShapeCustom_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeCustom_Curve2d {
 	public:
 		%feature("compactdefaultargs") IsLinear;
@@ -417,6 +432,11 @@ class ShapeCustom_Curve2d {
 };
 
 
+%extend ShapeCustom_Curve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_DirectModification;
 class ShapeCustom_DirectModification : public BRepTools_Modification {
 	public:
@@ -567,6 +587,11 @@ class Handle_ShapeCustom_DirectModification : public Handle_BRepTools_Modificati
     }
 };
 
+%extend ShapeCustom_DirectModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_RestrictionParameters;
 class ShapeCustom_RestrictionParameters : public MMgt_TShared {
 	public:
@@ -833,6 +858,11 @@ class Handle_ShapeCustom_RestrictionParameters : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeCustom_RestrictionParameters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_Surface;
 class ShapeCustom_Surface {
 	public:
@@ -881,6 +911,11 @@ class ShapeCustom_Surface {
 };
 
 
+%extend ShapeCustom_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeCustom_TrsfModification;
 class ShapeCustom_TrsfModification : public BRepTools_TrsfModification {
 	public:
@@ -1017,3 +1052,8 @@ class Handle_ShapeCustom_TrsfModification : public Handle_BRepTools_TrsfModifica
     }
 };
 
+%extend ShapeCustom_TrsfModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeExtend.i
+++ b/src/SWIG_files/wrapper/ShapeExtend.i
@@ -114,6 +114,11 @@ class ShapeExtend {
 };
 
 
+%extend ShapeExtend {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_BasicMsgRegistrator;
 class ShapeExtend_BasicMsgRegistrator : public MMgt_TShared {
 	public:
@@ -206,6 +211,11 @@ class Handle_ShapeExtend_BasicMsgRegistrator : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeExtend_BasicMsgRegistrator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_ComplexCurve;
 class ShapeExtend_ComplexCurve : public Geom_Curve {
 	public:
@@ -416,6 +426,11 @@ class Handle_ShapeExtend_ComplexCurve : public Handle_Geom_Curve {
     }
 };
 
+%extend ShapeExtend_ComplexCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_CompositeSurface;
 class ShapeExtend_CompositeSurface : public Geom_Surface {
 	public:
@@ -974,6 +989,11 @@ class Handle_ShapeExtend_CompositeSurface : public Handle_Geom_Surface {
     }
 };
 
+%extend ShapeExtend_CompositeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapIteratorOfDataMapOfShapeListOfMsg;
 class ShapeExtend_DataMapIteratorOfDataMapOfShapeListOfMsg : public TCollection_BasicMapIterator {
 	public:
@@ -1004,6 +1024,11 @@ class ShapeExtend_DataMapIteratorOfDataMapOfShapeListOfMsg : public TCollection_
 };
 
 
+%extend ShapeExtend_DataMapIteratorOfDataMapOfShapeListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapIteratorOfDataMapOfTransientListOfMsg;
 class ShapeExtend_DataMapIteratorOfDataMapOfTransientListOfMsg : public TCollection_BasicMapIterator {
 	public:
@@ -1034,6 +1059,11 @@ class ShapeExtend_DataMapIteratorOfDataMapOfTransientListOfMsg : public TCollect
 };
 
 
+%extend ShapeExtend_DataMapIteratorOfDataMapOfTransientListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapNodeOfDataMapOfShapeListOfMsg;
 class ShapeExtend_DataMapNodeOfDataMapOfShapeListOfMsg : public TCollection_MapNode {
 	public:
@@ -1104,6 +1134,11 @@ class Handle_ShapeExtend_DataMapNodeOfDataMapOfShapeListOfMsg : public Handle_TC
     }
 };
 
+%extend ShapeExtend_DataMapNodeOfDataMapOfShapeListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapNodeOfDataMapOfTransientListOfMsg;
 class ShapeExtend_DataMapNodeOfDataMapOfTransientListOfMsg : public TCollection_MapNode {
 	public:
@@ -1174,6 +1209,11 @@ class Handle_ShapeExtend_DataMapNodeOfDataMapOfTransientListOfMsg : public Handl
     }
 };
 
+%extend ShapeExtend_DataMapNodeOfDataMapOfTransientListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapOfShapeListOfMsg;
 class ShapeExtend_DataMapOfShapeListOfMsg : public TCollection_BasicMap {
 	public:
@@ -1252,6 +1292,11 @@ class ShapeExtend_DataMapOfShapeListOfMsg : public TCollection_BasicMap {
 };
 
 
+%extend ShapeExtend_DataMapOfShapeListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_DataMapOfTransientListOfMsg;
 class ShapeExtend_DataMapOfTransientListOfMsg : public TCollection_BasicMap {
 	public:
@@ -1330,6 +1375,11 @@ class ShapeExtend_DataMapOfTransientListOfMsg : public TCollection_BasicMap {
 };
 
 
+%extend ShapeExtend_DataMapOfTransientListOfMsg {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_Explorer;
 class ShapeExtend_Explorer {
 	public:
@@ -1428,6 +1478,11 @@ class ShapeExtend_Explorer {
 };
 
 
+%extend ShapeExtend_Explorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_WireData;
 class ShapeExtend_WireData : public MMgt_TShared {
 	public:
@@ -1723,6 +1778,11 @@ class Handle_ShapeExtend_WireData : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeExtend_WireData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeExtend_MsgRegistrator;
 class ShapeExtend_MsgRegistrator : public ShapeExtend_BasicMsgRegistrator {
 	public:
@@ -1817,3 +1877,8 @@ class Handle_ShapeExtend_MsgRegistrator : public Handle_ShapeExtend_BasicMsgRegi
     }
 };
 
+%extend ShapeExtend_MsgRegistrator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeFix.i
+++ b/src/SWIG_files/wrapper/ShapeFix.i
@@ -118,6 +118,11 @@ class ShapeFix {
 };
 
 
+%extend ShapeFix {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_DataMapIteratorOfDataMapOfShapeBox2d;
 class ShapeFix_DataMapIteratorOfDataMapOfShapeBox2d : public TCollection_BasicMapIterator {
 	public:
@@ -148,6 +153,11 @@ class ShapeFix_DataMapIteratorOfDataMapOfShapeBox2d : public TCollection_BasicMa
 };
 
 
+%extend ShapeFix_DataMapIteratorOfDataMapOfShapeBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_DataMapNodeOfDataMapOfShapeBox2d;
 class ShapeFix_DataMapNodeOfDataMapOfShapeBox2d : public TCollection_MapNode {
 	public:
@@ -218,6 +228,11 @@ class Handle_ShapeFix_DataMapNodeOfDataMapOfShapeBox2d : public Handle_TCollecti
     }
 };
 
+%extend ShapeFix_DataMapNodeOfDataMapOfShapeBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_DataMapOfShapeBox2d;
 class ShapeFix_DataMapOfShapeBox2d : public TCollection_BasicMap {
 	public:
@@ -296,6 +311,11 @@ class ShapeFix_DataMapOfShapeBox2d : public TCollection_BasicMap {
 };
 
 
+%extend ShapeFix_DataMapOfShapeBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Edge;
 class ShapeFix_Edge : public MMgt_TShared {
 	public:
@@ -514,6 +534,11 @@ class Handle_ShapeFix_Edge : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeFix_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_EdgeConnect;
 class ShapeFix_EdgeConnect {
 	public:
@@ -554,6 +579,11 @@ class ShapeFix_EdgeConnect {
 };
 
 
+%extend ShapeFix_EdgeConnect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_EdgeProjAux;
 class ShapeFix_EdgeProjAux : public MMgt_TShared {
 	public:
@@ -654,6 +684,11 @@ class Handle_ShapeFix_EdgeProjAux : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeFix_EdgeProjAux {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_FaceConnect;
 class ShapeFix_FaceConnect {
 	public:
@@ -688,6 +723,11 @@ class ShapeFix_FaceConnect {
 };
 
 
+%extend ShapeFix_FaceConnect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_FreeBounds;
 class ShapeFix_FreeBounds {
 	public:
@@ -748,6 +788,11 @@ class ShapeFix_FreeBounds {
 };
 
 
+%extend ShapeFix_FreeBounds {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_IntersectionTool;
 class ShapeFix_IntersectionTool {
 	public:
@@ -828,6 +873,11 @@ class ShapeFix_IntersectionTool {
 };
 
 
+%extend ShapeFix_IntersectionTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Root;
 class ShapeFix_Root : public MMgt_TShared {
 	public:
@@ -1030,6 +1080,11 @@ class Handle_ShapeFix_Root : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeFix_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_SequenceNodeOfSequenceOfWireSegment;
 class ShapeFix_SequenceNodeOfSequenceOfWireSegment : public TCollection_SeqNode {
 	public:
@@ -1096,6 +1151,11 @@ class Handle_ShapeFix_SequenceNodeOfSequenceOfWireSegment : public Handle_TColle
     }
 };
 
+%extend ShapeFix_SequenceNodeOfSequenceOfWireSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_SequenceOfWireSegment;
 class ShapeFix_SequenceOfWireSegment : public TCollection_BaseSequence {
 	public:
@@ -1234,6 +1294,11 @@ class ShapeFix_SequenceOfWireSegment : public TCollection_BaseSequence {
 };
 
 
+%extend ShapeFix_SequenceOfWireSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_ShapeTolerance;
 class ShapeFix_ShapeTolerance {
 	public:
@@ -1270,6 +1335,11 @@ class ShapeFix_ShapeTolerance {
 };
 
 
+%extend ShapeFix_ShapeTolerance {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_SplitTool;
 class ShapeFix_SplitTool {
 	public:
@@ -1372,6 +1442,11 @@ class ShapeFix_SplitTool {
 };
 
 
+%extend ShapeFix_SplitTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_WireVertex;
 class ShapeFix_WireVertex {
 	public:
@@ -1440,6 +1515,11 @@ class ShapeFix_WireVertex {
 };
 
 
+%extend ShapeFix_WireVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_ComposeShell;
 class ShapeFix_ComposeShell : public ShapeFix_Root {
 	public:
@@ -1575,6 +1655,11 @@ class Handle_ShapeFix_ComposeShell : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_ComposeShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Face;
 class ShapeFix_Face : public ShapeFix_Root {
 	public:
@@ -1947,6 +2032,11 @@ class Handle_ShapeFix_Face : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_FixSmallFace;
 class ShapeFix_FixSmallFace : public ShapeFix_Root {
 	public:
@@ -2133,6 +2223,11 @@ class Handle_ShapeFix_FixSmallFace : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_FixSmallFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Shape;
 class ShapeFix_Shape : public ShapeFix_Root {
 	public:
@@ -2369,6 +2464,11 @@ class Handle_ShapeFix_Shape : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Shape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Shell;
 class ShapeFix_Shell : public ShapeFix_Root {
 	public:
@@ -2559,6 +2659,11 @@ class Handle_ShapeFix_Shell : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Shell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Solid;
 class ShapeFix_Solid : public ShapeFix_Root {
 	public:
@@ -2733,6 +2838,11 @@ class Handle_ShapeFix_Solid : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Solid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_SplitCommonVertex;
 class ShapeFix_SplitCommonVertex : public ShapeFix_Root {
 	public:
@@ -2803,6 +2913,11 @@ class Handle_ShapeFix_SplitCommonVertex : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_SplitCommonVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Wire;
 class ShapeFix_Wire : public ShapeFix_Root {
 	public:
@@ -3615,6 +3730,11 @@ class Handle_ShapeFix_Wire : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Wire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeFix_Wireframe;
 class ShapeFix_Wireframe : public ShapeFix_Root {
 	public:
@@ -3782,3 +3902,8 @@ class Handle_ShapeFix_Wireframe : public Handle_ShapeFix_Root {
     }
 };
 
+%extend ShapeFix_Wireframe {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeProcess.i
+++ b/src/SWIG_files/wrapper/ShapeProcess.i
@@ -93,6 +93,11 @@ class ShapeProcess {
 };
 
 
+%extend ShapeProcess {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_Context;
 class ShapeProcess_Context : public MMgt_TShared {
 	public:
@@ -317,6 +322,11 @@ class Handle_ShapeProcess_Context : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeProcess_Context {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_DictionaryOfOperator;
 class ShapeProcess_DictionaryOfOperator : public MMgt_TShared {
 	public:
@@ -507,6 +517,11 @@ class Handle_ShapeProcess_DictionaryOfOperator : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeProcess_DictionaryOfOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_IteratorOfDictionaryOfOperator;
 class ShapeProcess_IteratorOfDictionaryOfOperator {
 	public:
@@ -555,6 +570,11 @@ class ShapeProcess_IteratorOfDictionaryOfOperator {
 };
 
 
+%extend ShapeProcess_IteratorOfDictionaryOfOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class ShapeProcess_OperLibrary {
 	public:
 		%feature("compactdefaultargs") Init;
@@ -580,6 +600,11 @@ class ShapeProcess_OperLibrary {
 };
 
 
+%extend ShapeProcess_OperLibrary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_Operator;
 class ShapeProcess_Operator : public MMgt_TShared {
 	public:
@@ -640,6 +665,11 @@ class Handle_ShapeProcess_Operator : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeProcess_Operator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_StackItemOfDictionaryOfOperator;
 class ShapeProcess_StackItemOfDictionaryOfOperator : public MMgt_TShared {
 	public:
@@ -716,6 +746,11 @@ class Handle_ShapeProcess_StackItemOfDictionaryOfOperator : public Handle_MMgt_T
     }
 };
 
+%extend ShapeProcess_StackItemOfDictionaryOfOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_ShapeContext;
 class ShapeProcess_ShapeContext : public ShapeProcess_Context {
 	public:
@@ -912,6 +947,11 @@ class Handle_ShapeProcess_ShapeContext : public Handle_ShapeProcess_Context {
     }
 };
 
+%extend ShapeProcess_ShapeContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeProcess_UOperator;
 class ShapeProcess_UOperator : public ShapeProcess_Operator {
 	public:
@@ -980,3 +1020,8 @@ class Handle_ShapeProcess_UOperator : public Handle_ShapeProcess_Operator {
     }
 };
 
+%extend ShapeProcess_UOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeProcessAPI.i
+++ b/src/SWIG_files/wrapper/ShapeProcessAPI.i
@@ -108,3 +108,8 @@ class ShapeProcessAPI_ApplySequence {
 };
 
 
+%extend ShapeProcessAPI_ApplySequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/ShapeUpgrade.i
+++ b/src/SWIG_files/wrapper/ShapeUpgrade.i
@@ -82,6 +82,11 @@ class ShapeUpgrade {
 };
 
 
+%extend ShapeUpgrade {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_RemoveLocations;
 class ShapeUpgrade_RemoveLocations : public MMgt_TShared {
 	public:
@@ -176,6 +181,11 @@ class Handle_ShapeUpgrade_RemoveLocations : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeUpgrade_RemoveLocations {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivide;
 class ShapeUpgrade_ShapeDivide {
 	public:
@@ -290,6 +300,11 @@ class ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShellSewing;
 class ShapeUpgrade_ShellSewing {
 	public:
@@ -312,6 +327,11 @@ class ShapeUpgrade_ShellSewing {
 };
 
 
+%extend ShapeUpgrade_ShellSewing {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitCurve;
 class ShapeUpgrade_SplitCurve : public MMgt_TShared {
 	public:
@@ -424,6 +444,11 @@ class Handle_ShapeUpgrade_SplitCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeUpgrade_SplitCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitSurface;
 class ShapeUpgrade_SplitSurface : public MMgt_TShared {
 	public:
@@ -572,6 +597,11 @@ class Handle_ShapeUpgrade_SplitSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeUpgrade_SplitSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_Tool;
 class ShapeUpgrade_Tool : public MMgt_TShared {
 	public:
@@ -702,6 +732,11 @@ class Handle_ShapeUpgrade_Tool : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeUpgrade_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_UnifySameDomain;
 class ShapeUpgrade_UnifySameDomain : public MMgt_TShared {
 	public:
@@ -820,6 +855,11 @@ class Handle_ShapeUpgrade_UnifySameDomain : public Handle_MMgt_TShared {
     }
 };
 
+%extend ShapeUpgrade_UnifySameDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ConvertSurfaceToBezierBasis;
 class ShapeUpgrade_ConvertSurfaceToBezierBasis : public ShapeUpgrade_SplitSurface {
 	public:
@@ -956,6 +996,11 @@ class Handle_ShapeUpgrade_ConvertSurfaceToBezierBasis : public Handle_ShapeUpgra
     }
 };
 
+%extend ShapeUpgrade_ConvertSurfaceToBezierBasis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_EdgeDivide;
 class ShapeUpgrade_EdgeDivide : public ShapeUpgrade_Tool {
 	public:
@@ -1076,6 +1121,11 @@ class Handle_ShapeUpgrade_EdgeDivide : public Handle_ShapeUpgrade_Tool {
     }
 };
 
+%extend ShapeUpgrade_EdgeDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_FaceDivide;
 class ShapeUpgrade_FaceDivide : public ShapeUpgrade_Tool {
 	public:
@@ -1218,6 +1268,11 @@ class Handle_ShapeUpgrade_FaceDivide : public Handle_ShapeUpgrade_Tool {
     }
 };
 
+%extend ShapeUpgrade_FaceDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_FixSmallCurves;
 class ShapeUpgrade_FixSmallCurves : public ShapeUpgrade_Tool {
 	public:
@@ -1320,6 +1375,11 @@ class Handle_ShapeUpgrade_FixSmallCurves : public Handle_ShapeUpgrade_Tool {
     }
 };
 
+%extend ShapeUpgrade_FixSmallCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_RemoveInternalWires;
 class ShapeUpgrade_RemoveInternalWires : public ShapeUpgrade_Tool {
 	public:
@@ -1458,6 +1518,11 @@ class Handle_ShapeUpgrade_RemoveInternalWires : public Handle_ShapeUpgrade_Tool 
     }
 };
 
+%extend ShapeUpgrade_RemoveInternalWires {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeConvertToBezier;
 class ShapeUpgrade_ShapeConvertToBezier : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1626,6 +1691,11 @@ class ShapeUpgrade_ShapeConvertToBezier : public ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeConvertToBezier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivideAngle;
 class ShapeUpgrade_ShapeDivideAngle : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1672,6 +1742,11 @@ class ShapeUpgrade_ShapeDivideAngle : public ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeDivideAngle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivideArea;
 class ShapeUpgrade_ShapeDivideArea : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1703,6 +1778,11 @@ class ShapeUpgrade_ShapeDivideArea : public ShapeUpgrade_ShapeDivide {
             };
 
 
+%extend ShapeUpgrade_ShapeDivideArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivideClosed;
 class ShapeUpgrade_ShapeDivideClosed : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1725,6 +1805,11 @@ class ShapeUpgrade_ShapeDivideClosed : public ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeDivideClosed {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivideClosedEdges;
 class ShapeUpgrade_ShapeDivideClosedEdges : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1747,6 +1832,11 @@ class ShapeUpgrade_ShapeDivideClosedEdges : public ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeDivideClosedEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ShapeDivideContinuity;
 class ShapeUpgrade_ShapeDivideContinuity : public ShapeUpgrade_ShapeDivide {
 	public:
@@ -1805,6 +1895,11 @@ class ShapeUpgrade_ShapeDivideContinuity : public ShapeUpgrade_ShapeDivide {
 };
 
 
+%extend ShapeUpgrade_ShapeDivideContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitCurve2d;
 class ShapeUpgrade_SplitCurve2d : public ShapeUpgrade_SplitCurve {
 	public:
@@ -1895,6 +1990,11 @@ class Handle_ShapeUpgrade_SplitCurve2d : public Handle_ShapeUpgrade_SplitCurve {
     }
 };
 
+%extend ShapeUpgrade_SplitCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitCurve3d;
 class ShapeUpgrade_SplitCurve3d : public ShapeUpgrade_SplitCurve {
 	public:
@@ -1985,6 +2085,11 @@ class Handle_ShapeUpgrade_SplitCurve3d : public Handle_ShapeUpgrade_SplitCurve {
     }
 };
 
+%extend ShapeUpgrade_SplitCurve3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitSurfaceAngle;
 class ShapeUpgrade_SplitSurfaceAngle : public ShapeUpgrade_SplitSurface {
 	public:
@@ -2067,6 +2172,11 @@ class Handle_ShapeUpgrade_SplitSurfaceAngle : public Handle_ShapeUpgrade_SplitSu
     }
 };
 
+%extend ShapeUpgrade_SplitSurfaceAngle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitSurfaceArea;
 class ShapeUpgrade_SplitSurfaceArea : public ShapeUpgrade_SplitSurface {
 	public:
@@ -2144,6 +2254,11 @@ class Handle_ShapeUpgrade_SplitSurfaceArea : public Handle_ShapeUpgrade_SplitSur
     }
 };
 
+%extend ShapeUpgrade_SplitSurfaceArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitSurfaceContinuity;
 class ShapeUpgrade_SplitSurfaceContinuity : public ShapeUpgrade_SplitSurface {
 	public:
@@ -2224,6 +2339,11 @@ class Handle_ShapeUpgrade_SplitSurfaceContinuity : public Handle_ShapeUpgrade_Sp
     }
 };
 
+%extend ShapeUpgrade_SplitSurfaceContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_WireDivide;
 class ShapeUpgrade_WireDivide : public ShapeUpgrade_Tool {
 	public:
@@ -2430,6 +2550,11 @@ class Handle_ShapeUpgrade_WireDivide : public Handle_ShapeUpgrade_Tool {
     }
 };
 
+%extend ShapeUpgrade_WireDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ClosedEdgeDivide;
 class ShapeUpgrade_ClosedEdgeDivide : public ShapeUpgrade_EdgeDivide {
 	public:
@@ -2494,6 +2619,11 @@ class Handle_ShapeUpgrade_ClosedEdgeDivide : public Handle_ShapeUpgrade_EdgeDivi
     }
 };
 
+%extend ShapeUpgrade_ClosedEdgeDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ClosedFaceDivide;
 class ShapeUpgrade_ClosedFaceDivide : public ShapeUpgrade_FaceDivide {
 	public:
@@ -2580,6 +2710,11 @@ class Handle_ShapeUpgrade_ClosedFaceDivide : public Handle_ShapeUpgrade_FaceDivi
     }
 };
 
+%extend ShapeUpgrade_ClosedFaceDivide {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ConvertCurve2dToBezier;
 class ShapeUpgrade_ConvertCurve2dToBezier : public ShapeUpgrade_SplitCurve2d {
 	public:
@@ -2658,6 +2793,11 @@ class Handle_ShapeUpgrade_ConvertCurve2dToBezier : public Handle_ShapeUpgrade_Sp
     }
 };
 
+%extend ShapeUpgrade_ConvertCurve2dToBezier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_ConvertCurve3dToBezier;
 class ShapeUpgrade_ConvertCurve3dToBezier : public ShapeUpgrade_SplitCurve3d {
 	public:
@@ -2778,6 +2918,11 @@ class Handle_ShapeUpgrade_ConvertCurve3dToBezier : public Handle_ShapeUpgrade_Sp
     }
 };
 
+%extend ShapeUpgrade_ConvertCurve3dToBezier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_FaceDivideArea;
 class ShapeUpgrade_FaceDivideArea : public ShapeUpgrade_FaceDivide {
 	public:
@@ -2861,6 +3006,11 @@ class Handle_ShapeUpgrade_FaceDivideArea : public Handle_ShapeUpgrade_FaceDivide
     }
 };
 
+%extend ShapeUpgrade_FaceDivideArea {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_FixSmallBezierCurves;
 class ShapeUpgrade_FixSmallBezierCurves : public ShapeUpgrade_FixSmallCurves {
 	public:
@@ -2931,6 +3081,11 @@ class Handle_ShapeUpgrade_FixSmallBezierCurves : public Handle_ShapeUpgrade_FixS
     }
 };
 
+%extend ShapeUpgrade_FixSmallBezierCurves {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitCurve2dContinuity;
 class ShapeUpgrade_SplitCurve2dContinuity : public ShapeUpgrade_SplitCurve2d {
 	public:
@@ -3011,6 +3166,11 @@ class Handle_ShapeUpgrade_SplitCurve2dContinuity : public Handle_ShapeUpgrade_Sp
     }
 };
 
+%extend ShapeUpgrade_SplitCurve2dContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor ShapeUpgrade_SplitCurve3dContinuity;
 class ShapeUpgrade_SplitCurve3dContinuity : public ShapeUpgrade_SplitCurve3d {
 	public:
@@ -3095,3 +3255,8 @@ class Handle_ShapeUpgrade_SplitCurve3dContinuity : public Handle_ShapeUpgrade_Sp
     }
 };
 
+%extend ShapeUpgrade_SplitCurve3dContinuity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/SortTools.i
+++ b/src/SWIG_files/wrapper/SortTools.i
@@ -69,6 +69,11 @@ class SortTools_HeapSortOfInteger {
 };
 
 
+%extend SortTools_HeapSortOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_HeapSortOfReal {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -82,6 +87,11 @@ class SortTools_HeapSortOfReal {
 };
 
 
+%extend SortTools_HeapSortOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_QuickSortOfInteger {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -95,6 +105,11 @@ class SortTools_QuickSortOfInteger {
 };
 
 
+%extend SortTools_QuickSortOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_QuickSortOfReal {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -108,6 +123,11 @@ class SortTools_QuickSortOfReal {
 };
 
 
+%extend SortTools_QuickSortOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_ShellSortOfInteger {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -121,6 +141,11 @@ class SortTools_ShellSortOfInteger {
 };
 
 
+%extend SortTools_ShellSortOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_ShellSortOfReal {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -134,6 +159,11 @@ class SortTools_ShellSortOfReal {
 };
 
 
+%extend SortTools_ShellSortOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_StraightInsertionSortOfInteger {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -147,6 +177,11 @@ class SortTools_StraightInsertionSortOfInteger {
 };
 
 
+%extend SortTools_StraightInsertionSortOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class SortTools_StraightInsertionSortOfReal {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -160,3 +195,8 @@ class SortTools_StraightInsertionSortOfReal {
 };
 
 
+%extend SortTools_StraightInsertionSortOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Standard.i
+++ b/src/SWIG_files/wrapper/Standard.i
@@ -166,6 +166,11 @@ class Standard {
 };
 
 
+%extend Standard {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_ErrorHandler;
 class Standard_ErrorHandler {
 	public:
@@ -222,6 +227,11 @@ class Standard_ErrorHandler {
 };
 
 
+%extend Standard_ErrorHandler {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_ErrorHandlerCallback;
 class Standard_ErrorHandlerCallback {
 	public:
@@ -234,6 +244,11 @@ class Standard_ErrorHandlerCallback {
 };
 
 
+%extend Standard_ErrorHandlerCallback {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_GUID;
 class Standard_GUID {
 	public:
@@ -524,6 +539,11 @@ class Standard_GUID {
 };
 
 
+%extend Standard_GUID {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_MMgrRoot;
 class Standard_MMgrRoot {
 	public:
@@ -564,6 +584,11 @@ class Standard_MMgrRoot {
 };
 
 
+%extend Standard_MMgrRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_Static_Assert<true>;
 class Standard_Static_Assert<true> {
 	public:
@@ -574,6 +599,11 @@ class Standard_Static_Assert<true> {
 };
 
 
+%extend Standard_Static_Assert<true> {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class Standard_Storable {
 	public:
 		%feature("compactdefaultargs") Delete;
@@ -627,6 +657,11 @@ class Standard_Storable {
 };
 
 
+%extend Standard_Storable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_Transient;
 class Standard_Transient {
 	public:
@@ -803,6 +838,11 @@ class Handle_Standard_Transient {
     }
 };
 
+%extend Standard_Transient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_Failure;
 class Standard_Failure : public Standard_Transient {
 	public:
@@ -921,6 +961,11 @@ class Handle_Standard_Failure : public Handle_Standard_Transient {
     }
 };
 
+%extend Standard_Failure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_MMgrOpt;
 class Standard_MMgrOpt : public Standard_MMgrRoot {
 	public:
@@ -977,6 +1022,11 @@ class Standard_MMgrOpt : public Standard_MMgrRoot {
 };
 
 
+%extend Standard_MMgrOpt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_MMgrRaw;
 class Standard_MMgrRaw : public Standard_MMgrRoot {
 	public:
@@ -1017,6 +1067,11 @@ class Standard_MMgrRaw : public Standard_MMgrRoot {
 };
 
 
+%extend Standard_MMgrRaw {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_MMgrTBBalloc;
 class Standard_MMgrTBBalloc : public Standard_MMgrRoot {
 	public:
@@ -1057,6 +1112,11 @@ class Standard_MMgrTBBalloc : public Standard_MMgrRoot {
 };
 
 
+%extend Standard_MMgrTBBalloc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_Mutex;
 class Standard_Mutex : public Standard_ErrorHandlerCallback {
 	public:
@@ -1087,6 +1147,11 @@ class Standard_Mutex : public Standard_ErrorHandlerCallback {
 };
 
 
+%extend Standard_Mutex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Standard_Type;
 class Standard_Type : public Standard_Transient {
 	public:
@@ -1269,3 +1334,8 @@ class Handle_Standard_Type : public Handle_Standard_Transient {
     }
 };
 
+%extend Standard_Type {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StdPrs.i
+++ b/src/SWIG_files/wrapper/StdPrs.i
@@ -221,6 +221,11 @@ class StdPrs_Curve : public Prs3d_Root {
 };
 
 
+%extend StdPrs_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_HLRPolyShape : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -240,6 +245,11 @@ class StdPrs_HLRPolyShape : public Prs3d_Root {
 };
 
 
+%extend StdPrs_HLRPolyShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_HLRShape : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -257,6 +267,11 @@ class StdPrs_HLRShape : public Prs3d_Root {
 };
 
 
+%extend StdPrs_HLRShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StdPrs_HLRToolShape;
 class StdPrs_HLRToolShape {
 	public:
@@ -323,6 +338,11 @@ class StdPrs_HLRToolShape {
 };
 
 
+%extend StdPrs_HLRToolShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_Plane : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -358,6 +378,11 @@ class StdPrs_Plane : public Prs3d_Root {
 };
 
 
+%extend StdPrs_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_PoleCurve : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -411,6 +436,11 @@ class StdPrs_PoleCurve : public Prs3d_Root {
 };
 
 
+%extend StdPrs_PoleCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_ShadedShape : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -462,6 +492,11 @@ class StdPrs_ShadedShape : public Prs3d_Root {
 };
 
 
+%extend StdPrs_ShadedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_ShadedSurface : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -479,6 +514,11 @@ class StdPrs_ShadedSurface : public Prs3d_Root {
 };
 
 
+%extend StdPrs_ShadedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_ToolPoint {
 	public:
 		%feature("compactdefaultargs") Coord;
@@ -496,6 +536,11 @@ class StdPrs_ToolPoint {
 };
 
 
+%extend StdPrs_ToolPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StdPrs_ToolRFace;
 class StdPrs_ToolRFace {
 	public:
@@ -536,6 +581,11 @@ class StdPrs_ToolRFace {
 };
 
 
+%extend StdPrs_ToolRFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_ToolShadedShape {
 	public:
 		%feature("compactdefaultargs") IsTriangulated;
@@ -575,6 +625,11 @@ class StdPrs_ToolShadedShape {
 };
 
 
+%extend StdPrs_ToolShadedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_ToolVertex {
 	public:
 		%feature("compactdefaultargs") Coord;
@@ -592,6 +647,11 @@ class StdPrs_ToolVertex {
 };
 
 
+%extend StdPrs_ToolVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_WFDeflectionRestrictedFace : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -743,6 +803,11 @@ class StdPrs_WFDeflectionRestrictedFace : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFDeflectionRestrictedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StdPrs_WFDeflectionShape;
 class StdPrs_WFDeflectionShape : public Prs3d_Root {
 	public:
@@ -793,6 +858,11 @@ class StdPrs_WFDeflectionShape : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFDeflectionShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_WFDeflectionSurface : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -810,6 +880,11 @@ class StdPrs_WFDeflectionSurface : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFDeflectionSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_WFPoleSurface : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -827,6 +902,11 @@ class StdPrs_WFPoleSurface : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFPoleSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_WFRestrictedFace : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -958,6 +1038,11 @@ class StdPrs_WFRestrictedFace : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFRestrictedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StdPrs_WFShape;
 class StdPrs_WFShape : public Prs3d_Root {
 	public:
@@ -1008,6 +1093,11 @@ class StdPrs_WFShape : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StdPrs_WFSurface : public Prs3d_Root {
 	public:
 		%feature("compactdefaultargs") Add;
@@ -1025,3 +1115,8 @@ class StdPrs_WFSurface : public Prs3d_Root {
 };
 
 
+%extend StdPrs_WFSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepAP203.i
+++ b/src/SWIG_files/wrapper/StepAP203.i
@@ -142,6 +142,11 @@ class StepAP203_ApprovedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_ApprovedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfApprovedItem;
 class StepAP203_Array1OfApprovedItem {
 	public:
@@ -224,6 +229,11 @@ class StepAP203_Array1OfApprovedItem {
 };
 
 
+%extend StepAP203_Array1OfApprovedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfCertifiedItem;
 class StepAP203_Array1OfCertifiedItem {
 	public:
@@ -306,6 +316,11 @@ class StepAP203_Array1OfCertifiedItem {
 };
 
 
+%extend StepAP203_Array1OfCertifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfChangeRequestItem;
 class StepAP203_Array1OfChangeRequestItem {
 	public:
@@ -388,6 +403,11 @@ class StepAP203_Array1OfChangeRequestItem {
 };
 
 
+%extend StepAP203_Array1OfChangeRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfClassifiedItem;
 class StepAP203_Array1OfClassifiedItem {
 	public:
@@ -470,6 +490,11 @@ class StepAP203_Array1OfClassifiedItem {
 };
 
 
+%extend StepAP203_Array1OfClassifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfContractedItem;
 class StepAP203_Array1OfContractedItem {
 	public:
@@ -552,6 +577,11 @@ class StepAP203_Array1OfContractedItem {
 };
 
 
+%extend StepAP203_Array1OfContractedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfDateTimeItem;
 class StepAP203_Array1OfDateTimeItem {
 	public:
@@ -634,6 +664,11 @@ class StepAP203_Array1OfDateTimeItem {
 };
 
 
+%extend StepAP203_Array1OfDateTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfPersonOrganizationItem;
 class StepAP203_Array1OfPersonOrganizationItem {
 	public:
@@ -716,6 +751,11 @@ class StepAP203_Array1OfPersonOrganizationItem {
 };
 
 
+%extend StepAP203_Array1OfPersonOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfSpecifiedItem;
 class StepAP203_Array1OfSpecifiedItem {
 	public:
@@ -798,6 +838,11 @@ class StepAP203_Array1OfSpecifiedItem {
 };
 
 
+%extend StepAP203_Array1OfSpecifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfStartRequestItem;
 class StepAP203_Array1OfStartRequestItem {
 	public:
@@ -880,6 +925,11 @@ class StepAP203_Array1OfStartRequestItem {
 };
 
 
+%extend StepAP203_Array1OfStartRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Array1OfWorkItem;
 class StepAP203_Array1OfWorkItem {
 	public:
@@ -962,6 +1012,11 @@ class StepAP203_Array1OfWorkItem {
 };
 
 
+%extend StepAP203_Array1OfWorkItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignApproval;
 class StepAP203_CcDesignApproval : public StepBasic_ApprovalAssignment {
 	public:
@@ -1044,6 +1099,11 @@ class Handle_StepAP203_CcDesignApproval : public Handle_StepBasic_ApprovalAssign
     }
 };
 
+%extend StepAP203_CcDesignApproval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignCertification;
 class StepAP203_CcDesignCertification : public StepBasic_CertificationAssignment {
 	public:
@@ -1126,6 +1186,11 @@ class Handle_StepAP203_CcDesignCertification : public Handle_StepBasic_Certifica
     }
 };
 
+%extend StepAP203_CcDesignCertification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignContract;
 class StepAP203_CcDesignContract : public StepBasic_ContractAssignment {
 	public:
@@ -1208,6 +1273,11 @@ class Handle_StepAP203_CcDesignContract : public Handle_StepBasic_ContractAssign
     }
 };
 
+%extend StepAP203_CcDesignContract {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignDateAndTimeAssignment;
 class StepAP203_CcDesignDateAndTimeAssignment : public StepBasic_DateAndTimeAssignment {
 	public:
@@ -1292,6 +1362,11 @@ class Handle_StepAP203_CcDesignDateAndTimeAssignment : public Handle_StepBasic_D
     }
 };
 
+%extend StepAP203_CcDesignDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignPersonAndOrganizationAssignment;
 class StepAP203_CcDesignPersonAndOrganizationAssignment : public StepBasic_PersonAndOrganizationAssignment {
 	public:
@@ -1376,6 +1451,11 @@ class Handle_StepAP203_CcDesignPersonAndOrganizationAssignment : public Handle_S
     }
 };
 
+%extend StepAP203_CcDesignPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignSecurityClassification;
 class StepAP203_CcDesignSecurityClassification : public StepBasic_SecurityClassificationAssignment {
 	public:
@@ -1458,6 +1538,11 @@ class Handle_StepAP203_CcDesignSecurityClassification : public Handle_StepBasic_
     }
 };
 
+%extend StepAP203_CcDesignSecurityClassification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CcDesignSpecificationReference;
 class StepAP203_CcDesignSpecificationReference : public StepBasic_DocumentReference {
 	public:
@@ -1542,6 +1627,11 @@ class Handle_StepAP203_CcDesignSpecificationReference : public Handle_StepBasic_
     }
 };
 
+%extend StepAP203_CcDesignSpecificationReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_CertifiedItem;
 class StepAP203_CertifiedItem : public StepData_SelectType {
 	public:
@@ -1568,6 +1658,11 @@ class StepAP203_CertifiedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_CertifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_Change;
 class StepAP203_Change : public StepBasic_ActionAssignment {
 	public:
@@ -1650,6 +1745,11 @@ class Handle_StepAP203_Change : public Handle_StepBasic_ActionAssignment {
     }
 };
 
+%extend StepAP203_Change {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_ChangeRequest;
 class StepAP203_ChangeRequest : public StepBasic_ActionRequestAssignment {
 	public:
@@ -1732,6 +1832,11 @@ class Handle_StepAP203_ChangeRequest : public Handle_StepBasic_ActionRequestAssi
     }
 };
 
+%extend StepAP203_ChangeRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_ChangeRequestItem;
 class StepAP203_ChangeRequestItem : public StepData_SelectType {
 	public:
@@ -1758,6 +1863,11 @@ class StepAP203_ChangeRequestItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_ChangeRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_ClassifiedItem;
 class StepAP203_ClassifiedItem : public StepData_SelectType {
 	public:
@@ -1790,6 +1900,11 @@ class StepAP203_ClassifiedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_ClassifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_ContractedItem;
 class StepAP203_ContractedItem : public StepData_SelectType {
 	public:
@@ -1816,6 +1931,11 @@ class StepAP203_ContractedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_ContractedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_DateTimeItem;
 class StepAP203_DateTimeItem : public StepData_SelectType {
 	public:
@@ -1890,6 +2010,11 @@ class StepAP203_DateTimeItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_DateTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfApprovedItem;
 class StepAP203_HArray1OfApprovedItem : public MMgt_TShared {
 	public:
@@ -2006,6 +2131,11 @@ class Handle_StepAP203_HArray1OfApprovedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfApprovedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfCertifiedItem;
 class StepAP203_HArray1OfCertifiedItem : public MMgt_TShared {
 	public:
@@ -2122,6 +2252,11 @@ class Handle_StepAP203_HArray1OfCertifiedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfCertifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfChangeRequestItem;
 class StepAP203_HArray1OfChangeRequestItem : public MMgt_TShared {
 	public:
@@ -2238,6 +2373,11 @@ class Handle_StepAP203_HArray1OfChangeRequestItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfChangeRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfClassifiedItem;
 class StepAP203_HArray1OfClassifiedItem : public MMgt_TShared {
 	public:
@@ -2354,6 +2494,11 @@ class Handle_StepAP203_HArray1OfClassifiedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfClassifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfContractedItem;
 class StepAP203_HArray1OfContractedItem : public MMgt_TShared {
 	public:
@@ -2470,6 +2615,11 @@ class Handle_StepAP203_HArray1OfContractedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfContractedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfDateTimeItem;
 class StepAP203_HArray1OfDateTimeItem : public MMgt_TShared {
 	public:
@@ -2586,6 +2736,11 @@ class Handle_StepAP203_HArray1OfDateTimeItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfDateTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfPersonOrganizationItem;
 class StepAP203_HArray1OfPersonOrganizationItem : public MMgt_TShared {
 	public:
@@ -2702,6 +2857,11 @@ class Handle_StepAP203_HArray1OfPersonOrganizationItem : public Handle_MMgt_TSha
     }
 };
 
+%extend StepAP203_HArray1OfPersonOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfSpecifiedItem;
 class StepAP203_HArray1OfSpecifiedItem : public MMgt_TShared {
 	public:
@@ -2818,6 +2978,11 @@ class Handle_StepAP203_HArray1OfSpecifiedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfSpecifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfStartRequestItem;
 class StepAP203_HArray1OfStartRequestItem : public MMgt_TShared {
 	public:
@@ -2934,6 +3099,11 @@ class Handle_StepAP203_HArray1OfStartRequestItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfStartRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_HArray1OfWorkItem;
 class StepAP203_HArray1OfWorkItem : public MMgt_TShared {
 	public:
@@ -3050,6 +3220,11 @@ class Handle_StepAP203_HArray1OfWorkItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP203_HArray1OfWorkItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_PersonOrganizationItem;
 class StepAP203_PersonOrganizationItem : public StepData_SelectType {
 	public:
@@ -3130,6 +3305,11 @@ class StepAP203_PersonOrganizationItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_PersonOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_SpecifiedItem;
 class StepAP203_SpecifiedItem : public StepData_SelectType {
 	public:
@@ -3162,6 +3342,11 @@ class StepAP203_SpecifiedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_SpecifiedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_StartRequest;
 class StepAP203_StartRequest : public StepBasic_ActionRequestAssignment {
 	public:
@@ -3244,6 +3429,11 @@ class Handle_StepAP203_StartRequest : public Handle_StepBasic_ActionRequestAssig
     }
 };
 
+%extend StepAP203_StartRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_StartRequestItem;
 class StepAP203_StartRequestItem : public StepData_SelectType {
 	public:
@@ -3270,6 +3460,11 @@ class StepAP203_StartRequestItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_StartRequestItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_StartWork;
 class StepAP203_StartWork : public StepBasic_ActionAssignment {
 	public:
@@ -3352,6 +3547,11 @@ class Handle_StepAP203_StartWork : public Handle_StepBasic_ActionAssignment {
     }
 };
 
+%extend StepAP203_StartWork {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP203_WorkItem;
 class StepAP203_WorkItem : public StepData_SelectType {
 	public:
@@ -3378,3 +3578,8 @@ class StepAP203_WorkItem : public StepData_SelectType {
 };
 
 
+%extend StepAP203_WorkItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepAP209.i
+++ b/src/SWIG_files/wrapper/StepAP209.i
@@ -248,3 +248,8 @@ class StepAP209_Construct : public STEPConstruct_Tool {
 };
 
 
+%extend StepAP209_Construct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepAP214.i
+++ b/src/SWIG_files/wrapper/StepAP214.i
@@ -68,6 +68,11 @@ class StepAP214 {
 };
 
 
+%extend StepAP214 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedApprovalAssignment;
 class StepAP214_AppliedApprovalAssignment : public StepBasic_ApprovalAssignment {
 	public:
@@ -160,6 +165,11 @@ class Handle_StepAP214_AppliedApprovalAssignment : public Handle_StepBasic_Appro
     }
 };
 
+%extend StepAP214_AppliedApprovalAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedDateAndTimeAssignment;
 class StepAP214_AppliedDateAndTimeAssignment : public StepBasic_DateAndTimeAssignment {
 	public:
@@ -256,6 +266,11 @@ class Handle_StepAP214_AppliedDateAndTimeAssignment : public Handle_StepBasic_Da
     }
 };
 
+%extend StepAP214_AppliedDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedDateAssignment;
 class StepAP214_AppliedDateAssignment : public StepBasic_DateAssignment {
 	public:
@@ -352,6 +367,11 @@ class Handle_StepAP214_AppliedDateAssignment : public Handle_StepBasic_DateAssig
     }
 };
 
+%extend StepAP214_AppliedDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedDocumentReference;
 class StepAP214_AppliedDocumentReference : public StepBasic_DocumentReference {
 	public:
@@ -438,6 +458,11 @@ class Handle_StepAP214_AppliedDocumentReference : public Handle_StepBasic_Docume
     }
 };
 
+%extend StepAP214_AppliedDocumentReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedExternalIdentificationAssignment;
 class StepAP214_AppliedExternalIdentificationAssignment : public StepBasic_ExternalIdentificationAssignment {
 	public:
@@ -524,6 +549,11 @@ class Handle_StepAP214_AppliedExternalIdentificationAssignment : public Handle_S
     }
 };
 
+%extend StepAP214_AppliedExternalIdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedGroupAssignment;
 class StepAP214_AppliedGroupAssignment : public StepBasic_GroupAssignment {
 	public:
@@ -606,6 +636,11 @@ class Handle_StepAP214_AppliedGroupAssignment : public Handle_StepBasic_GroupAss
     }
 };
 
+%extend StepAP214_AppliedGroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedOrganizationAssignment;
 class StepAP214_AppliedOrganizationAssignment : public StepBasic_OrganizationAssignment {
 	public:
@@ -702,6 +737,11 @@ class Handle_StepAP214_AppliedOrganizationAssignment : public Handle_StepBasic_O
     }
 };
 
+%extend StepAP214_AppliedOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedPersonAndOrganizationAssignment;
 class StepAP214_AppliedPersonAndOrganizationAssignment : public StepBasic_PersonAndOrganizationAssignment {
 	public:
@@ -798,6 +838,11 @@ class Handle_StepAP214_AppliedPersonAndOrganizationAssignment : public Handle_St
     }
 };
 
+%extend StepAP214_AppliedPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedPresentedItem;
 class StepAP214_AppliedPresentedItem : public StepVisual_PresentedItem {
 	public:
@@ -882,6 +927,11 @@ class Handle_StepAP214_AppliedPresentedItem : public Handle_StepVisual_Presented
     }
 };
 
+%extend StepAP214_AppliedPresentedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AppliedSecurityClassificationAssignment;
 class StepAP214_AppliedSecurityClassificationAssignment : public StepBasic_SecurityClassificationAssignment {
 	public:
@@ -974,6 +1024,11 @@ class Handle_StepAP214_AppliedSecurityClassificationAssignment : public Handle_S
     }
 };
 
+%extend StepAP214_AppliedSecurityClassificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_ApprovalItem;
 class StepAP214_ApprovalItem : public StepData_SelectType {
 	public:
@@ -1066,6 +1121,11 @@ class StepAP214_ApprovalItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_ApprovalItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfApprovalItem;
 class StepAP214_Array1OfApprovalItem {
 	public:
@@ -1148,6 +1208,11 @@ class StepAP214_Array1OfApprovalItem {
 };
 
 
+%extend StepAP214_Array1OfApprovalItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignDateAndPersonItem;
 class StepAP214_Array1OfAutoDesignDateAndPersonItem {
 	public:
@@ -1230,6 +1295,11 @@ class StepAP214_Array1OfAutoDesignDateAndPersonItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignDateAndPersonItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignDateAndTimeItem;
 class StepAP214_Array1OfAutoDesignDateAndTimeItem {
 	public:
@@ -1312,6 +1382,11 @@ class StepAP214_Array1OfAutoDesignDateAndTimeItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignDateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignDatedItem;
 class StepAP214_Array1OfAutoDesignDatedItem {
 	public:
@@ -1394,6 +1469,11 @@ class StepAP214_Array1OfAutoDesignDatedItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignDatedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignGeneralOrgItem;
 class StepAP214_Array1OfAutoDesignGeneralOrgItem {
 	public:
@@ -1476,6 +1556,11 @@ class StepAP214_Array1OfAutoDesignGeneralOrgItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignGeneralOrgItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignGroupedItem;
 class StepAP214_Array1OfAutoDesignGroupedItem {
 	public:
@@ -1558,6 +1643,11 @@ class StepAP214_Array1OfAutoDesignGroupedItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignGroupedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignPresentedItemSelect;
 class StepAP214_Array1OfAutoDesignPresentedItemSelect {
 	public:
@@ -1640,6 +1730,11 @@ class StepAP214_Array1OfAutoDesignPresentedItemSelect {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignPresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfAutoDesignReferencingItem;
 class StepAP214_Array1OfAutoDesignReferencingItem {
 	public:
@@ -1722,6 +1817,11 @@ class StepAP214_Array1OfAutoDesignReferencingItem {
 };
 
 
+%extend StepAP214_Array1OfAutoDesignReferencingItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfDateAndTimeItem;
 class StepAP214_Array1OfDateAndTimeItem {
 	public:
@@ -1804,6 +1904,11 @@ class StepAP214_Array1OfDateAndTimeItem {
 };
 
 
+%extend StepAP214_Array1OfDateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfDateItem;
 class StepAP214_Array1OfDateItem {
 	public:
@@ -1886,6 +1991,11 @@ class StepAP214_Array1OfDateItem {
 };
 
 
+%extend StepAP214_Array1OfDateItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfDocumentReferenceItem;
 class StepAP214_Array1OfDocumentReferenceItem {
 	public:
@@ -1968,6 +2078,11 @@ class StepAP214_Array1OfDocumentReferenceItem {
 };
 
 
+%extend StepAP214_Array1OfDocumentReferenceItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfExternalIdentificationItem;
 class StepAP214_Array1OfExternalIdentificationItem {
 	public:
@@ -2050,6 +2165,11 @@ class StepAP214_Array1OfExternalIdentificationItem {
 };
 
 
+%extend StepAP214_Array1OfExternalIdentificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfGroupItem;
 class StepAP214_Array1OfGroupItem {
 	public:
@@ -2132,6 +2252,11 @@ class StepAP214_Array1OfGroupItem {
 };
 
 
+%extend StepAP214_Array1OfGroupItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfOrganizationItem;
 class StepAP214_Array1OfOrganizationItem {
 	public:
@@ -2214,6 +2339,11 @@ class StepAP214_Array1OfOrganizationItem {
 };
 
 
+%extend StepAP214_Array1OfOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfPersonAndOrganizationItem;
 class StepAP214_Array1OfPersonAndOrganizationItem {
 	public:
@@ -2296,6 +2426,11 @@ class StepAP214_Array1OfPersonAndOrganizationItem {
 };
 
 
+%extend StepAP214_Array1OfPersonAndOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfPresentedItemSelect;
 class StepAP214_Array1OfPresentedItemSelect {
 	public:
@@ -2378,6 +2513,11 @@ class StepAP214_Array1OfPresentedItemSelect {
 };
 
 
+%extend StepAP214_Array1OfPresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Array1OfSecurityClassificationItem;
 class StepAP214_Array1OfSecurityClassificationItem {
 	public:
@@ -2460,6 +2600,11 @@ class StepAP214_Array1OfSecurityClassificationItem {
 };
 
 
+%extend StepAP214_Array1OfSecurityClassificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignActualDateAndTimeAssignment;
 class StepAP214_AutoDesignActualDateAndTimeAssignment : public StepBasic_DateAndTimeAssignment {
 	public:
@@ -2556,6 +2701,11 @@ class Handle_StepAP214_AutoDesignActualDateAndTimeAssignment : public Handle_Ste
     }
 };
 
+%extend StepAP214_AutoDesignActualDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignActualDateAssignment;
 class StepAP214_AutoDesignActualDateAssignment : public StepBasic_DateAssignment {
 	public:
@@ -2652,6 +2802,11 @@ class Handle_StepAP214_AutoDesignActualDateAssignment : public Handle_StepBasic_
     }
 };
 
+%extend StepAP214_AutoDesignActualDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignApprovalAssignment;
 class StepAP214_AutoDesignApprovalAssignment : public StepBasic_ApprovalAssignment {
 	public:
@@ -2744,6 +2899,11 @@ class Handle_StepAP214_AutoDesignApprovalAssignment : public Handle_StepBasic_Ap
     }
 };
 
+%extend StepAP214_AutoDesignApprovalAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignDateAndPersonAssignment;
 class StepAP214_AutoDesignDateAndPersonAssignment : public StepBasic_PersonAndOrganizationAssignment {
 	public:
@@ -2840,6 +3000,11 @@ class Handle_StepAP214_AutoDesignDateAndPersonAssignment : public Handle_StepBas
     }
 };
 
+%extend StepAP214_AutoDesignDateAndPersonAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignDateAndPersonItem;
 class StepAP214_AutoDesignDateAndPersonItem : public StepData_SelectType {
 	public:
@@ -2896,6 +3061,11 @@ class StepAP214_AutoDesignDateAndPersonItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignDateAndPersonItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignDateAndTimeItem;
 class StepAP214_AutoDesignDateAndTimeItem : public StepData_SelectType {
 	public:
@@ -2932,6 +3102,11 @@ class StepAP214_AutoDesignDateAndTimeItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignDateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignDatedItem;
 class StepAP214_AutoDesignDatedItem : public StepData_SelectType {
 	public:
@@ -2970,6 +3145,11 @@ class StepAP214_AutoDesignDatedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignDatedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignDocumentReference;
 class StepAP214_AutoDesignDocumentReference : public StepBasic_DocumentReference {
 	public:
@@ -3056,6 +3236,11 @@ class Handle_StepAP214_AutoDesignDocumentReference : public Handle_StepBasic_Doc
     }
 };
 
+%extend StepAP214_AutoDesignDocumentReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignGeneralOrgItem;
 class StepAP214_AutoDesignGeneralOrgItem : public StepData_SelectType {
 	public:
@@ -3122,6 +3307,11 @@ class StepAP214_AutoDesignGeneralOrgItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignGeneralOrgItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignGroupAssignment;
 class StepAP214_AutoDesignGroupAssignment : public StepBasic_GroupAssignment {
 	public:
@@ -3208,6 +3398,11 @@ class Handle_StepAP214_AutoDesignGroupAssignment : public Handle_StepBasic_Group
     }
 };
 
+%extend StepAP214_AutoDesignGroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignGroupedItem;
 class StepAP214_AutoDesignGroupedItem : public StepData_SelectType {
 	public:
@@ -3294,6 +3489,11 @@ class StepAP214_AutoDesignGroupedItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignGroupedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignNominalDateAndTimeAssignment;
 class StepAP214_AutoDesignNominalDateAndTimeAssignment : public StepBasic_DateAndTimeAssignment {
 	public:
@@ -3390,6 +3590,11 @@ class Handle_StepAP214_AutoDesignNominalDateAndTimeAssignment : public Handle_St
     }
 };
 
+%extend StepAP214_AutoDesignNominalDateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignNominalDateAssignment;
 class StepAP214_AutoDesignNominalDateAssignment : public StepBasic_DateAssignment {
 	public:
@@ -3486,6 +3691,11 @@ class Handle_StepAP214_AutoDesignNominalDateAssignment : public Handle_StepBasic
     }
 };
 
+%extend StepAP214_AutoDesignNominalDateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignOrganizationAssignment;
 class StepAP214_AutoDesignOrganizationAssignment : public StepBasic_OrganizationAssignment {
 	public:
@@ -3582,6 +3792,11 @@ class Handle_StepAP214_AutoDesignOrganizationAssignment : public Handle_StepBasi
     }
 };
 
+%extend StepAP214_AutoDesignOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignPersonAndOrganizationAssignment;
 class StepAP214_AutoDesignPersonAndOrganizationAssignment : public StepBasic_PersonAndOrganizationAssignment {
 	public:
@@ -3678,6 +3893,11 @@ class Handle_StepAP214_AutoDesignPersonAndOrganizationAssignment : public Handle
     }
 };
 
+%extend StepAP214_AutoDesignPersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignPresentedItem;
 class StepAP214_AutoDesignPresentedItem : public StepVisual_PresentedItem {
 	public:
@@ -3762,6 +3982,11 @@ class Handle_StepAP214_AutoDesignPresentedItem : public Handle_StepVisual_Presen
     }
 };
 
+%extend StepAP214_AutoDesignPresentedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignPresentedItemSelect;
 class StepAP214_AutoDesignPresentedItemSelect : public StepData_SelectType {
 	public:
@@ -3818,6 +4043,11 @@ class StepAP214_AutoDesignPresentedItemSelect : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignPresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignReferencingItem;
 class StepAP214_AutoDesignReferencingItem : public StepData_SelectType {
 	public:
@@ -3894,6 +4124,11 @@ class StepAP214_AutoDesignReferencingItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_AutoDesignReferencingItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignSecurityClassificationAssignment;
 class StepAP214_AutoDesignSecurityClassificationAssignment : public StepBasic_SecurityClassificationAssignment {
 	public:
@@ -3986,6 +4221,11 @@ class Handle_StepAP214_AutoDesignSecurityClassificationAssignment : public Handl
     }
 };
 
+%extend StepAP214_AutoDesignSecurityClassificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Class;
 class StepAP214_Class : public StepBasic_Group {
 	public:
@@ -4044,6 +4284,11 @@ class Handle_StepAP214_Class : public Handle_StepBasic_Group {
     }
 };
 
+%extend StepAP214_Class {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_DocumentReferenceItem;
 class StepAP214_DocumentReferenceItem : public StepData_SelectType {
 	public:
@@ -4118,6 +4363,11 @@ class StepAP214_DocumentReferenceItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_DocumentReferenceItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_ExternalIdentificationItem;
 class StepAP214_ExternalIdentificationItem : public StepData_SelectType {
 	public:
@@ -4162,6 +4412,11 @@ class StepAP214_ExternalIdentificationItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_ExternalIdentificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_ExternallyDefinedGeneralProperty;
 class StepAP214_ExternallyDefinedGeneralProperty : public StepBasic_GeneralProperty {
 	public:
@@ -4252,6 +4507,11 @@ class Handle_StepAP214_ExternallyDefinedGeneralProperty : public Handle_StepBasi
     }
 };
 
+%extend StepAP214_ExternallyDefinedGeneralProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_GroupItem;
 class StepAP214_GroupItem : public StepData_SelectType {
 	public:
@@ -4278,6 +4538,11 @@ class StepAP214_GroupItem : public StepData_SelectType {
 };
 
 
+%extend StepAP214_GroupItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfApprovalItem;
 class StepAP214_HArray1OfApprovalItem : public MMgt_TShared {
 	public:
@@ -4394,6 +4659,11 @@ class Handle_StepAP214_HArray1OfApprovalItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP214_HArray1OfApprovalItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignDateAndPersonItem;
 class StepAP214_HArray1OfAutoDesignDateAndPersonItem : public MMgt_TShared {
 	public:
@@ -4510,6 +4780,11 @@ class Handle_StepAP214_HArray1OfAutoDesignDateAndPersonItem : public Handle_MMgt
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignDateAndPersonItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignDateAndTimeItem;
 class StepAP214_HArray1OfAutoDesignDateAndTimeItem : public MMgt_TShared {
 	public:
@@ -4626,6 +4901,11 @@ class Handle_StepAP214_HArray1OfAutoDesignDateAndTimeItem : public Handle_MMgt_T
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignDateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignDatedItem;
 class StepAP214_HArray1OfAutoDesignDatedItem : public MMgt_TShared {
 	public:
@@ -4742,6 +5022,11 @@ class Handle_StepAP214_HArray1OfAutoDesignDatedItem : public Handle_MMgt_TShared
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignDatedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignGeneralOrgItem;
 class StepAP214_HArray1OfAutoDesignGeneralOrgItem : public MMgt_TShared {
 	public:
@@ -4858,6 +5143,11 @@ class Handle_StepAP214_HArray1OfAutoDesignGeneralOrgItem : public Handle_MMgt_TS
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignGeneralOrgItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignGroupedItem;
 class StepAP214_HArray1OfAutoDesignGroupedItem : public MMgt_TShared {
 	public:
@@ -4974,6 +5264,11 @@ class Handle_StepAP214_HArray1OfAutoDesignGroupedItem : public Handle_MMgt_TShar
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignGroupedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignPresentedItemSelect;
 class StepAP214_HArray1OfAutoDesignPresentedItemSelect : public MMgt_TShared {
 	public:
@@ -5090,6 +5385,11 @@ class Handle_StepAP214_HArray1OfAutoDesignPresentedItemSelect : public Handle_MM
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignPresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfAutoDesignReferencingItem;
 class StepAP214_HArray1OfAutoDesignReferencingItem : public MMgt_TShared {
 	public:
@@ -5206,6 +5506,11 @@ class Handle_StepAP214_HArray1OfAutoDesignReferencingItem : public Handle_MMgt_T
     }
 };
 
+%extend StepAP214_HArray1OfAutoDesignReferencingItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfDateAndTimeItem;
 class StepAP214_HArray1OfDateAndTimeItem : public MMgt_TShared {
 	public:
@@ -5322,6 +5627,11 @@ class Handle_StepAP214_HArray1OfDateAndTimeItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP214_HArray1OfDateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfDateItem;
 class StepAP214_HArray1OfDateItem : public MMgt_TShared {
 	public:
@@ -5438,6 +5748,11 @@ class Handle_StepAP214_HArray1OfDateItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP214_HArray1OfDateItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfDocumentReferenceItem;
 class StepAP214_HArray1OfDocumentReferenceItem : public MMgt_TShared {
 	public:
@@ -5554,6 +5869,11 @@ class Handle_StepAP214_HArray1OfDocumentReferenceItem : public Handle_MMgt_TShar
     }
 };
 
+%extend StepAP214_HArray1OfDocumentReferenceItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfExternalIdentificationItem;
 class StepAP214_HArray1OfExternalIdentificationItem : public MMgt_TShared {
 	public:
@@ -5670,6 +5990,11 @@ class Handle_StepAP214_HArray1OfExternalIdentificationItem : public Handle_MMgt_
     }
 };
 
+%extend StepAP214_HArray1OfExternalIdentificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfGroupItem;
 class StepAP214_HArray1OfGroupItem : public MMgt_TShared {
 	public:
@@ -5786,6 +6111,11 @@ class Handle_StepAP214_HArray1OfGroupItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP214_HArray1OfGroupItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfOrganizationItem;
 class StepAP214_HArray1OfOrganizationItem : public MMgt_TShared {
 	public:
@@ -5902,6 +6232,11 @@ class Handle_StepAP214_HArray1OfOrganizationItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepAP214_HArray1OfOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfPersonAndOrganizationItem;
 class StepAP214_HArray1OfPersonAndOrganizationItem : public MMgt_TShared {
 	public:
@@ -6018,6 +6353,11 @@ class Handle_StepAP214_HArray1OfPersonAndOrganizationItem : public Handle_MMgt_T
     }
 };
 
+%extend StepAP214_HArray1OfPersonAndOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfPresentedItemSelect;
 class StepAP214_HArray1OfPresentedItemSelect : public MMgt_TShared {
 	public:
@@ -6134,6 +6474,11 @@ class Handle_StepAP214_HArray1OfPresentedItemSelect : public Handle_MMgt_TShared
     }
 };
 
+%extend StepAP214_HArray1OfPresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_HArray1OfSecurityClassificationItem;
 class StepAP214_HArray1OfSecurityClassificationItem : public MMgt_TShared {
 	public:
@@ -6250,6 +6595,11 @@ class Handle_StepAP214_HArray1OfSecurityClassificationItem : public Handle_MMgt_
     }
 };
 
+%extend StepAP214_HArray1OfSecurityClassificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_PresentedItemSelect;
 class StepAP214_PresentedItemSelect : public StepData_SelectType {
 	public:
@@ -6282,6 +6632,11 @@ class StepAP214_PresentedItemSelect : public StepData_SelectType {
 };
 
 
+%extend StepAP214_PresentedItemSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_Protocol;
 class StepAP214_Protocol : public StepData_Protocol {
 	public:
@@ -6364,6 +6719,11 @@ class Handle_StepAP214_Protocol : public Handle_StepData_Protocol {
     }
 };
 
+%extend StepAP214_Protocol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_RepItemGroup;
 class StepAP214_RepItemGroup : public StepBasic_Group {
 	public:
@@ -6450,6 +6810,11 @@ class Handle_StepAP214_RepItemGroup : public Handle_StepBasic_Group {
     }
 };
 
+%extend StepAP214_RepItemGroup {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_AutoDesignOrganizationItem;
 class StepAP214_AutoDesignOrganizationItem : public StepAP214_AutoDesignGeneralOrgItem {
 	public:
@@ -6474,6 +6839,11 @@ class StepAP214_AutoDesignOrganizationItem : public StepAP214_AutoDesignGeneralO
 };
 
 
+%extend StepAP214_AutoDesignOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_DateAndTimeItem;
 class StepAP214_DateAndTimeItem : public StepAP214_ApprovalItem {
 	public:
@@ -6518,6 +6888,11 @@ class StepAP214_DateAndTimeItem : public StepAP214_ApprovalItem {
 };
 
 
+%extend StepAP214_DateAndTimeItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_DateItem;
 class StepAP214_DateItem : public StepAP214_ApprovalItem {
 	public:
@@ -6562,6 +6937,11 @@ class StepAP214_DateItem : public StepAP214_ApprovalItem {
 };
 
 
+%extend StepAP214_DateItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_ExternallyDefinedClass;
 class StepAP214_ExternallyDefinedClass : public StepAP214_Class {
 	public:
@@ -6650,6 +7030,11 @@ class Handle_StepAP214_ExternallyDefinedClass : public Handle_StepAP214_Class {
     }
 };
 
+%extend StepAP214_ExternallyDefinedClass {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_OrganizationItem;
 class StepAP214_OrganizationItem : public StepAP214_ApprovalItem {
 	public:
@@ -6682,6 +7067,11 @@ class StepAP214_OrganizationItem : public StepAP214_ApprovalItem {
 };
 
 
+%extend StepAP214_OrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_PersonAndOrganizationItem;
 class StepAP214_PersonAndOrganizationItem : public StepAP214_ApprovalItem {
 	public:
@@ -6708,6 +7098,11 @@ class StepAP214_PersonAndOrganizationItem : public StepAP214_ApprovalItem {
 };
 
 
+%extend StepAP214_PersonAndOrganizationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepAP214_SecurityClassificationItem;
 class StepAP214_SecurityClassificationItem : public StepAP214_ApprovalItem {
 	public:
@@ -6720,3 +7115,8 @@ class StepAP214_SecurityClassificationItem : public StepAP214_ApprovalItem {
 };
 
 
+%extend StepAP214_SecurityClassificationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepBasic.i
+++ b/src/SWIG_files/wrapper/StepBasic.i
@@ -238,6 +238,11 @@ class Handle_StepBasic_Action : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Action {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ActionAssignment;
 class StepBasic_ActionAssignment : public MMgt_TShared {
 	public:
@@ -318,6 +323,11 @@ class Handle_StepBasic_ActionAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ActionAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ActionMethod;
 class StepBasic_ActionMethod : public MMgt_TShared {
 	public:
@@ -454,6 +464,11 @@ class Handle_StepBasic_ActionMethod : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ActionMethod {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ActionRequestAssignment;
 class StepBasic_ActionRequestAssignment : public MMgt_TShared {
 	public:
@@ -534,6 +549,11 @@ class Handle_StepBasic_ActionRequestAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ActionRequestAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ActionRequestSolution;
 class StepBasic_ActionRequestSolution : public MMgt_TShared {
 	public:
@@ -630,6 +650,11 @@ class Handle_StepBasic_ActionRequestSolution : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ActionRequestSolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Address;
 class StepBasic_Address : public MMgt_TShared {
 	public:
@@ -956,6 +981,11 @@ class Handle_StepBasic_Address : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Address {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApplicationContext;
 class StepBasic_ApplicationContext : public MMgt_TShared {
 	public:
@@ -1030,6 +1060,11 @@ class Handle_StepBasic_ApplicationContext : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApplicationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApplicationContextElement;
 class StepBasic_ApplicationContextElement : public MMgt_TShared {
 	public:
@@ -1116,6 +1151,11 @@ class Handle_StepBasic_ApplicationContextElement : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApplicationContextElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApplicationProtocolDefinition;
 class StepBasic_ApplicationProtocolDefinition : public MMgt_TShared {
 	public:
@@ -1226,6 +1266,11 @@ class Handle_StepBasic_ApplicationProtocolDefinition : public Handle_MMgt_TShare
     }
 };
 
+%extend StepBasic_ApplicationProtocolDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Approval;
 class StepBasic_Approval : public MMgt_TShared {
 	public:
@@ -1312,6 +1357,11 @@ class Handle_StepBasic_Approval : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Approval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalAssignment;
 class StepBasic_ApprovalAssignment : public MMgt_TShared {
 	public:
@@ -1380,6 +1430,11 @@ class Handle_StepBasic_ApprovalAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalDateTime;
 class StepBasic_ApprovalDateTime : public MMgt_TShared {
 	public:
@@ -1464,6 +1519,11 @@ class Handle_StepBasic_ApprovalDateTime : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalDateTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalPersonOrganization;
 class StepBasic_ApprovalPersonOrganization : public MMgt_TShared {
 	public:
@@ -1562,6 +1622,11 @@ class Handle_StepBasic_ApprovalPersonOrganization : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalPersonOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalRelationship;
 class StepBasic_ApprovalRelationship : public MMgt_TShared {
 	public:
@@ -1672,6 +1737,11 @@ class Handle_StepBasic_ApprovalRelationship : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalRole;
 class StepBasic_ApprovalRole : public MMgt_TShared {
 	public:
@@ -1746,6 +1816,11 @@ class Handle_StepBasic_ApprovalRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ApprovalStatus;
 class StepBasic_ApprovalStatus : public MMgt_TShared {
 	public:
@@ -1820,6 +1895,11 @@ class Handle_StepBasic_ApprovalStatus : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ApprovalStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfApproval;
 class StepBasic_Array1OfApproval {
 	public:
@@ -1902,6 +1982,11 @@ class StepBasic_Array1OfApproval {
 };
 
 
+%extend StepBasic_Array1OfApproval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfDerivedUnitElement;
 class StepBasic_Array1OfDerivedUnitElement {
 	public:
@@ -1984,6 +2069,11 @@ class StepBasic_Array1OfDerivedUnitElement {
 };
 
 
+%extend StepBasic_Array1OfDerivedUnitElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfDocument;
 class StepBasic_Array1OfDocument {
 	public:
@@ -2066,6 +2156,11 @@ class StepBasic_Array1OfDocument {
 };
 
 
+%extend StepBasic_Array1OfDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfNamedUnit;
 class StepBasic_Array1OfNamedUnit {
 	public:
@@ -2148,6 +2243,11 @@ class StepBasic_Array1OfNamedUnit {
 };
 
 
+%extend StepBasic_Array1OfNamedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfOrganization;
 class StepBasic_Array1OfOrganization {
 	public:
@@ -2230,6 +2330,11 @@ class StepBasic_Array1OfOrganization {
 };
 
 
+%extend StepBasic_Array1OfOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfPerson;
 class StepBasic_Array1OfPerson {
 	public:
@@ -2312,6 +2417,11 @@ class StepBasic_Array1OfPerson {
 };
 
 
+%extend StepBasic_Array1OfPerson {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfProduct;
 class StepBasic_Array1OfProduct {
 	public:
@@ -2394,6 +2504,11 @@ class StepBasic_Array1OfProduct {
 };
 
 
+%extend StepBasic_Array1OfProduct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfProductContext;
 class StepBasic_Array1OfProductContext {
 	public:
@@ -2476,6 +2591,11 @@ class StepBasic_Array1OfProductContext {
 };
 
 
+%extend StepBasic_Array1OfProductContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfProductDefinition;
 class StepBasic_Array1OfProductDefinition {
 	public:
@@ -2558,6 +2678,11 @@ class StepBasic_Array1OfProductDefinition {
 };
 
 
+%extend StepBasic_Array1OfProductDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Array1OfUncertaintyMeasureWithUnit;
 class StepBasic_Array1OfUncertaintyMeasureWithUnit {
 	public:
@@ -2640,6 +2765,11 @@ class StepBasic_Array1OfUncertaintyMeasureWithUnit {
 };
 
 
+%extend StepBasic_Array1OfUncertaintyMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Certification;
 class StepBasic_Certification : public MMgt_TShared {
 	public:
@@ -2752,6 +2882,11 @@ class Handle_StepBasic_Certification : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Certification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_CertificationAssignment;
 class StepBasic_CertificationAssignment : public MMgt_TShared {
 	public:
@@ -2832,6 +2967,11 @@ class Handle_StepBasic_CertificationAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_CertificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_CertificationType;
 class StepBasic_CertificationType : public MMgt_TShared {
 	public:
@@ -2912,6 +3052,11 @@ class Handle_StepBasic_CertificationType : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_CertificationType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_CharacterizedObject;
 class StepBasic_CharacterizedObject : public MMgt_TShared {
 	public:
@@ -3016,6 +3161,11 @@ class Handle_StepBasic_CharacterizedObject : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_CharacterizedObject {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Contract;
 class StepBasic_Contract : public MMgt_TShared {
 	public:
@@ -3128,6 +3278,11 @@ class Handle_StepBasic_Contract : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Contract {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ContractAssignment;
 class StepBasic_ContractAssignment : public MMgt_TShared {
 	public:
@@ -3208,6 +3363,11 @@ class Handle_StepBasic_ContractAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ContractAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ContractType;
 class StepBasic_ContractType : public MMgt_TShared {
 	public:
@@ -3288,6 +3448,11 @@ class Handle_StepBasic_ContractType : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ContractType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_CoordinatedUniversalTimeOffset;
 class StepBasic_CoordinatedUniversalTimeOffset : public MMgt_TShared {
 	public:
@@ -3396,6 +3561,11 @@ class Handle_StepBasic_CoordinatedUniversalTimeOffset : public Handle_MMgt_TShar
     }
 };
 
+%extend StepBasic_CoordinatedUniversalTimeOffset {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Date;
 class StepBasic_Date : public MMgt_TShared {
 	public:
@@ -3470,6 +3640,11 @@ class Handle_StepBasic_Date : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Date {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateAndTime;
 class StepBasic_DateAndTime : public MMgt_TShared {
 	public:
@@ -3556,6 +3731,11 @@ class Handle_StepBasic_DateAndTime : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DateAndTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateAndTimeAssignment;
 class StepBasic_DateAndTimeAssignment : public MMgt_TShared {
 	public:
@@ -3636,6 +3816,11 @@ class Handle_StepBasic_DateAndTimeAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DateAndTimeAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateAssignment;
 class StepBasic_DateAssignment : public MMgt_TShared {
 	public:
@@ -3716,6 +3901,11 @@ class Handle_StepBasic_DateAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DateAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateRole;
 class StepBasic_DateRole : public MMgt_TShared {
 	public:
@@ -3790,6 +3980,11 @@ class Handle_StepBasic_DateRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DateRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateTimeRole;
 class StepBasic_DateTimeRole : public MMgt_TShared {
 	public:
@@ -3864,6 +4059,11 @@ class Handle_StepBasic_DateTimeRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DateTimeRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DateTimeSelect;
 class StepBasic_DateTimeSelect : public StepData_SelectType {
 	public:
@@ -3902,6 +4102,11 @@ class StepBasic_DateTimeSelect : public StepData_SelectType {
 };
 
 
+%extend StepBasic_DateTimeSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DerivedUnit;
 class StepBasic_DerivedUnit : public MMgt_TShared {
 	public:
@@ -3984,6 +4189,11 @@ class Handle_StepBasic_DerivedUnit : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DerivedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DerivedUnitElement;
 class StepBasic_DerivedUnitElement : public MMgt_TShared {
 	public:
@@ -4068,6 +4278,11 @@ class Handle_StepBasic_DerivedUnitElement : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DerivedUnitElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DimensionalExponents;
 class StepBasic_DimensionalExponents : public MMgt_TShared {
 	public:
@@ -4214,6 +4429,11 @@ class Handle_StepBasic_DimensionalExponents : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DimensionalExponents {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Document;
 class StepBasic_Document : public MMgt_TShared {
 	public:
@@ -4350,6 +4570,11 @@ class Handle_StepBasic_Document : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Document {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentProductAssociation;
 class StepBasic_DocumentProductAssociation : public MMgt_TShared {
 	public:
@@ -4486,6 +4711,11 @@ class Handle_StepBasic_DocumentProductAssociation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentProductAssociation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentReference;
 class StepBasic_DocumentReference : public MMgt_TShared {
 	public:
@@ -4566,6 +4796,11 @@ class Handle_StepBasic_DocumentReference : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentReference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentRelationship;
 class StepBasic_DocumentRelationship : public MMgt_TShared {
 	public:
@@ -4674,6 +4909,11 @@ class Handle_StepBasic_DocumentRelationship : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentRepresentationType;
 class StepBasic_DocumentRepresentationType : public MMgt_TShared {
 	public:
@@ -4770,6 +5010,11 @@ class Handle_StepBasic_DocumentRepresentationType : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentRepresentationType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentType;
 class StepBasic_DocumentType : public MMgt_TShared {
 	public:
@@ -4842,6 +5087,11 @@ class Handle_StepBasic_DocumentType : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentUsageConstraint;
 class StepBasic_DocumentUsageConstraint : public MMgt_TShared {
 	public:
@@ -4938,6 +5188,11 @@ class Handle_StepBasic_DocumentUsageConstraint : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_DocumentUsageConstraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Effectivity;
 class StepBasic_Effectivity : public MMgt_TShared {
 	public:
@@ -5010,6 +5265,11 @@ class Handle_StepBasic_Effectivity : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Effectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_EffectivityAssignment;
 class StepBasic_EffectivityAssignment : public MMgt_TShared {
 	public:
@@ -5090,6 +5350,11 @@ class Handle_StepBasic_EffectivityAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_EffectivityAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_EulerAngles;
 class StepBasic_EulerAngles : public MMgt_TShared {
 	public:
@@ -5170,6 +5435,11 @@ class Handle_StepBasic_EulerAngles : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_EulerAngles {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ExternalSource;
 class StepBasic_ExternalSource : public MMgt_TShared {
 	public:
@@ -5250,6 +5520,11 @@ class Handle_StepBasic_ExternalSource : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ExternalSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ExternallyDefinedItem;
 class StepBasic_ExternallyDefinedItem : public MMgt_TShared {
 	public:
@@ -5346,6 +5621,11 @@ class Handle_StepBasic_ExternallyDefinedItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ExternallyDefinedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_GeneralProperty;
 class StepBasic_GeneralProperty : public MMgt_TShared {
 	public:
@@ -5466,6 +5746,11 @@ class Handle_StepBasic_GeneralProperty : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_GeneralProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Group;
 class StepBasic_Group : public MMgt_TShared {
 	public:
@@ -5570,6 +5855,11 @@ class Handle_StepBasic_Group : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Group {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_GroupAssignment;
 class StepBasic_GroupAssignment : public MMgt_TShared {
 	public:
@@ -5650,6 +5940,11 @@ class Handle_StepBasic_GroupAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_GroupAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_GroupRelationship;
 class StepBasic_GroupRelationship : public MMgt_TShared {
 	public:
@@ -5786,6 +6081,11 @@ class Handle_StepBasic_GroupRelationship : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_GroupRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfApproval;
 class StepBasic_HArray1OfApproval : public MMgt_TShared {
 	public:
@@ -5902,6 +6202,11 @@ class Handle_StepBasic_HArray1OfApproval : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfApproval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfDerivedUnitElement;
 class StepBasic_HArray1OfDerivedUnitElement : public MMgt_TShared {
 	public:
@@ -6018,6 +6323,11 @@ class Handle_StepBasic_HArray1OfDerivedUnitElement : public Handle_MMgt_TShared 
     }
 };
 
+%extend StepBasic_HArray1OfDerivedUnitElement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfDocument;
 class StepBasic_HArray1OfDocument : public MMgt_TShared {
 	public:
@@ -6134,6 +6444,11 @@ class Handle_StepBasic_HArray1OfDocument : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfNamedUnit;
 class StepBasic_HArray1OfNamedUnit : public MMgt_TShared {
 	public:
@@ -6250,6 +6565,11 @@ class Handle_StepBasic_HArray1OfNamedUnit : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfNamedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfOrganization;
 class StepBasic_HArray1OfOrganization : public MMgt_TShared {
 	public:
@@ -6366,6 +6686,11 @@ class Handle_StepBasic_HArray1OfOrganization : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfPerson;
 class StepBasic_HArray1OfPerson : public MMgt_TShared {
 	public:
@@ -6482,6 +6807,11 @@ class Handle_StepBasic_HArray1OfPerson : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfPerson {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfProduct;
 class StepBasic_HArray1OfProduct : public MMgt_TShared {
 	public:
@@ -6598,6 +6928,11 @@ class Handle_StepBasic_HArray1OfProduct : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfProduct {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfProductContext;
 class StepBasic_HArray1OfProductContext : public MMgt_TShared {
 	public:
@@ -6714,6 +7049,11 @@ class Handle_StepBasic_HArray1OfProductContext : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfProductContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfProductDefinition;
 class StepBasic_HArray1OfProductDefinition : public MMgt_TShared {
 	public:
@@ -6830,6 +7170,11 @@ class Handle_StepBasic_HArray1OfProductDefinition : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_HArray1OfProductDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_HArray1OfUncertaintyMeasureWithUnit;
 class StepBasic_HArray1OfUncertaintyMeasureWithUnit : public MMgt_TShared {
 	public:
@@ -6946,6 +7291,11 @@ class Handle_StepBasic_HArray1OfUncertaintyMeasureWithUnit : public Handle_MMgt_
     }
 };
 
+%extend StepBasic_HArray1OfUncertaintyMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_IdentificationAssignment;
 class StepBasic_IdentificationAssignment : public MMgt_TShared {
 	public:
@@ -7042,6 +7392,11 @@ class Handle_StepBasic_IdentificationAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_IdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_IdentificationRole;
 class StepBasic_IdentificationRole : public MMgt_TShared {
 	public:
@@ -7146,6 +7501,11 @@ class Handle_StepBasic_IdentificationRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_IdentificationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_LocalTime;
 class StepBasic_LocalTime : public MMgt_TShared {
 	public:
@@ -7276,6 +7636,11 @@ class Handle_StepBasic_LocalTime : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_LocalTime {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_MeasureValueMember;
 class StepBasic_MeasureValueMember : public StepData_SelectReal {
 	public:
@@ -7346,6 +7711,11 @@ class Handle_StepBasic_MeasureValueMember : public Handle_StepData_SelectReal {
     }
 };
 
+%extend StepBasic_MeasureValueMember {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_MeasureWithUnit;
 class StepBasic_MeasureWithUnit : public MMgt_TShared {
 	public:
@@ -7442,6 +7812,11 @@ class Handle_StepBasic_MeasureWithUnit : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_MeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_NameAssignment;
 class StepBasic_NameAssignment : public MMgt_TShared {
 	public:
@@ -7522,6 +7897,11 @@ class Handle_StepBasic_NameAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_NameAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_NamedUnit;
 class StepBasic_NamedUnit : public MMgt_TShared {
 	public:
@@ -7596,6 +7976,11 @@ class Handle_StepBasic_NamedUnit : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_NamedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ObjectRole;
 class StepBasic_ObjectRole : public MMgt_TShared {
 	public:
@@ -7700,6 +8085,11 @@ class Handle_StepBasic_ObjectRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ObjectRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Organization;
 class StepBasic_Organization : public MMgt_TShared {
 	public:
@@ -7808,6 +8198,11 @@ class Handle_StepBasic_Organization : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Organization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_OrganizationAssignment;
 class StepBasic_OrganizationAssignment : public MMgt_TShared {
 	public:
@@ -7888,6 +8283,11 @@ class Handle_StepBasic_OrganizationAssignment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_OrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_OrganizationRole;
 class StepBasic_OrganizationRole : public MMgt_TShared {
 	public:
@@ -7962,6 +8362,11 @@ class Handle_StepBasic_OrganizationRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_OrganizationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Person;
 class StepBasic_Person : public MMgt_TShared {
 	public:
@@ -8176,6 +8581,11 @@ class Handle_StepBasic_Person : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Person {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PersonAndOrganization;
 class StepBasic_PersonAndOrganization : public MMgt_TShared {
 	public:
@@ -8262,6 +8672,11 @@ class Handle_StepBasic_PersonAndOrganization : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_PersonAndOrganization {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PersonAndOrganizationAssignment;
 class StepBasic_PersonAndOrganizationAssignment : public MMgt_TShared {
 	public:
@@ -8342,6 +8757,11 @@ class Handle_StepBasic_PersonAndOrganizationAssignment : public Handle_MMgt_TSha
     }
 };
 
+%extend StepBasic_PersonAndOrganizationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PersonAndOrganizationRole;
 class StepBasic_PersonAndOrganizationRole : public MMgt_TShared {
 	public:
@@ -8416,6 +8836,11 @@ class Handle_StepBasic_PersonAndOrganizationRole : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_PersonAndOrganizationRole {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PersonOrganizationSelect;
 class StepBasic_PersonOrganizationSelect : public StepData_SelectType {
 	public:
@@ -8454,6 +8879,11 @@ class StepBasic_PersonOrganizationSelect : public StepData_SelectType {
 };
 
 
+%extend StepBasic_PersonOrganizationSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Product;
 class StepBasic_Product : public MMgt_TShared {
 	public:
@@ -8574,6 +9004,11 @@ class Handle_StepBasic_Product : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_Product {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductCategory;
 class StepBasic_ProductCategory : public MMgt_TShared {
 	public:
@@ -8670,6 +9105,11 @@ class Handle_StepBasic_ProductCategory : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ProductCategory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductCategoryRelationship;
 class StepBasic_ProductCategoryRelationship : public MMgt_TShared {
 	public:
@@ -8806,6 +9246,11 @@ class Handle_StepBasic_ProductCategoryRelationship : public Handle_MMgt_TShared 
     }
 };
 
+%extend StepBasic_ProductCategoryRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinition;
 class StepBasic_ProductDefinition : public MMgt_TShared {
 	public:
@@ -8916,6 +9361,11 @@ class Handle_StepBasic_ProductDefinition : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ProductDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionFormation;
 class StepBasic_ProductDefinitionFormation : public MMgt_TShared {
 	public:
@@ -9014,6 +9464,11 @@ class Handle_StepBasic_ProductDefinitionFormation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_ProductDefinitionFormation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionFormationRelationship;
 class StepBasic_ProductDefinitionFormationRelationship : public MMgt_TShared {
 	public:
@@ -9158,6 +9613,11 @@ class Handle_StepBasic_ProductDefinitionFormationRelationship : public Handle_MM
     }
 };
 
+%extend StepBasic_ProductDefinitionFormationRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionRelationship;
 class StepBasic_ProductDefinitionRelationship : public MMgt_TShared {
 	public:
@@ -9310,6 +9770,11 @@ class Handle_StepBasic_ProductDefinitionRelationship : public Handle_MMgt_TShare
     }
 };
 
+%extend StepBasic_ProductDefinitionRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductOrFormationOrDefinition;
 class StepBasic_ProductOrFormationOrDefinition : public StepData_SelectType {
 	public:
@@ -9348,6 +9813,11 @@ class StepBasic_ProductOrFormationOrDefinition : public StepData_SelectType {
 };
 
 
+%extend StepBasic_ProductOrFormationOrDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_RoleAssociation;
 class StepBasic_RoleAssociation : public MMgt_TShared {
 	public:
@@ -9444,6 +9914,11 @@ class Handle_StepBasic_RoleAssociation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_RoleAssociation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_RoleSelect;
 class StepBasic_RoleSelect : public StepData_SelectType {
 	public:
@@ -9530,6 +10005,11 @@ class StepBasic_RoleSelect : public StepData_SelectType {
 };
 
 
+%extend StepBasic_RoleSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SecurityClassification;
 class StepBasic_SecurityClassification : public MMgt_TShared {
 	public:
@@ -9628,6 +10108,11 @@ class Handle_StepBasic_SecurityClassification : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_SecurityClassification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SecurityClassificationAssignment;
 class StepBasic_SecurityClassificationAssignment : public MMgt_TShared {
 	public:
@@ -9696,6 +10181,11 @@ class Handle_StepBasic_SecurityClassificationAssignment : public Handle_MMgt_TSh
     }
 };
 
+%extend StepBasic_SecurityClassificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SecurityClassificationLevel;
 class StepBasic_SecurityClassificationLevel : public MMgt_TShared {
 	public:
@@ -9770,6 +10260,11 @@ class Handle_StepBasic_SecurityClassificationLevel : public Handle_MMgt_TShared 
     }
 };
 
+%extend StepBasic_SecurityClassificationLevel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SizeMember;
 class StepBasic_SizeMember : public StepData_SelectReal {
 	public:
@@ -9840,6 +10335,11 @@ class Handle_StepBasic_SizeMember : public Handle_StepData_SelectReal {
     }
 };
 
+%extend StepBasic_SizeMember {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SizeSelect;
 class StepBasic_SizeSelect : public StepData_SelectType {
 	public:
@@ -9886,6 +10386,11 @@ class StepBasic_SizeSelect : public StepData_SelectType {
 };
 
 
+%extend StepBasic_SizeSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SourceItem;
 class StepBasic_SourceItem : public StepData_SelectType {
 	public:
@@ -9916,6 +10421,11 @@ class StepBasic_SourceItem : public StepData_SelectType {
 };
 
 
+%extend StepBasic_SourceItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_Unit;
 class StepBasic_Unit : public StepData_SelectType {
 	public:
@@ -9948,6 +10458,11 @@ class StepBasic_Unit : public StepData_SelectType {
 };
 
 
+%extend StepBasic_Unit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_VersionedActionRequest;
 class StepBasic_VersionedActionRequest : public MMgt_TShared {
 	public:
@@ -10084,6 +10599,11 @@ class Handle_StepBasic_VersionedActionRequest : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepBasic_VersionedActionRequest {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_AreaUnit;
 class StepBasic_AreaUnit : public StepBasic_NamedUnit {
 	public:
@@ -10140,6 +10660,11 @@ class Handle_StepBasic_AreaUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_AreaUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_CalendarDate;
 class StepBasic_CalendarDate : public StepBasic_Date {
 	public:
@@ -10234,6 +10759,11 @@ class Handle_StepBasic_CalendarDate : public Handle_StepBasic_Date {
     }
 };
 
+%extend StepBasic_CalendarDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnit;
 class StepBasic_ConversionBasedUnit : public StepBasic_NamedUnit {
 	public:
@@ -10328,6 +10858,11 @@ class Handle_StepBasic_ConversionBasedUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_ConversionBasedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DigitalDocument;
 class StepBasic_DigitalDocument : public StepBasic_Document {
 	public:
@@ -10384,6 +10919,11 @@ class Handle_StepBasic_DigitalDocument : public Handle_StepBasic_Document {
     }
 };
 
+%extend StepBasic_DigitalDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentFile;
 class StepBasic_DocumentFile : public StepBasic_Document {
 	public:
@@ -10478,6 +11018,11 @@ class Handle_StepBasic_DocumentFile : public Handle_StepBasic_Document {
     }
 };
 
+%extend StepBasic_DocumentFile {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DocumentProductEquivalence;
 class StepBasic_DocumentProductEquivalence : public StepBasic_DocumentProductAssociation {
 	public:
@@ -10536,6 +11081,11 @@ class Handle_StepBasic_DocumentProductEquivalence : public Handle_StepBasic_Docu
     }
 };
 
+%extend StepBasic_DocumentProductEquivalence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ExternalIdentificationAssignment;
 class StepBasic_ExternalIdentificationAssignment : public StepBasic_IdentificationAssignment {
 	public:
@@ -10620,6 +11170,11 @@ class Handle_StepBasic_ExternalIdentificationAssignment : public Handle_StepBasi
     }
 };
 
+%extend StepBasic_ExternalIdentificationAssignment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_LengthMeasureWithUnit;
 class StepBasic_LengthMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -10678,6 +11233,11 @@ class Handle_StepBasic_LengthMeasureWithUnit : public Handle_StepBasic_MeasureWi
     }
 };
 
+%extend StepBasic_LengthMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_LengthUnit;
 class StepBasic_LengthUnit : public StepBasic_NamedUnit {
 	public:
@@ -10736,6 +11296,11 @@ class Handle_StepBasic_LengthUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_LengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_MassMeasureWithUnit;
 class StepBasic_MassMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -10794,6 +11359,11 @@ class Handle_StepBasic_MassMeasureWithUnit : public Handle_StepBasic_MeasureWith
     }
 };
 
+%extend StepBasic_MassMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_MassUnit;
 class StepBasic_MassUnit : public StepBasic_NamedUnit {
 	public:
@@ -10852,6 +11422,11 @@ class Handle_StepBasic_MassUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_MassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_OrdinalDate;
 class StepBasic_OrdinalDate : public StepBasic_Date {
 	public:
@@ -10934,6 +11509,11 @@ class Handle_StepBasic_OrdinalDate : public Handle_StepBasic_Date {
     }
 };
 
+%extend StepBasic_OrdinalDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_OrganizationalAddress;
 class StepBasic_OrganizationalAddress : public StepBasic_Address {
 	public:
@@ -11130,6 +11710,11 @@ class Handle_StepBasic_OrganizationalAddress : public Handle_StepBasic_Address {
     }
 };
 
+%extend StepBasic_OrganizationalAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PersonalAddress;
 class StepBasic_PersonalAddress : public StepBasic_Address {
 	public:
@@ -11326,6 +11911,11 @@ class Handle_StepBasic_PersonalAddress : public Handle_StepBasic_Address {
     }
 };
 
+%extend StepBasic_PersonalAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PhysicallyModeledProductDefinition;
 class StepBasic_PhysicallyModeledProductDefinition : public StepBasic_ProductDefinition {
 	public:
@@ -11382,6 +11972,11 @@ class Handle_StepBasic_PhysicallyModeledProductDefinition : public Handle_StepBa
     }
 };
 
+%extend StepBasic_PhysicallyModeledProductDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PlaneAngleMeasureWithUnit;
 class StepBasic_PlaneAngleMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -11440,6 +12035,11 @@ class Handle_StepBasic_PlaneAngleMeasureWithUnit : public Handle_StepBasic_Measu
     }
 };
 
+%extend StepBasic_PlaneAngleMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_PlaneAngleUnit;
 class StepBasic_PlaneAngleUnit : public StepBasic_NamedUnit {
 	public:
@@ -11498,6 +12098,11 @@ class Handle_StepBasic_PlaneAngleUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_PlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductConceptContext;
 class StepBasic_ProductConceptContext : public StepBasic_ApplicationContextElement {
 	public:
@@ -11582,6 +12187,11 @@ class Handle_StepBasic_ProductConceptContext : public Handle_StepBasic_Applicati
     }
 };
 
+%extend StepBasic_ProductConceptContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductContext;
 class StepBasic_ProductContext : public StepBasic_ApplicationContextElement {
 	public:
@@ -11668,6 +12278,11 @@ class Handle_StepBasic_ProductContext : public Handle_StepBasic_ApplicationConte
     }
 };
 
+%extend StepBasic_ProductContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionContext;
 class StepBasic_ProductDefinitionContext : public StepBasic_ApplicationContextElement {
 	public:
@@ -11754,6 +12369,11 @@ class Handle_StepBasic_ProductDefinitionContext : public Handle_StepBasic_Applic
     }
 };
 
+%extend StepBasic_ProductDefinitionContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionEffectivity;
 class StepBasic_ProductDefinitionEffectivity : public StepBasic_Effectivity {
 	public:
@@ -11828,6 +12448,11 @@ class Handle_StepBasic_ProductDefinitionEffectivity : public Handle_StepBasic_Ef
     }
 };
 
+%extend StepBasic_ProductDefinitionEffectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionFormationWithSpecifiedSource;
 class StepBasic_ProductDefinitionFormationWithSpecifiedSource : public StepBasic_ProductDefinitionFormation {
 	public:
@@ -11918,6 +12543,11 @@ class Handle_StepBasic_ProductDefinitionFormationWithSpecifiedSource : public Ha
     }
 };
 
+%extend StepBasic_ProductDefinitionFormationWithSpecifiedSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductDefinitionWithAssociatedDocuments;
 class StepBasic_ProductDefinitionWithAssociatedDocuments : public StepBasic_ProductDefinition {
 	public:
@@ -12016,6 +12646,11 @@ class Handle_StepBasic_ProductDefinitionWithAssociatedDocuments : public Handle_
     }
 };
 
+%extend StepBasic_ProductDefinitionWithAssociatedDocuments {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductRelatedProductCategory;
 class StepBasic_ProductRelatedProductCategory : public StepBasic_ProductCategory {
 	public:
@@ -12116,6 +12751,11 @@ class Handle_StepBasic_ProductRelatedProductCategory : public Handle_StepBasic_P
     }
 };
 
+%extend StepBasic_ProductRelatedProductCategory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_RatioMeasureWithUnit;
 class StepBasic_RatioMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -12174,6 +12814,11 @@ class Handle_StepBasic_RatioMeasureWithUnit : public Handle_StepBasic_MeasureWit
     }
 };
 
+%extend StepBasic_RatioMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_RatioUnit;
 class StepBasic_RatioUnit : public StepBasic_NamedUnit {
 	public:
@@ -12232,6 +12877,11 @@ class Handle_StepBasic_RatioUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_RatioUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnit;
 class StepBasic_SiUnit : public StepBasic_NamedUnit {
 	public:
@@ -12344,6 +12994,11 @@ class Handle_StepBasic_SiUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_SiUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SolidAngleMeasureWithUnit;
 class StepBasic_SolidAngleMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -12402,6 +13057,11 @@ class Handle_StepBasic_SolidAngleMeasureWithUnit : public Handle_StepBasic_Measu
     }
 };
 
+%extend StepBasic_SolidAngleMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SolidAngleUnit;
 class StepBasic_SolidAngleUnit : public StepBasic_NamedUnit {
 	public:
@@ -12460,6 +13120,11 @@ class Handle_StepBasic_SolidAngleUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_SolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ThermodynamicTemperatureUnit;
 class StepBasic_ThermodynamicTemperatureUnit : public StepBasic_NamedUnit {
 	public:
@@ -12518,6 +13183,11 @@ class Handle_StepBasic_ThermodynamicTemperatureUnit : public Handle_StepBasic_Na
     }
 };
 
+%extend StepBasic_ThermodynamicTemperatureUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_TimeMeasureWithUnit;
 class StepBasic_TimeMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -12576,6 +13246,11 @@ class Handle_StepBasic_TimeMeasureWithUnit : public Handle_StepBasic_MeasureWith
     }
 };
 
+%extend StepBasic_TimeMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_TimeUnit;
 class StepBasic_TimeUnit : public StepBasic_NamedUnit {
 	public:
@@ -12634,6 +13309,11 @@ class Handle_StepBasic_TimeUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_TimeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_UncertaintyMeasureWithUnit;
 class StepBasic_UncertaintyMeasureWithUnit : public StepBasic_MeasureWithUnit {
 	public:
@@ -12732,6 +13412,11 @@ class Handle_StepBasic_UncertaintyMeasureWithUnit : public Handle_StepBasic_Meas
     }
 };
 
+%extend StepBasic_UncertaintyMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_VolumeUnit;
 class StepBasic_VolumeUnit : public StepBasic_NamedUnit {
 	public:
@@ -12788,6 +13473,11 @@ class Handle_StepBasic_VolumeUnit : public Handle_StepBasic_NamedUnit {
     }
 };
 
+%extend StepBasic_VolumeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_WeekOfYearAndDayDate;
 class StepBasic_WeekOfYearAndDayDate : public StepBasic_Date {
 	public:
@@ -12892,6 +13582,11 @@ class Handle_StepBasic_WeekOfYearAndDayDate : public Handle_StepBasic_Date {
     }
 };
 
+%extend StepBasic_WeekOfYearAndDayDate {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndAreaUnit;
 class StepBasic_ConversionBasedUnitAndAreaUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -12960,6 +13655,11 @@ class Handle_StepBasic_ConversionBasedUnitAndAreaUnit : public Handle_StepBasic_
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndAreaUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndLengthUnit;
 class StepBasic_ConversionBasedUnitAndLengthUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13044,6 +13744,11 @@ class Handle_StepBasic_ConversionBasedUnitAndLengthUnit : public Handle_StepBasi
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndLengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndMassUnit;
 class StepBasic_ConversionBasedUnitAndMassUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13128,6 +13833,11 @@ class Handle_StepBasic_ConversionBasedUnitAndMassUnit : public Handle_StepBasic_
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndMassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndPlaneAngleUnit;
 class StepBasic_ConversionBasedUnitAndPlaneAngleUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13212,6 +13922,11 @@ class Handle_StepBasic_ConversionBasedUnitAndPlaneAngleUnit : public Handle_Step
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndPlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndRatioUnit;
 class StepBasic_ConversionBasedUnitAndRatioUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13296,6 +14011,11 @@ class Handle_StepBasic_ConversionBasedUnitAndRatioUnit : public Handle_StepBasic
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndRatioUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndSolidAngleUnit;
 class StepBasic_ConversionBasedUnitAndSolidAngleUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13380,6 +14100,11 @@ class Handle_StepBasic_ConversionBasedUnitAndSolidAngleUnit : public Handle_Step
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndSolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndTimeUnit;
 class StepBasic_ConversionBasedUnitAndTimeUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13464,6 +14189,11 @@ class Handle_StepBasic_ConversionBasedUnitAndTimeUnit : public Handle_StepBasic_
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndTimeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ConversionBasedUnitAndVolumeUnit;
 class StepBasic_ConversionBasedUnitAndVolumeUnit : public StepBasic_ConversionBasedUnit {
 	public:
@@ -13532,6 +14262,11 @@ class Handle_StepBasic_ConversionBasedUnitAndVolumeUnit : public Handle_StepBasi
     }
 };
 
+%extend StepBasic_ConversionBasedUnitAndVolumeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_DesignContext;
 class StepBasic_DesignContext : public StepBasic_ProductDefinitionContext {
 	public:
@@ -13588,6 +14323,11 @@ class Handle_StepBasic_DesignContext : public Handle_StepBasic_ProductDefinition
     }
 };
 
+%extend StepBasic_DesignContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_MechanicalContext;
 class StepBasic_MechanicalContext : public StepBasic_ProductContext {
 	public:
@@ -13646,6 +14386,11 @@ class Handle_StepBasic_MechanicalContext : public Handle_StepBasic_ProductContex
     }
 };
 
+%extend StepBasic_MechanicalContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_ProductType;
 class StepBasic_ProductType : public StepBasic_ProductRelatedProductCategory {
 	public:
@@ -13704,6 +14449,11 @@ class Handle_StepBasic_ProductType : public Handle_StepBasic_ProductRelatedProdu
     }
 };
 
+%extend StepBasic_ProductType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndAreaUnit;
 class StepBasic_SiUnitAndAreaUnit : public StepBasic_SiUnit {
 	public:
@@ -13782,6 +14532,11 @@ class Handle_StepBasic_SiUnitAndAreaUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndAreaUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndLengthUnit;
 class StepBasic_SiUnitAndLengthUnit : public StepBasic_SiUnit {
 	public:
@@ -13866,6 +14621,11 @@ class Handle_StepBasic_SiUnitAndLengthUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndLengthUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndMassUnit;
 class StepBasic_SiUnitAndMassUnit : public StepBasic_SiUnit {
 	public:
@@ -13950,6 +14710,11 @@ class Handle_StepBasic_SiUnitAndMassUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndMassUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndPlaneAngleUnit;
 class StepBasic_SiUnitAndPlaneAngleUnit : public StepBasic_SiUnit {
 	public:
@@ -14034,6 +14799,11 @@ class Handle_StepBasic_SiUnitAndPlaneAngleUnit : public Handle_StepBasic_SiUnit 
     }
 };
 
+%extend StepBasic_SiUnitAndPlaneAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndRatioUnit;
 class StepBasic_SiUnitAndRatioUnit : public StepBasic_SiUnit {
 	public:
@@ -14118,6 +14888,11 @@ class Handle_StepBasic_SiUnitAndRatioUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndRatioUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndSolidAngleUnit;
 class StepBasic_SiUnitAndSolidAngleUnit : public StepBasic_SiUnit {
 	public:
@@ -14202,6 +14977,11 @@ class Handle_StepBasic_SiUnitAndSolidAngleUnit : public Handle_StepBasic_SiUnit 
     }
 };
 
+%extend StepBasic_SiUnitAndSolidAngleUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndThermodynamicTemperatureUnit;
 class StepBasic_SiUnitAndThermodynamicTemperatureUnit : public StepBasic_SiUnit {
 	public:
@@ -14286,6 +15066,11 @@ class Handle_StepBasic_SiUnitAndThermodynamicTemperatureUnit : public Handle_Ste
     }
 };
 
+%extend StepBasic_SiUnitAndThermodynamicTemperatureUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndTimeUnit;
 class StepBasic_SiUnitAndTimeUnit : public StepBasic_SiUnit {
 	public:
@@ -14370,6 +15155,11 @@ class Handle_StepBasic_SiUnitAndTimeUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndTimeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepBasic_SiUnitAndVolumeUnit;
 class StepBasic_SiUnitAndVolumeUnit : public StepBasic_SiUnit {
 	public:
@@ -14448,3 +15238,8 @@ class Handle_StepBasic_SiUnitAndVolumeUnit : public Handle_StepBasic_SiUnit {
     }
 };
 
+%extend StepBasic_SiUnitAndVolumeUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepGeom.i
+++ b/src/SWIG_files/wrapper/StepGeom.i
@@ -187,6 +187,11 @@ class StepGeom_Array1OfBoundaryCurve {
 };
 
 
+%extend StepGeom_Array1OfBoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfCartesianPoint;
 class StepGeom_Array1OfCartesianPoint {
 	public:
@@ -269,6 +274,11 @@ class StepGeom_Array1OfCartesianPoint {
 };
 
 
+%extend StepGeom_Array1OfCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfCompositeCurveSegment;
 class StepGeom_Array1OfCompositeCurveSegment {
 	public:
@@ -351,6 +361,11 @@ class StepGeom_Array1OfCompositeCurveSegment {
 };
 
 
+%extend StepGeom_Array1OfCompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfCurve;
 class StepGeom_Array1OfCurve {
 	public:
@@ -433,6 +448,11 @@ class StepGeom_Array1OfCurve {
 };
 
 
+%extend StepGeom_Array1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfPcurveOrSurface;
 class StepGeom_Array1OfPcurveOrSurface {
 	public:
@@ -515,6 +535,11 @@ class StepGeom_Array1OfPcurveOrSurface {
 };
 
 
+%extend StepGeom_Array1OfPcurveOrSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfSurfaceBoundary;
 class StepGeom_Array1OfSurfaceBoundary {
 	public:
@@ -597,6 +622,11 @@ class StepGeom_Array1OfSurfaceBoundary {
 };
 
 
+%extend StepGeom_Array1OfSurfaceBoundary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array1OfTrimmingSelect;
 class StepGeom_Array1OfTrimmingSelect {
 	public:
@@ -679,6 +709,11 @@ class StepGeom_Array1OfTrimmingSelect {
 };
 
 
+%extend StepGeom_Array1OfTrimmingSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array2OfCartesianPoint;
 class StepGeom_Array2OfCartesianPoint {
 	public:
@@ -783,6 +818,11 @@ class StepGeom_Array2OfCartesianPoint {
 };
 
 
+%extend StepGeom_Array2OfCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Array2OfSurfacePatch;
 class StepGeom_Array2OfSurfacePatch {
 	public:
@@ -887,6 +927,11 @@ class StepGeom_Array2OfSurfacePatch {
 };
 
 
+%extend StepGeom_Array2OfSurfacePatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Axis2Placement;
 class StepGeom_Axis2Placement : public StepData_SelectType {
 	public:
@@ -919,6 +964,11 @@ class StepGeom_Axis2Placement : public StepData_SelectType {
 };
 
 
+%extend StepGeom_Axis2Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CompositeCurveSegment;
 class StepGeom_CompositeCurveSegment : public MMgt_TShared {
 	public:
@@ -1017,6 +1067,11 @@ class Handle_StepGeom_CompositeCurveSegment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_CompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CurveOnSurface;
 class StepGeom_CurveOnSurface : public StepData_SelectType {
 	public:
@@ -1055,6 +1110,11 @@ class StepGeom_CurveOnSurface : public StepData_SelectType {
 };
 
 
+%extend StepGeom_CurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_GeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx;
 class StepGeom_GeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx : public StepRepr_RepresentationContext {
 	public:
@@ -1227,6 +1287,11 @@ class Handle_StepGeom_GeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx : 
     }
 };
 
+%extend StepGeom_GeomRepContextAndGlobUnitAssCtxAndGlobUncertaintyAssCtx {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_GeometricRepresentationContext;
 class StepGeom_GeometricRepresentationContext : public StepRepr_RepresentationContext {
 	public:
@@ -1313,6 +1378,11 @@ class Handle_StepGeom_GeometricRepresentationContext : public Handle_StepRepr_Re
     }
 };
 
+%extend StepGeom_GeometricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_GeometricRepresentationContextAndGlobalUnitAssignedContext;
 class StepGeom_GeometricRepresentationContextAndGlobalUnitAssignedContext : public StepRepr_RepresentationContext {
 	public:
@@ -1453,6 +1523,11 @@ class Handle_StepGeom_GeometricRepresentationContextAndGlobalUnitAssignedContext
     }
 };
 
+%extend StepGeom_GeometricRepresentationContextAndGlobalUnitAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_GeometricRepresentationContextAndParametricRepresentationContext;
 class StepGeom_GeometricRepresentationContextAndParametricRepresentationContext : public StepRepr_RepresentationContext {
 	public:
@@ -1571,6 +1646,11 @@ class Handle_StepGeom_GeometricRepresentationContextAndParametricRepresentationC
     }
 };
 
+%extend StepGeom_GeometricRepresentationContextAndParametricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_GeometricRepresentationItem;
 class StepGeom_GeometricRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -1629,6 +1709,11 @@ class Handle_StepGeom_GeometricRepresentationItem : public Handle_StepRepr_Repre
     }
 };
 
+%extend StepGeom_GeometricRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfBoundaryCurve;
 class StepGeom_HArray1OfBoundaryCurve : public MMgt_TShared {
 	public:
@@ -1745,6 +1830,11 @@ class Handle_StepGeom_HArray1OfBoundaryCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfBoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfCartesianPoint;
 class StepGeom_HArray1OfCartesianPoint : public MMgt_TShared {
 	public:
@@ -1861,6 +1951,11 @@ class Handle_StepGeom_HArray1OfCartesianPoint : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfCompositeCurveSegment;
 class StepGeom_HArray1OfCompositeCurveSegment : public MMgt_TShared {
 	public:
@@ -1977,6 +2072,11 @@ class Handle_StepGeom_HArray1OfCompositeCurveSegment : public Handle_MMgt_TShare
     }
 };
 
+%extend StepGeom_HArray1OfCompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfCurve;
 class StepGeom_HArray1OfCurve : public MMgt_TShared {
 	public:
@@ -2093,6 +2193,11 @@ class Handle_StepGeom_HArray1OfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfPcurveOrSurface;
 class StepGeom_HArray1OfPcurveOrSurface : public MMgt_TShared {
 	public:
@@ -2209,6 +2314,11 @@ class Handle_StepGeom_HArray1OfPcurveOrSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfPcurveOrSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfSurfaceBoundary;
 class StepGeom_HArray1OfSurfaceBoundary : public MMgt_TShared {
 	public:
@@ -2325,6 +2435,11 @@ class Handle_StepGeom_HArray1OfSurfaceBoundary : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfSurfaceBoundary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray1OfTrimmingSelect;
 class StepGeom_HArray1OfTrimmingSelect : public MMgt_TShared {
 	public:
@@ -2441,6 +2556,11 @@ class Handle_StepGeom_HArray1OfTrimmingSelect : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray1OfTrimmingSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray2OfCartesianPoint;
 class StepGeom_HArray2OfCartesianPoint : public MMgt_TShared {
 	public:
@@ -2583,6 +2703,11 @@ class Handle_StepGeom_HArray2OfCartesianPoint : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray2OfCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_HArray2OfSurfacePatch;
 class StepGeom_HArray2OfSurfacePatch : public MMgt_TShared {
 	public:
@@ -2725,6 +2850,11 @@ class Handle_StepGeom_HArray2OfSurfacePatch : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_HArray2OfSurfacePatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_PcurveOrSurface;
 class StepGeom_PcurveOrSurface : public StepData_SelectType {
 	public:
@@ -2757,6 +2887,11 @@ class StepGeom_PcurveOrSurface : public StepData_SelectType {
 };
 
 
+%extend StepGeom_PcurveOrSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceBoundary;
 class StepGeom_SurfaceBoundary : public StepData_SelectType {
 	public:
@@ -2789,6 +2924,11 @@ class StepGeom_SurfaceBoundary : public StepData_SelectType {
 };
 
 
+%extend StepGeom_SurfaceBoundary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfacePatch;
 class StepGeom_SurfacePatch : public MMgt_TShared {
 	public:
@@ -2911,6 +3051,11 @@ class Handle_StepGeom_SurfacePatch : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepGeom_SurfacePatch {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_TrimmingMember;
 class StepGeom_TrimmingMember : public StepData_SelectReal {
 	public:
@@ -2981,6 +3126,11 @@ class Handle_StepGeom_TrimmingMember : public Handle_StepData_SelectReal {
     }
 };
 
+%extend StepGeom_TrimmingMember {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_TrimmingSelect;
 class StepGeom_TrimmingSelect : public StepData_SelectType {
 	public:
@@ -3035,6 +3185,11 @@ class StepGeom_TrimmingSelect : public StepData_SelectType {
 };
 
 
+%extend StepGeom_TrimmingSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_VectorOrDirection;
 class StepGeom_VectorOrDirection : public StepData_SelectType {
 	public:
@@ -3067,6 +3222,11 @@ class StepGeom_VectorOrDirection : public StepData_SelectType {
 };
 
 
+%extend StepGeom_VectorOrDirection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CartesianTransformationOperator;
 class StepGeom_CartesianTransformationOperator : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3215,6 +3375,11 @@ class Handle_StepGeom_CartesianTransformationOperator : public Handle_StepGeom_G
     }
 };
 
+%extend StepGeom_CartesianTransformationOperator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Curve;
 class StepGeom_Curve : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3273,6 +3438,11 @@ class Handle_StepGeom_Curve : public Handle_StepGeom_GeometricRepresentationItem
     }
 };
 
+%extend StepGeom_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Direction;
 class StepGeom_Direction : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3365,6 +3535,11 @@ class Handle_StepGeom_Direction : public Handle_StepGeom_GeometricRepresentation
     }
 };
 
+%extend StepGeom_Direction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Placement;
 class StepGeom_Placement : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3447,6 +3622,11 @@ class Handle_StepGeom_Placement : public Handle_StepGeom_GeometricRepresentation
     }
 };
 
+%extend StepGeom_Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Point;
 class StepGeom_Point : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3505,6 +3685,11 @@ class Handle_StepGeom_Point : public Handle_StepGeom_GeometricRepresentationItem
     }
 };
 
+%extend StepGeom_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_ReparametrisedCompositeCurveSegment;
 class StepGeom_ReparametrisedCompositeCurveSegment : public StepGeom_CompositeCurveSegment {
 	public:
@@ -3595,6 +3780,11 @@ class Handle_StepGeom_ReparametrisedCompositeCurveSegment : public Handle_StepGe
     }
 };
 
+%extend StepGeom_ReparametrisedCompositeCurveSegment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Surface;
 class StepGeom_Surface : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3653,6 +3843,11 @@ class Handle_StepGeom_Surface : public Handle_StepGeom_GeometricRepresentationIt
     }
 };
 
+%extend StepGeom_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Vector;
 class StepGeom_Vector : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3747,6 +3942,11 @@ class Handle_StepGeom_Vector : public Handle_StepGeom_GeometricRepresentationIte
     }
 };
 
+%extend StepGeom_Vector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Axis1Placement;
 class StepGeom_Axis1Placement : public StepGeom_Placement {
 	public:
@@ -3843,6 +4043,11 @@ class Handle_StepGeom_Axis1Placement : public Handle_StepGeom_Placement {
     }
 };
 
+%extend StepGeom_Axis1Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Axis2Placement2d;
 class StepGeom_Axis2Placement2d : public StepGeom_Placement {
 	public:
@@ -3939,6 +4144,11 @@ class Handle_StepGeom_Axis2Placement2d : public Handle_StepGeom_Placement {
     }
 };
 
+%extend StepGeom_Axis2Placement2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Axis2Placement3d;
 class StepGeom_Axis2Placement3d : public StepGeom_Placement {
 	public:
@@ -4057,6 +4267,11 @@ class Handle_StepGeom_Axis2Placement3d : public Handle_StepGeom_Placement {
     }
 };
 
+%extend StepGeom_Axis2Placement3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BoundedCurve;
 class StepGeom_BoundedCurve : public StepGeom_Curve {
 	public:
@@ -4115,6 +4330,11 @@ class Handle_StepGeom_BoundedCurve : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_BoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BoundedSurface;
 class StepGeom_BoundedSurface : public StepGeom_Surface {
 	public:
@@ -4173,6 +4393,11 @@ class Handle_StepGeom_BoundedSurface : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_BoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CartesianPoint;
 class StepGeom_CartesianPoint : public StepGeom_Point {
 	public:
@@ -4287,6 +4512,11 @@ class Handle_StepGeom_CartesianPoint : public Handle_StepGeom_Point {
     }
 };
 
+%extend StepGeom_CartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CartesianTransformationOperator2d;
 class StepGeom_CartesianTransformationOperator2d : public StepGeom_CartesianTransformationOperator {
 	public:
@@ -4343,6 +4573,11 @@ class Handle_StepGeom_CartesianTransformationOperator2d : public Handle_StepGeom
     }
 };
 
+%extend StepGeom_CartesianTransformationOperator2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CartesianTransformationOperator3d;
 class StepGeom_CartesianTransformationOperator3d : public StepGeom_CartesianTransformationOperator {
 	public:
@@ -4463,6 +4698,11 @@ class Handle_StepGeom_CartesianTransformationOperator3d : public Handle_StepGeom
     }
 };
 
+%extend StepGeom_CartesianTransformationOperator3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Conic;
 class StepGeom_Conic : public StepGeom_Curve {
 	public:
@@ -4545,6 +4785,11 @@ class Handle_StepGeom_Conic : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_Conic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CurveReplica;
 class StepGeom_CurveReplica : public StepGeom_Curve {
 	public:
@@ -4639,6 +4884,11 @@ class Handle_StepGeom_CurveReplica : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_CurveReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_DegeneratePcurve;
 class StepGeom_DegeneratePcurve : public StepGeom_Point {
 	public:
@@ -4733,6 +4983,11 @@ class Handle_StepGeom_DegeneratePcurve : public Handle_StepGeom_Point {
     }
 };
 
+%extend StepGeom_DegeneratePcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_ElementarySurface;
 class StepGeom_ElementarySurface : public StepGeom_Surface {
 	public:
@@ -4815,6 +5070,11 @@ class Handle_StepGeom_ElementarySurface : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_ElementarySurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Line;
 class StepGeom_Line : public StepGeom_Curve {
 	public:
@@ -4909,6 +5169,11 @@ class Handle_StepGeom_Line : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_Line {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_OffsetCurve3d;
 class StepGeom_OffsetCurve3d : public StepGeom_Curve {
 	public:
@@ -5027,6 +5292,11 @@ class Handle_StepGeom_OffsetCurve3d : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_OffsetCurve3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_OffsetSurface;
 class StepGeom_OffsetSurface : public StepGeom_Surface {
 	public:
@@ -5133,6 +5403,11 @@ class Handle_StepGeom_OffsetSurface : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_OffsetSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_OrientedSurface;
 class StepGeom_OrientedSurface : public StepGeom_Surface {
 	public:
@@ -5215,6 +5490,11 @@ class Handle_StepGeom_OrientedSurface : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_OrientedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Pcurve;
 class StepGeom_Pcurve : public StepGeom_Curve {
 	public:
@@ -5309,6 +5589,11 @@ class Handle_StepGeom_Pcurve : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_Pcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_PointOnCurve;
 class StepGeom_PointOnCurve : public StepGeom_Point {
 	public:
@@ -5403,6 +5688,11 @@ class Handle_StepGeom_PointOnCurve : public Handle_StepGeom_Point {
     }
 };
 
+%extend StepGeom_PointOnCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_PointOnSurface;
 class StepGeom_PointOnSurface : public StepGeom_Point {
 	public:
@@ -5509,6 +5799,11 @@ class Handle_StepGeom_PointOnSurface : public Handle_StepGeom_Point {
     }
 };
 
+%extend StepGeom_PointOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_PointReplica;
 class StepGeom_PointReplica : public StepGeom_Point {
 	public:
@@ -5603,6 +5898,11 @@ class Handle_StepGeom_PointReplica : public Handle_StepGeom_Point {
     }
 };
 
+%extend StepGeom_PointReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceCurve;
 class StepGeom_SurfaceCurve : public StepGeom_Curve {
 	public:
@@ -5719,6 +6019,11 @@ class Handle_StepGeom_SurfaceCurve : public Handle_StepGeom_Curve {
     }
 };
 
+%extend StepGeom_SurfaceCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceReplica;
 class StepGeom_SurfaceReplica : public StepGeom_Surface {
 	public:
@@ -5813,6 +6118,11 @@ class Handle_StepGeom_SurfaceReplica : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_SurfaceReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SweptSurface;
 class StepGeom_SweptSurface : public StepGeom_Surface {
 	public:
@@ -5895,6 +6205,11 @@ class Handle_StepGeom_SweptSurface : public Handle_StepGeom_Surface {
     }
 };
 
+%extend StepGeom_SweptSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineCurve;
 class StepGeom_BSplineCurve : public StepGeom_BoundedCurve {
 	public:
@@ -6035,6 +6350,11 @@ class Handle_StepGeom_BSplineCurve : public Handle_StepGeom_BoundedCurve {
     }
 };
 
+%extend StepGeom_BSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineSurface;
 class StepGeom_BSplineSurface : public StepGeom_BoundedSurface {
 	public:
@@ -6205,6 +6525,11 @@ class Handle_StepGeom_BSplineSurface : public Handle_StepGeom_BoundedSurface {
     }
 };
 
+%extend StepGeom_BSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Circle;
 class StepGeom_Circle : public StepGeom_Conic {
 	public:
@@ -6291,6 +6616,11 @@ class Handle_StepGeom_Circle : public Handle_StepGeom_Conic {
     }
 };
 
+%extend StepGeom_Circle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CompositeCurve;
 class StepGeom_CompositeCurve : public StepGeom_BoundedCurve {
 	public:
@@ -6395,6 +6725,11 @@ class Handle_StepGeom_CompositeCurve : public Handle_StepGeom_BoundedCurve {
     }
 };
 
+%extend StepGeom_CompositeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_ConicalSurface;
 class StepGeom_ConicalSurface : public StepGeom_ElementarySurface {
 	public:
@@ -6493,6 +6828,11 @@ class Handle_StepGeom_ConicalSurface : public Handle_StepGeom_ElementarySurface 
     }
 };
 
+%extend StepGeom_ConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CurveBoundedSurface;
 class StepGeom_CurveBoundedSurface : public StepGeom_BoundedSurface {
 	public:
@@ -6607,6 +6947,11 @@ class Handle_StepGeom_CurveBoundedSurface : public Handle_StepGeom_BoundedSurfac
     }
 };
 
+%extend StepGeom_CurveBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CylindricalSurface;
 class StepGeom_CylindricalSurface : public StepGeom_ElementarySurface {
 	public:
@@ -6693,6 +7038,11 @@ class Handle_StepGeom_CylindricalSurface : public Handle_StepGeom_ElementarySurf
     }
 };
 
+%extend StepGeom_CylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Ellipse;
 class StepGeom_Ellipse : public StepGeom_Conic {
 	public:
@@ -6791,6 +7141,11 @@ class Handle_StepGeom_Ellipse : public Handle_StepGeom_Conic {
     }
 };
 
+%extend StepGeom_Ellipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_EvaluatedDegeneratePcurve;
 class StepGeom_EvaluatedDegeneratePcurve : public StepGeom_DegeneratePcurve {
 	public:
@@ -6881,6 +7236,11 @@ class Handle_StepGeom_EvaluatedDegeneratePcurve : public Handle_StepGeom_Degener
     }
 };
 
+%extend StepGeom_EvaluatedDegeneratePcurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Hyperbola;
 class StepGeom_Hyperbola : public StepGeom_Conic {
 	public:
@@ -6979,6 +7339,11 @@ class Handle_StepGeom_Hyperbola : public Handle_StepGeom_Conic {
     }
 };
 
+%extend StepGeom_Hyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_IntersectionCurve;
 class StepGeom_IntersectionCurve : public StepGeom_SurfaceCurve {
 	public:
@@ -7037,6 +7402,11 @@ class Handle_StepGeom_IntersectionCurve : public Handle_StepGeom_SurfaceCurve {
     }
 };
 
+%extend StepGeom_IntersectionCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Parabola;
 class StepGeom_Parabola : public StepGeom_Conic {
 	public:
@@ -7123,6 +7493,11 @@ class Handle_StepGeom_Parabola : public Handle_StepGeom_Conic {
     }
 };
 
+%extend StepGeom_Parabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Plane;
 class StepGeom_Plane : public StepGeom_ElementarySurface {
 	public:
@@ -7181,6 +7556,11 @@ class Handle_StepGeom_Plane : public Handle_StepGeom_ElementarySurface {
     }
 };
 
+%extend StepGeom_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_Polyline;
 class StepGeom_Polyline : public StepGeom_BoundedCurve {
 	public:
@@ -7273,6 +7653,11 @@ class Handle_StepGeom_Polyline : public Handle_StepGeom_BoundedCurve {
     }
 };
 
+%extend StepGeom_Polyline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_RectangularCompositeSurface;
 class StepGeom_RectangularCompositeSurface : public StepGeom_BoundedSurface {
 	public:
@@ -7371,6 +7756,11 @@ class Handle_StepGeom_RectangularCompositeSurface : public Handle_StepGeom_Bound
     }
 };
 
+%extend StepGeom_RectangularCompositeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_RectangularTrimmedSurface;
 class StepGeom_RectangularTrimmedSurface : public StepGeom_BoundedSurface {
 	public:
@@ -7525,6 +7915,11 @@ class Handle_StepGeom_RectangularTrimmedSurface : public Handle_StepGeom_Bounded
     }
 };
 
+%extend StepGeom_RectangularTrimmedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SeamCurve;
 class StepGeom_SeamCurve : public StepGeom_SurfaceCurve {
 	public:
@@ -7583,6 +7978,11 @@ class Handle_StepGeom_SeamCurve : public Handle_StepGeom_SurfaceCurve {
     }
 };
 
+%extend StepGeom_SeamCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SphericalSurface;
 class StepGeom_SphericalSurface : public StepGeom_ElementarySurface {
 	public:
@@ -7669,6 +8069,11 @@ class Handle_StepGeom_SphericalSurface : public Handle_StepGeom_ElementarySurfac
     }
 };
 
+%extend StepGeom_SphericalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceCurveAndBoundedCurve;
 class StepGeom_SurfaceCurveAndBoundedCurve : public StepGeom_SurfaceCurve {
 	public:
@@ -7733,6 +8138,11 @@ class Handle_StepGeom_SurfaceCurveAndBoundedCurve : public Handle_StepGeom_Surfa
     }
 };
 
+%extend StepGeom_SurfaceCurveAndBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceOfLinearExtrusion;
 class StepGeom_SurfaceOfLinearExtrusion : public StepGeom_SweptSurface {
 	public:
@@ -7819,6 +8229,11 @@ class Handle_StepGeom_SurfaceOfLinearExtrusion : public Handle_StepGeom_SweptSur
     }
 };
 
+%extend StepGeom_SurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_SurfaceOfRevolution;
 class StepGeom_SurfaceOfRevolution : public StepGeom_SweptSurface {
 	public:
@@ -7905,6 +8320,11 @@ class Handle_StepGeom_SurfaceOfRevolution : public Handle_StepGeom_SweptSurface 
     }
 };
 
+%extend StepGeom_SurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_ToroidalSurface;
 class StepGeom_ToroidalSurface : public StepGeom_ElementarySurface {
 	public:
@@ -8003,6 +8423,11 @@ class Handle_StepGeom_ToroidalSurface : public Handle_StepGeom_ElementarySurface
     }
 };
 
+%extend StepGeom_ToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_TrimmedCurve;
 class StepGeom_TrimmedCurve : public StepGeom_BoundedCurve {
 	public:
@@ -8153,6 +8578,11 @@ class Handle_StepGeom_TrimmedCurve : public Handle_StepGeom_BoundedCurve {
     }
 };
 
+%extend StepGeom_TrimmedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineCurveWithKnots;
 class StepGeom_BSplineCurveWithKnots : public StepGeom_BSplineCurve {
 	public:
@@ -8299,6 +8729,11 @@ class Handle_StepGeom_BSplineCurveWithKnots : public Handle_StepGeom_BSplineCurv
     }
 };
 
+%extend StepGeom_BSplineCurveWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve;
 class StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve : public StepGeom_BSplineCurve {
 	public:
@@ -8507,6 +8942,11 @@ class Handle_StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve : public Hand
     }
 };
 
+%extend StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineSurfaceWithKnots;
 class StepGeom_BSplineSurfaceWithKnots : public StepGeom_BSplineSurface {
 	public:
@@ -8705,6 +9145,11 @@ class Handle_StepGeom_BSplineSurfaceWithKnots : public Handle_StepGeom_BSplineSu
     }
 };
 
+%extend StepGeom_BSplineSurfaceWithKnots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BSplineSurfaceWithKnotsAndRationalBSplineSurface;
 class StepGeom_BSplineSurfaceWithKnotsAndRationalBSplineSurface : public StepGeom_BSplineSurface {
 	public:
@@ -8975,6 +9420,11 @@ class Handle_StepGeom_BSplineSurfaceWithKnotsAndRationalBSplineSurface : public 
     }
 };
 
+%extend StepGeom_BSplineSurfaceWithKnotsAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BezierCurve;
 class StepGeom_BezierCurve : public StepGeom_BSplineCurve {
 	public:
@@ -9033,6 +9483,11 @@ class Handle_StepGeom_BezierCurve : public Handle_StepGeom_BSplineCurve {
     }
 };
 
+%extend StepGeom_BezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BezierCurveAndRationalBSplineCurve;
 class StepGeom_BezierCurveAndRationalBSplineCurve : public StepGeom_BSplineCurve {
 	public:
@@ -9185,6 +9640,11 @@ class Handle_StepGeom_BezierCurveAndRationalBSplineCurve : public Handle_StepGeo
     }
 };
 
+%extend StepGeom_BezierCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BezierSurface;
 class StepGeom_BezierSurface : public StepGeom_BSplineSurface {
 	public:
@@ -9243,6 +9703,11 @@ class Handle_StepGeom_BezierSurface : public Handle_StepGeom_BSplineSurface {
     }
 };
 
+%extend StepGeom_BezierSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BezierSurfaceAndRationalBSplineSurface;
 class StepGeom_BezierSurfaceAndRationalBSplineSurface : public StepGeom_BSplineSurface {
 	public:
@@ -9413,6 +9878,11 @@ class Handle_StepGeom_BezierSurfaceAndRationalBSplineSurface : public Handle_Ste
     }
 };
 
+%extend StepGeom_BezierSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_CompositeCurveOnSurface;
 class StepGeom_CompositeCurveOnSurface : public StepGeom_CompositeCurve {
 	public:
@@ -9471,6 +9941,11 @@ class Handle_StepGeom_CompositeCurveOnSurface : public Handle_StepGeom_Composite
     }
 };
 
+%extend StepGeom_CompositeCurveOnSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_DegenerateToroidalSurface;
 class StepGeom_DegenerateToroidalSurface : public StepGeom_ToroidalSurface {
 	public:
@@ -9565,6 +10040,11 @@ class Handle_StepGeom_DegenerateToroidalSurface : public Handle_StepGeom_Toroida
     }
 };
 
+%extend StepGeom_DegenerateToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_QuasiUniformCurve;
 class StepGeom_QuasiUniformCurve : public StepGeom_BSplineCurve {
 	public:
@@ -9623,6 +10103,11 @@ class Handle_StepGeom_QuasiUniformCurve : public Handle_StepGeom_BSplineCurve {
     }
 };
 
+%extend StepGeom_QuasiUniformCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_QuasiUniformCurveAndRationalBSplineCurve;
 class StepGeom_QuasiUniformCurveAndRationalBSplineCurve : public StepGeom_BSplineCurve {
 	public:
@@ -9775,6 +10260,11 @@ class Handle_StepGeom_QuasiUniformCurveAndRationalBSplineCurve : public Handle_S
     }
 };
 
+%extend StepGeom_QuasiUniformCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_QuasiUniformSurface;
 class StepGeom_QuasiUniformSurface : public StepGeom_BSplineSurface {
 	public:
@@ -9833,6 +10323,11 @@ class Handle_StepGeom_QuasiUniformSurface : public Handle_StepGeom_BSplineSurfac
     }
 };
 
+%extend StepGeom_QuasiUniformSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_QuasiUniformSurfaceAndRationalBSplineSurface;
 class StepGeom_QuasiUniformSurfaceAndRationalBSplineSurface : public StepGeom_BSplineSurface {
 	public:
@@ -10003,6 +10498,11 @@ class Handle_StepGeom_QuasiUniformSurfaceAndRationalBSplineSurface : public Hand
     }
 };
 
+%extend StepGeom_QuasiUniformSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_RationalBSplineCurve;
 class StepGeom_RationalBSplineCurve : public StepGeom_BSplineCurve {
 	public:
@@ -10115,6 +10615,11 @@ class Handle_StepGeom_RationalBSplineCurve : public Handle_StepGeom_BSplineCurve
     }
 };
 
+%extend StepGeom_RationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_RationalBSplineSurface;
 class StepGeom_RationalBSplineSurface : public StepGeom_BSplineSurface {
 	public:
@@ -10241,6 +10746,11 @@ class Handle_StepGeom_RationalBSplineSurface : public Handle_StepGeom_BSplineSur
     }
 };
 
+%extend StepGeom_RationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_UniformCurve;
 class StepGeom_UniformCurve : public StepGeom_BSplineCurve {
 	public:
@@ -10299,6 +10809,11 @@ class Handle_StepGeom_UniformCurve : public Handle_StepGeom_BSplineCurve {
     }
 };
 
+%extend StepGeom_UniformCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_UniformCurveAndRationalBSplineCurve;
 class StepGeom_UniformCurveAndRationalBSplineCurve : public StepGeom_BSplineCurve {
 	public:
@@ -10451,6 +10966,11 @@ class Handle_StepGeom_UniformCurveAndRationalBSplineCurve : public Handle_StepGe
     }
 };
 
+%extend StepGeom_UniformCurveAndRationalBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_UniformSurface;
 class StepGeom_UniformSurface : public StepGeom_BSplineSurface {
 	public:
@@ -10509,6 +11029,11 @@ class Handle_StepGeom_UniformSurface : public Handle_StepGeom_BSplineSurface {
     }
 };
 
+%extend StepGeom_UniformSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_UniformSurfaceAndRationalBSplineSurface;
 class StepGeom_UniformSurfaceAndRationalBSplineSurface : public StepGeom_BSplineSurface {
 	public:
@@ -10679,6 +11204,11 @@ class Handle_StepGeom_UniformSurfaceAndRationalBSplineSurface : public Handle_St
     }
 };
 
+%extend StepGeom_UniformSurfaceAndRationalBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_BoundaryCurve;
 class StepGeom_BoundaryCurve : public StepGeom_CompositeCurveOnSurface {
 	public:
@@ -10737,6 +11267,11 @@ class Handle_StepGeom_BoundaryCurve : public Handle_StepGeom_CompositeCurveOnSur
     }
 };
 
+%extend StepGeom_BoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepGeom_OuterBoundaryCurve;
 class StepGeom_OuterBoundaryCurve : public StepGeom_BoundaryCurve {
 	public:
@@ -10795,3 +11330,8 @@ class Handle_StepGeom_OuterBoundaryCurve : public Handle_StepGeom_BoundaryCurve 
     }
 };
 
+%extend StepGeom_OuterBoundaryCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepRepr.i
+++ b/src/SWIG_files/wrapper/StepRepr.i
@@ -138,6 +138,11 @@ class StepRepr_Array1OfMaterialPropertyRepresentation {
 };
 
 
+%extend StepRepr_Array1OfMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_Array1OfPropertyDefinitionRepresentation;
 class StepRepr_Array1OfPropertyDefinitionRepresentation {
 	public:
@@ -220,6 +225,11 @@ class StepRepr_Array1OfPropertyDefinitionRepresentation {
 };
 
 
+%extend StepRepr_Array1OfPropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_Array1OfRepresentationItem;
 class StepRepr_Array1OfRepresentationItem {
 	public:
@@ -302,6 +312,11 @@ class StepRepr_Array1OfRepresentationItem {
 };
 
 
+%extend StepRepr_Array1OfRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_AssemblyComponentUsageSubstitute;
 class StepRepr_AssemblyComponentUsageSubstitute : public MMgt_TShared {
 	public:
@@ -410,6 +425,11 @@ class Handle_StepRepr_AssemblyComponentUsageSubstitute : public Handle_MMgt_TSha
     }
 };
 
+%extend StepRepr_AssemblyComponentUsageSubstitute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_CharacterizedDefinition;
 class StepRepr_CharacterizedDefinition : public StepData_SelectType {
 	public:
@@ -472,6 +492,11 @@ class StepRepr_CharacterizedDefinition : public StepData_SelectType {
 };
 
 
+%extend StepRepr_CharacterizedDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ConfigurationDesign;
 class StepRepr_ConfigurationDesign : public MMgt_TShared {
 	public:
@@ -568,6 +593,11 @@ class Handle_StepRepr_ConfigurationDesign : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ConfigurationDesign {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ConfigurationDesignItem;
 class StepRepr_ConfigurationDesignItem : public StepData_SelectType {
 	public:
@@ -600,6 +630,11 @@ class StepRepr_ConfigurationDesignItem : public StepData_SelectType {
 };
 
 
+%extend StepRepr_ConfigurationDesignItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ConfigurationEffectivity;
 class StepRepr_ConfigurationEffectivity : public StepBasic_ProductDefinitionEffectivity {
 	public:
@@ -684,6 +719,11 @@ class Handle_StepRepr_ConfigurationEffectivity : public Handle_StepBasic_Product
     }
 };
 
+%extend StepRepr_ConfigurationEffectivity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ConfigurationItem;
 class StepRepr_ConfigurationItem : public MMgt_TShared {
 	public:
@@ -844,6 +884,11 @@ class Handle_StepRepr_ConfigurationItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ConfigurationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_DataEnvironment;
 class StepRepr_DataEnvironment : public MMgt_TShared {
 	public:
@@ -956,6 +1001,11 @@ class Handle_StepRepr_DataEnvironment : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_DataEnvironment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_FunctionallyDefinedTransformation;
 class StepRepr_FunctionallyDefinedTransformation : public MMgt_TShared {
 	public:
@@ -1042,6 +1092,11 @@ class Handle_StepRepr_FunctionallyDefinedTransformation : public Handle_MMgt_TSh
     }
 };
 
+%extend StepRepr_FunctionallyDefinedTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_HArray1OfMaterialPropertyRepresentation;
 class StepRepr_HArray1OfMaterialPropertyRepresentation : public MMgt_TShared {
 	public:
@@ -1158,6 +1213,11 @@ class Handle_StepRepr_HArray1OfMaterialPropertyRepresentation : public Handle_MM
     }
 };
 
+%extend StepRepr_HArray1OfMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_HArray1OfPropertyDefinitionRepresentation;
 class StepRepr_HArray1OfPropertyDefinitionRepresentation : public MMgt_TShared {
 	public:
@@ -1274,6 +1334,11 @@ class Handle_StepRepr_HArray1OfPropertyDefinitionRepresentation : public Handle_
     }
 };
 
+%extend StepRepr_HArray1OfPropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_HArray1OfRepresentationItem;
 class StepRepr_HArray1OfRepresentationItem : public MMgt_TShared {
 	public:
@@ -1390,6 +1455,11 @@ class Handle_StepRepr_HArray1OfRepresentationItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_HArray1OfRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_HSequenceOfMaterialPropertyRepresentation;
 class StepRepr_HSequenceOfMaterialPropertyRepresentation : public MMgt_TShared {
 	public:
@@ -1574,6 +1644,11 @@ class Handle_StepRepr_HSequenceOfMaterialPropertyRepresentation : public Handle_
     }
 };
 
+%extend StepRepr_HSequenceOfMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_HSequenceOfRepresentationItem;
 class StepRepr_HSequenceOfRepresentationItem : public MMgt_TShared {
 	public:
@@ -1758,6 +1833,11 @@ class Handle_StepRepr_HSequenceOfRepresentationItem : public Handle_MMgt_TShared
     }
 };
 
+%extend StepRepr_HSequenceOfRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ItemDefinedTransformation;
 class StepRepr_ItemDefinedTransformation : public MMgt_TShared {
 	public:
@@ -1866,6 +1946,11 @@ class Handle_StepRepr_ItemDefinedTransformation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ItemDefinedTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MaterialDesignation;
 class StepRepr_MaterialDesignation : public MMgt_TShared {
 	public:
@@ -1950,6 +2035,11 @@ class Handle_StepRepr_MaterialDesignation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_MaterialDesignation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ProductConcept;
 class StepRepr_ProductConcept : public MMgt_TShared {
 	public:
@@ -2086,6 +2176,11 @@ class Handle_StepRepr_ProductConcept : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ProductConcept {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ProductDefinitionUsage;
 class StepRepr_ProductDefinitionUsage : public StepBasic_ProductDefinitionRelationship {
 	public:
@@ -2144,6 +2239,11 @@ class Handle_StepRepr_ProductDefinitionUsage : public Handle_StepBasic_ProductDe
     }
 };
 
+%extend StepRepr_ProductDefinitionUsage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_PropertyDefinition;
 class StepRepr_PropertyDefinition : public MMgt_TShared {
 	public:
@@ -2264,6 +2364,11 @@ class Handle_StepRepr_PropertyDefinition : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_PropertyDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_PropertyDefinitionRelationship;
 class StepRepr_PropertyDefinitionRelationship : public MMgt_TShared {
 	public:
@@ -2392,6 +2497,11 @@ class Handle_StepRepr_PropertyDefinitionRelationship : public Handle_MMgt_TShare
     }
 };
 
+%extend StepRepr_PropertyDefinitionRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_PropertyDefinitionRepresentation;
 class StepRepr_PropertyDefinitionRepresentation : public MMgt_TShared {
 	public:
@@ -2488,6 +2598,11 @@ class Handle_StepRepr_PropertyDefinitionRepresentation : public Handle_MMgt_TSha
     }
 };
 
+%extend StepRepr_PropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_Representation;
 class StepRepr_Representation : public MMgt_TShared {
 	public:
@@ -2596,6 +2711,11 @@ class Handle_StepRepr_Representation : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_Representation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentationContext;
 class StepRepr_RepresentationContext : public MMgt_TShared {
 	public:
@@ -2682,6 +2802,11 @@ class Handle_StepRepr_RepresentationContext : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_RepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentationItem;
 class StepRepr_RepresentationItem : public MMgt_TShared {
 	public:
@@ -2756,6 +2881,11 @@ class Handle_StepRepr_RepresentationItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_RepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentationMap;
 class StepRepr_RepresentationMap : public MMgt_TShared {
 	public:
@@ -2842,6 +2972,11 @@ class Handle_StepRepr_RepresentationMap : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_RepresentationMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentationRelationship;
 class StepRepr_RepresentationRelationship : public MMgt_TShared {
 	public:
@@ -2952,6 +3087,11 @@ class Handle_StepRepr_RepresentationRelationship : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_RepresentationRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentedDefinition;
 class StepRepr_RepresentedDefinition : public StepData_SelectType {
 	public:
@@ -3002,6 +3142,11 @@ class StepRepr_RepresentedDefinition : public StepData_SelectType {
 };
 
 
+%extend StepRepr_RepresentedDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SequenceNodeOfSequenceOfMaterialPropertyRepresentation;
 class StepRepr_SequenceNodeOfSequenceOfMaterialPropertyRepresentation : public TCollection_SeqNode {
 	public:
@@ -3068,6 +3213,11 @@ class Handle_StepRepr_SequenceNodeOfSequenceOfMaterialPropertyRepresentation : p
     }
 };
 
+%extend StepRepr_SequenceNodeOfSequenceOfMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SequenceNodeOfSequenceOfRepresentationItem;
 class StepRepr_SequenceNodeOfSequenceOfRepresentationItem : public TCollection_SeqNode {
 	public:
@@ -3134,6 +3284,11 @@ class Handle_StepRepr_SequenceNodeOfSequenceOfRepresentationItem : public Handle
     }
 };
 
+%extend StepRepr_SequenceNodeOfSequenceOfRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SequenceOfMaterialPropertyRepresentation;
 class StepRepr_SequenceOfMaterialPropertyRepresentation : public TCollection_BaseSequence {
 	public:
@@ -3272,6 +3427,11 @@ class StepRepr_SequenceOfMaterialPropertyRepresentation : public TCollection_Bas
 };
 
 
+%extend StepRepr_SequenceOfMaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SequenceOfRepresentationItem;
 class StepRepr_SequenceOfRepresentationItem : public TCollection_BaseSequence {
 	public:
@@ -3410,6 +3570,11 @@ class StepRepr_SequenceOfRepresentationItem : public TCollection_BaseSequence {
 };
 
 
+%extend StepRepr_SequenceOfRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeAspect;
 class StepRepr_ShapeAspect : public MMgt_TShared {
 	public:
@@ -3520,6 +3685,11 @@ class Handle_StepRepr_ShapeAspect : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeAspectRelationship;
 class StepRepr_ShapeAspectRelationship : public MMgt_TShared {
 	public:
@@ -3656,6 +3826,11 @@ class Handle_StepRepr_ShapeAspectRelationship : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepRepr_ShapeAspectRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeDefinition;
 class StepRepr_ShapeDefinition : public StepData_SelectType {
 	public:
@@ -3694,6 +3869,11 @@ class StepRepr_ShapeDefinition : public StepData_SelectType {
 };
 
 
+%extend StepRepr_ShapeDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SuppliedPartRelationship;
 class StepRepr_SuppliedPartRelationship : public StepBasic_ProductDefinitionRelationship {
 	public:
@@ -3750,6 +3930,11 @@ class Handle_StepRepr_SuppliedPartRelationship : public Handle_StepBasic_Product
     }
 };
 
+%extend StepRepr_SuppliedPartRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_Transformation;
 class StepRepr_Transformation : public StepData_SelectType {
 	public:
@@ -3782,6 +3967,11 @@ class StepRepr_Transformation : public StepData_SelectType {
 };
 
 
+%extend StepRepr_Transformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_AssemblyComponentUsage;
 class StepRepr_AssemblyComponentUsage : public StepRepr_ProductDefinitionUsage {
 	public:
@@ -3882,6 +4072,11 @@ class Handle_StepRepr_AssemblyComponentUsage : public Handle_StepRepr_ProductDef
     }
 };
 
+%extend StepRepr_AssemblyComponentUsage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_CompositeShapeAspect;
 class StepRepr_CompositeShapeAspect : public StepRepr_ShapeAspect {
 	public:
@@ -3938,6 +4133,11 @@ class Handle_StepRepr_CompositeShapeAspect : public Handle_StepRepr_ShapeAspect 
     }
 };
 
+%extend StepRepr_CompositeShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_CompoundRepresentationItem;
 class StepRepr_CompoundRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -4030,6 +4230,11 @@ class Handle_StepRepr_CompoundRepresentationItem : public Handle_StepRepr_Repres
     }
 };
 
+%extend StepRepr_CompoundRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_DefinitionalRepresentation;
 class StepRepr_DefinitionalRepresentation : public StepRepr_Representation {
 	public:
@@ -4088,6 +4293,11 @@ class Handle_StepRepr_DefinitionalRepresentation : public Handle_StepRepr_Repres
     }
 };
 
+%extend StepRepr_DefinitionalRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_DerivedShapeAspect;
 class StepRepr_DerivedShapeAspect : public StepRepr_ShapeAspect {
 	public:
@@ -4144,6 +4354,11 @@ class Handle_StepRepr_DerivedShapeAspect : public Handle_StepRepr_ShapeAspect {
     }
 };
 
+%extend StepRepr_DerivedShapeAspect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_DescriptiveRepresentationItem;
 class StepRepr_DescriptiveRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -4226,6 +4441,11 @@ class Handle_StepRepr_DescriptiveRepresentationItem : public Handle_StepRepr_Rep
     }
 };
 
+%extend StepRepr_DescriptiveRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ExternallyDefinedRepresentation;
 class StepRepr_ExternallyDefinedRepresentation : public StepRepr_Representation {
 	public:
@@ -4282,6 +4502,11 @@ class Handle_StepRepr_ExternallyDefinedRepresentation : public Handle_StepRepr_R
     }
 };
 
+%extend StepRepr_ExternallyDefinedRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_GlobalUncertaintyAssignedContext;
 class StepRepr_GlobalUncertaintyAssignedContext : public StepRepr_RepresentationContext {
 	public:
@@ -4378,6 +4603,11 @@ class Handle_StepRepr_GlobalUncertaintyAssignedContext : public Handle_StepRepr_
     }
 };
 
+%extend StepRepr_GlobalUncertaintyAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_GlobalUnitAssignedContext;
 class StepRepr_GlobalUnitAssignedContext : public StepRepr_RepresentationContext {
 	public:
@@ -4474,6 +4704,11 @@ class Handle_StepRepr_GlobalUnitAssignedContext : public Handle_StepRepr_Represe
     }
 };
 
+%extend StepRepr_GlobalUnitAssignedContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MakeFromUsageOption;
 class StepRepr_MakeFromUsageOption : public StepRepr_ProductDefinitionUsage {
 	public:
@@ -4598,6 +4833,11 @@ class Handle_StepRepr_MakeFromUsageOption : public Handle_StepRepr_ProductDefini
     }
 };
 
+%extend StepRepr_MakeFromUsageOption {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MappedItem;
 class StepRepr_MappedItem : public StepRepr_RepresentationItem {
 	public:
@@ -4692,6 +4932,11 @@ class Handle_StepRepr_MappedItem : public Handle_StepRepr_RepresentationItem {
     }
 };
 
+%extend StepRepr_MappedItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MaterialProperty;
 class StepRepr_MaterialProperty : public StepRepr_PropertyDefinition {
 	public:
@@ -4750,6 +4995,11 @@ class Handle_StepRepr_MaterialProperty : public Handle_StepRepr_PropertyDefiniti
     }
 };
 
+%extend StepRepr_MaterialProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MaterialPropertyRepresentation;
 class StepRepr_MaterialPropertyRepresentation : public StepRepr_PropertyDefinitionRepresentation {
 	public:
@@ -4834,6 +5084,11 @@ class Handle_StepRepr_MaterialPropertyRepresentation : public Handle_StepRepr_Pr
     }
 };
 
+%extend StepRepr_MaterialPropertyRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_MeasureRepresentationItem;
 class StepRepr_MeasureRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -4914,6 +5169,11 @@ class Handle_StepRepr_MeasureRepresentationItem : public Handle_StepRepr_Represe
     }
 };
 
+%extend StepRepr_MeasureRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ParametricRepresentationContext;
 class StepRepr_ParametricRepresentationContext : public StepRepr_RepresentationContext {
 	public:
@@ -4972,6 +5232,11 @@ class Handle_StepRepr_ParametricRepresentationContext : public Handle_StepRepr_R
     }
 };
 
+%extend StepRepr_ParametricRepresentationContext {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ProductDefinitionShape;
 class StepRepr_ProductDefinitionShape : public StepRepr_PropertyDefinition {
 	public:
@@ -5030,6 +5295,11 @@ class Handle_StepRepr_ProductDefinitionShape : public Handle_StepRepr_PropertyDe
     }
 };
 
+%extend StepRepr_ProductDefinitionShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ReprItemAndLengthMeasureWithUnit;
 class StepRepr_ReprItemAndLengthMeasureWithUnit : public StepRepr_RepresentationItem {
 	public:
@@ -5122,6 +5392,11 @@ class Handle_StepRepr_ReprItemAndLengthMeasureWithUnit : public Handle_StepRepr_
     }
 };
 
+%extend StepRepr_ReprItemAndLengthMeasureWithUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeAspectDerivingRelationship;
 class StepRepr_ShapeAspectDerivingRelationship : public StepRepr_ShapeAspectRelationship {
 	public:
@@ -5178,6 +5453,11 @@ class Handle_StepRepr_ShapeAspectDerivingRelationship : public Handle_StepRepr_S
     }
 };
 
+%extend StepRepr_ShapeAspectDerivingRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeAspectTransition;
 class StepRepr_ShapeAspectTransition : public StepRepr_ShapeAspectRelationship {
 	public:
@@ -5236,6 +5516,11 @@ class Handle_StepRepr_ShapeAspectTransition : public Handle_StepRepr_ShapeAspect
     }
 };
 
+%extend StepRepr_ShapeAspectTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeRepresentationRelationship;
 class StepRepr_ShapeRepresentationRelationship : public StepRepr_RepresentationRelationship {
 	public:
@@ -5292,6 +5577,11 @@ class Handle_StepRepr_ShapeRepresentationRelationship : public Handle_StepRepr_R
     }
 };
 
+%extend StepRepr_ShapeRepresentationRelationship {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_StructuralResponseProperty;
 class StepRepr_StructuralResponseProperty : public StepRepr_PropertyDefinition {
 	public:
@@ -5350,6 +5640,11 @@ class Handle_StepRepr_StructuralResponseProperty : public Handle_StepRepr_Proper
     }
 };
 
+%extend StepRepr_StructuralResponseProperty {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_StructuralResponsePropertyDefinitionRepresentation;
 class StepRepr_StructuralResponsePropertyDefinitionRepresentation : public StepRepr_PropertyDefinitionRepresentation {
 	public:
@@ -5408,6 +5703,11 @@ class Handle_StepRepr_StructuralResponsePropertyDefinitionRepresentation : publi
     }
 };
 
+%extend StepRepr_StructuralResponsePropertyDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_Extension;
 class StepRepr_Extension : public StepRepr_DerivedShapeAspect {
 	public:
@@ -5464,6 +5764,11 @@ class Handle_StepRepr_Extension : public Handle_StepRepr_DerivedShapeAspect {
     }
 };
 
+%extend StepRepr_Extension {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_NextAssemblyUsageOccurrence;
 class StepRepr_NextAssemblyUsageOccurrence : public StepRepr_AssemblyComponentUsage {
 	public:
@@ -5522,6 +5827,11 @@ class Handle_StepRepr_NextAssemblyUsageOccurrence : public Handle_StepRepr_Assem
     }
 };
 
+%extend StepRepr_NextAssemblyUsageOccurrence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_PromissoryUsageOccurrence;
 class StepRepr_PromissoryUsageOccurrence : public StepRepr_AssemblyComponentUsage {
 	public:
@@ -5578,6 +5888,11 @@ class Handle_StepRepr_PromissoryUsageOccurrence : public Handle_StepRepr_Assembl
     }
 };
 
+%extend StepRepr_PromissoryUsageOccurrence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_QuantifiedAssemblyComponentUsage;
 class StepRepr_QuantifiedAssemblyComponentUsage : public StepRepr_AssemblyComponentUsage {
 	public:
@@ -5674,6 +5989,11 @@ class Handle_StepRepr_QuantifiedAssemblyComponentUsage : public Handle_StepRepr_
     }
 };
 
+%extend StepRepr_QuantifiedAssemblyComponentUsage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_RepresentationRelationshipWithTransformation;
 class StepRepr_RepresentationRelationshipWithTransformation : public StepRepr_ShapeRepresentationRelationship {
 	public:
@@ -5754,6 +6074,11 @@ class Handle_StepRepr_RepresentationRelationshipWithTransformation : public Hand
     }
 };
 
+%extend StepRepr_RepresentationRelationshipWithTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_SpecifiedHigherUsageOccurrence;
 class StepRepr_SpecifiedHigherUsageOccurrence : public StepRepr_AssemblyComponentUsage {
 	public:
@@ -5866,6 +6191,11 @@ class Handle_StepRepr_SpecifiedHigherUsageOccurrence : public Handle_StepRepr_As
     }
 };
 
+%extend StepRepr_SpecifiedHigherUsageOccurrence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ValueRange;
 class StepRepr_ValueRange : public StepRepr_CompoundRepresentationItem {
 	public:
@@ -5922,6 +6252,11 @@ class Handle_StepRepr_ValueRange : public Handle_StepRepr_CompoundRepresentation
     }
 };
 
+%extend StepRepr_ValueRange {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepRepr_ShapeRepresentationRelationshipWithTransformation;
 class StepRepr_ShapeRepresentationRelationshipWithTransformation : public StepRepr_RepresentationRelationshipWithTransformation {
 	public:
@@ -5978,3 +6313,8 @@ class Handle_StepRepr_ShapeRepresentationRelationshipWithTransformation : public
     }
 };
 
+%extend StepRepr_ShapeRepresentationRelationshipWithTransformation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepShape.i
+++ b/src/SWIG_files/wrapper/StepShape.i
@@ -150,6 +150,11 @@ class StepShape_Array1OfConnectedEdgeSet {
 };
 
 
+%extend StepShape_Array1OfConnectedEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfConnectedFaceSet;
 class StepShape_Array1OfConnectedFaceSet {
 	public:
@@ -232,6 +237,11 @@ class StepShape_Array1OfConnectedFaceSet {
 };
 
 
+%extend StepShape_Array1OfConnectedFaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfEdge;
 class StepShape_Array1OfEdge {
 	public:
@@ -314,6 +324,11 @@ class StepShape_Array1OfEdge {
 };
 
 
+%extend StepShape_Array1OfEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfFace;
 class StepShape_Array1OfFace {
 	public:
@@ -396,6 +411,11 @@ class StepShape_Array1OfFace {
 };
 
 
+%extend StepShape_Array1OfFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfFaceBound;
 class StepShape_Array1OfFaceBound {
 	public:
@@ -478,6 +498,11 @@ class StepShape_Array1OfFaceBound {
 };
 
 
+%extend StepShape_Array1OfFaceBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfGeometricSetSelect;
 class StepShape_Array1OfGeometricSetSelect {
 	public:
@@ -560,6 +585,11 @@ class StepShape_Array1OfGeometricSetSelect {
 };
 
 
+%extend StepShape_Array1OfGeometricSetSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfOrientedClosedShell;
 class StepShape_Array1OfOrientedClosedShell {
 	public:
@@ -642,6 +672,11 @@ class StepShape_Array1OfOrientedClosedShell {
 };
 
 
+%extend StepShape_Array1OfOrientedClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfOrientedEdge;
 class StepShape_Array1OfOrientedEdge {
 	public:
@@ -724,6 +759,11 @@ class StepShape_Array1OfOrientedEdge {
 };
 
 
+%extend StepShape_Array1OfOrientedEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfShell;
 class StepShape_Array1OfShell {
 	public:
@@ -806,6 +846,11 @@ class StepShape_Array1OfShell {
 };
 
 
+%extend StepShape_Array1OfShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Array1OfValueQualifier;
 class StepShape_Array1OfValueQualifier {
 	public:
@@ -888,6 +933,11 @@ class StepShape_Array1OfValueQualifier {
 };
 
 
+%extend StepShape_Array1OfValueQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Block;
 class StepShape_Block : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -1006,6 +1056,11 @@ class Handle_StepShape_Block : public Handle_StepGeom_GeometricRepresentationIte
     }
 };
 
+%extend StepShape_Block {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_BooleanOperand;
 class StepShape_BooleanOperand {
 	public:
@@ -1076,6 +1131,11 @@ class StepShape_BooleanOperand {
 };
 
 
+%extend StepShape_BooleanOperand {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_BooleanResult;
 class StepShape_BooleanResult : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -1182,6 +1242,11 @@ class Handle_StepShape_BooleanResult : public Handle_StepGeom_GeometricRepresent
     }
 };
 
+%extend StepShape_BooleanResult {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_BoxDomain;
 class StepShape_BoxDomain : public MMgt_TShared {
 	public:
@@ -1292,6 +1357,11 @@ class Handle_StepShape_BoxDomain : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_BoxDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ConnectedFaceShapeRepresentation;
 class StepShape_ConnectedFaceShapeRepresentation : public StepRepr_Representation {
 	public:
@@ -1350,6 +1420,11 @@ class Handle_StepShape_ConnectedFaceShapeRepresentation : public Handle_StepRepr
     }
 };
 
+%extend StepShape_ConnectedFaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ContextDependentShapeRepresentation;
 class StepShape_ContextDependentShapeRepresentation : public MMgt_TShared {
 	public:
@@ -1434,6 +1509,11 @@ class Handle_StepShape_ContextDependentShapeRepresentation : public Handle_MMgt_
     }
 };
 
+%extend StepShape_ContextDependentShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_CsgPrimitive;
 class StepShape_CsgPrimitive : public StepData_SelectType {
 	public:
@@ -1490,6 +1570,11 @@ class StepShape_CsgPrimitive : public StepData_SelectType {
 };
 
 
+%extend StepShape_CsgPrimitive {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_CsgSelect;
 class StepShape_CsgSelect {
 	public:
@@ -1536,6 +1621,11 @@ class StepShape_CsgSelect {
 };
 
 
+%extend StepShape_CsgSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DefinitionalRepresentationAndShapeRepresentation;
 class StepShape_DefinitionalRepresentationAndShapeRepresentation : public StepRepr_DefinitionalRepresentation {
 	public:
@@ -1592,6 +1682,11 @@ class Handle_StepShape_DefinitionalRepresentationAndShapeRepresentation : public
     }
 };
 
+%extend StepShape_DefinitionalRepresentationAndShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalCharacteristic;
 class StepShape_DimensionalCharacteristic : public StepData_SelectType {
 	public:
@@ -1624,6 +1719,11 @@ class StepShape_DimensionalCharacteristic : public StepData_SelectType {
 };
 
 
+%extend StepShape_DimensionalCharacteristic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalCharacteristicRepresentation;
 class StepShape_DimensionalCharacteristicRepresentation : public MMgt_TShared {
 	public:
@@ -1720,6 +1820,11 @@ class Handle_StepShape_DimensionalCharacteristicRepresentation : public Handle_M
     }
 };
 
+%extend StepShape_DimensionalCharacteristicRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalLocation;
 class StepShape_DimensionalLocation : public StepRepr_ShapeAspectRelationship {
 	public:
@@ -1778,6 +1883,11 @@ class Handle_StepShape_DimensionalLocation : public Handle_StepRepr_ShapeAspectR
     }
 };
 
+%extend StepShape_DimensionalLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalSize;
 class StepShape_DimensionalSize : public MMgt_TShared {
 	public:
@@ -1874,6 +1984,11 @@ class Handle_StepShape_DimensionalSize : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_DimensionalSize {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_EdgeBasedWireframeModel;
 class StepShape_EdgeBasedWireframeModel : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -1956,6 +2071,11 @@ class Handle_StepShape_EdgeBasedWireframeModel : public Handle_StepGeom_Geometri
     }
 };
 
+%extend StepShape_EdgeBasedWireframeModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FaceBasedSurfaceModel;
 class StepShape_FaceBasedSurfaceModel : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -2038,6 +2158,11 @@ class Handle_StepShape_FaceBasedSurfaceModel : public Handle_StepGeom_GeometricR
     }
 };
 
+%extend StepShape_FaceBasedSurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_GeometricSet;
 class StepShape_GeometricSet : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -2130,6 +2255,11 @@ class Handle_StepShape_GeometricSet : public Handle_StepGeom_GeometricRepresenta
     }
 };
 
+%extend StepShape_GeometricSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_GeometricSetSelect;
 class StepShape_GeometricSetSelect : public StepData_SelectType {
 	public:
@@ -2168,6 +2298,11 @@ class StepShape_GeometricSetSelect : public StepData_SelectType {
 };
 
 
+%extend StepShape_GeometricSetSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfConnectedEdgeSet;
 class StepShape_HArray1OfConnectedEdgeSet : public MMgt_TShared {
 	public:
@@ -2284,6 +2419,11 @@ class Handle_StepShape_HArray1OfConnectedEdgeSet : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfConnectedEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfConnectedFaceSet;
 class StepShape_HArray1OfConnectedFaceSet : public MMgt_TShared {
 	public:
@@ -2400,6 +2540,11 @@ class Handle_StepShape_HArray1OfConnectedFaceSet : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfConnectedFaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfEdge;
 class StepShape_HArray1OfEdge : public MMgt_TShared {
 	public:
@@ -2516,6 +2661,11 @@ class Handle_StepShape_HArray1OfEdge : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfFace;
 class StepShape_HArray1OfFace : public MMgt_TShared {
 	public:
@@ -2632,6 +2782,11 @@ class Handle_StepShape_HArray1OfFace : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfFaceBound;
 class StepShape_HArray1OfFaceBound : public MMgt_TShared {
 	public:
@@ -2748,6 +2903,11 @@ class Handle_StepShape_HArray1OfFaceBound : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfFaceBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfGeometricSetSelect;
 class StepShape_HArray1OfGeometricSetSelect : public MMgt_TShared {
 	public:
@@ -2864,6 +3024,11 @@ class Handle_StepShape_HArray1OfGeometricSetSelect : public Handle_MMgt_TShared 
     }
 };
 
+%extend StepShape_HArray1OfGeometricSetSelect {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfOrientedClosedShell;
 class StepShape_HArray1OfOrientedClosedShell : public MMgt_TShared {
 	public:
@@ -2980,6 +3145,11 @@ class Handle_StepShape_HArray1OfOrientedClosedShell : public Handle_MMgt_TShared
     }
 };
 
+%extend StepShape_HArray1OfOrientedClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfOrientedEdge;
 class StepShape_HArray1OfOrientedEdge : public MMgt_TShared {
 	public:
@@ -3096,6 +3266,11 @@ class Handle_StepShape_HArray1OfOrientedEdge : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfOrientedEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfShell;
 class StepShape_HArray1OfShell : public MMgt_TShared {
 	public:
@@ -3212,6 +3387,11 @@ class Handle_StepShape_HArray1OfShell : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HArray1OfValueQualifier;
 class StepShape_HArray1OfValueQualifier : public MMgt_TShared {
 	public:
@@ -3328,6 +3508,11 @@ class Handle_StepShape_HArray1OfValueQualifier : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_HArray1OfValueQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_HalfSpaceSolid;
 class StepShape_HalfSpaceSolid : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -3422,6 +3607,11 @@ class Handle_StepShape_HalfSpaceSolid : public Handle_StepGeom_GeometricRepresen
     }
 };
 
+%extend StepShape_HalfSpaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_LimitsAndFits;
 class StepShape_LimitsAndFits : public MMgt_TShared {
 	public:
@@ -3530,6 +3720,11 @@ class Handle_StepShape_LimitsAndFits : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_LimitsAndFits {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_MeasureQualification;
 class StepShape_MeasureQualification : public MMgt_TShared {
 	public:
@@ -3656,6 +3851,11 @@ class Handle_StepShape_MeasureQualification : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_MeasureQualification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_MeasureRepresentationItemAndQualifiedRepresentationItem;
 class StepShape_MeasureRepresentationItemAndQualifiedRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -3762,6 +3962,11 @@ class Handle_StepShape_MeasureRepresentationItemAndQualifiedRepresentationItem :
     }
 };
 
+%extend StepShape_MeasureRepresentationItemAndQualifiedRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_PlusMinusTolerance;
 class StepShape_PlusMinusTolerance : public MMgt_TShared {
 	public:
@@ -3846,6 +4051,11 @@ class Handle_StepShape_PlusMinusTolerance : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_PlusMinusTolerance {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_PrecisionQualifier;
 class StepShape_PrecisionQualifier : public MMgt_TShared {
 	public:
@@ -3918,6 +4128,11 @@ class Handle_StepShape_PrecisionQualifier : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_PrecisionQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_QualifiedRepresentationItem;
 class StepShape_QualifiedRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -4010,6 +4225,11 @@ class Handle_StepShape_QualifiedRepresentationItem : public Handle_StepRepr_Repr
     }
 };
 
+%extend StepShape_QualifiedRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ReversibleTopologyItem;
 class StepShape_ReversibleTopologyItem : public StepData_SelectType {
 	public:
@@ -4066,6 +4286,11 @@ class StepShape_ReversibleTopologyItem : public StepData_SelectType {
 };
 
 
+%extend StepShape_ReversibleTopologyItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_RightAngularWedge;
 class StepShape_RightAngularWedge : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4196,6 +4421,11 @@ class Handle_StepShape_RightAngularWedge : public Handle_StepGeom_GeometricRepre
     }
 };
 
+%extend StepShape_RightAngularWedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_RightCircularCone;
 class StepShape_RightCircularCone : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4314,6 +4544,11 @@ class Handle_StepShape_RightCircularCone : public Handle_StepGeom_GeometricRepre
     }
 };
 
+%extend StepShape_RightCircularCone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_RightCircularCylinder;
 class StepShape_RightCircularCylinder : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4420,6 +4655,11 @@ class Handle_StepShape_RightCircularCylinder : public Handle_StepGeom_GeometricR
     }
 };
 
+%extend StepShape_RightCircularCylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ShapeDefinitionRepresentation;
 class StepShape_ShapeDefinitionRepresentation : public StepRepr_PropertyDefinitionRepresentation {
 	public:
@@ -4478,6 +4718,11 @@ class Handle_StepShape_ShapeDefinitionRepresentation : public Handle_StepRepr_Pr
     }
 };
 
+%extend StepShape_ShapeDefinitionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ShapeRepresentation;
 class StepShape_ShapeRepresentation : public StepRepr_Representation {
 	public:
@@ -4536,6 +4781,11 @@ class Handle_StepShape_ShapeRepresentation : public Handle_StepRepr_Representati
     }
 };
 
+%extend StepShape_ShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Shell;
 class StepShape_Shell : public StepData_SelectType {
 	public:
@@ -4568,6 +4818,11 @@ class StepShape_Shell : public StepData_SelectType {
 };
 
 
+%extend StepShape_Shell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ShellBasedSurfaceModel;
 class StepShape_ShellBasedSurfaceModel : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4660,6 +4915,11 @@ class Handle_StepShape_ShellBasedSurfaceModel : public Handle_StepGeom_Geometric
     }
 };
 
+%extend StepShape_ShellBasedSurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SolidModel;
 class StepShape_SolidModel : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4718,6 +4978,11 @@ class Handle_StepShape_SolidModel : public Handle_StepGeom_GeometricRepresentati
     }
 };
 
+%extend StepShape_SolidModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Sphere;
 class StepShape_Sphere : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -4812,6 +5077,11 @@ class Handle_StepShape_Sphere : public Handle_StepGeom_GeometricRepresentationIt
     }
 };
 
+%extend StepShape_Sphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SurfaceModel;
 class StepShape_SurfaceModel : public StepData_SelectType {
 	public:
@@ -4838,6 +5108,11 @@ class StepShape_SurfaceModel : public StepData_SelectType {
 };
 
 
+%extend StepShape_SurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ToleranceMethodDefinition;
 class StepShape_ToleranceMethodDefinition : public StepData_SelectType {
 	public:
@@ -4868,6 +5143,11 @@ class StepShape_ToleranceMethodDefinition : public StepData_SelectType {
 };
 
 
+%extend StepShape_ToleranceMethodDefinition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ToleranceValue;
 class StepShape_ToleranceValue : public MMgt_TShared {
 	public:
@@ -4952,6 +5232,11 @@ class Handle_StepShape_ToleranceValue : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_ToleranceValue {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_TopologicalRepresentationItem;
 class StepShape_TopologicalRepresentationItem : public StepRepr_RepresentationItem {
 	public:
@@ -5010,6 +5295,11 @@ class Handle_StepShape_TopologicalRepresentationItem : public Handle_StepRepr_Re
     }
 };
 
+%extend StepShape_TopologicalRepresentationItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Torus;
 class StepShape_Torus : public StepGeom_GeometricRepresentationItem {
 	public:
@@ -5116,6 +5406,11 @@ class Handle_StepShape_Torus : public Handle_StepGeom_GeometricRepresentationIte
     }
 };
 
+%extend StepShape_Torus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_TypeQualifier;
 class StepShape_TypeQualifier : public MMgt_TShared {
 	public:
@@ -5188,6 +5483,11 @@ class Handle_StepShape_TypeQualifier : public Handle_MMgt_TShared {
     }
 };
 
+%extend StepShape_TypeQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ValueQualifier;
 class StepShape_ValueQualifier : public StepData_SelectType {
 	public:
@@ -5218,6 +5518,11 @@ class StepShape_ValueQualifier : public StepData_SelectType {
 };
 
 
+%extend StepShape_ValueQualifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_AdvancedBrepShapeRepresentation;
 class StepShape_AdvancedBrepShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -5276,6 +5581,11 @@ class Handle_StepShape_AdvancedBrepShapeRepresentation : public Handle_StepShape
     }
 };
 
+%extend StepShape_AdvancedBrepShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_AngularLocation;
 class StepShape_AngularLocation : public StepShape_DimensionalLocation {
 	public:
@@ -5366,6 +5676,11 @@ class Handle_StepShape_AngularLocation : public Handle_StepShape_DimensionalLoca
     }
 };
 
+%extend StepShape_AngularLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_AngularSize;
 class StepShape_AngularSize : public StepShape_DimensionalSize {
 	public:
@@ -5450,6 +5765,11 @@ class Handle_StepShape_AngularSize : public Handle_StepShape_DimensionalSize {
     }
 };
 
+%extend StepShape_AngularSize {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_BoxedHalfSpace;
 class StepShape_BoxedHalfSpace : public StepShape_HalfSpaceSolid {
 	public:
@@ -5540,6 +5860,11 @@ class Handle_StepShape_BoxedHalfSpace : public Handle_StepShape_HalfSpaceSolid {
     }
 };
 
+%extend StepShape_BoxedHalfSpace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_CompoundShapeRepresentation;
 class StepShape_CompoundShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -5598,6 +5923,11 @@ class Handle_StepShape_CompoundShapeRepresentation : public Handle_StepShape_Sha
     }
 };
 
+%extend StepShape_CompoundShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ConnectedEdgeSet;
 class StepShape_ConnectedEdgeSet : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -5680,6 +6010,11 @@ class Handle_StepShape_ConnectedEdgeSet : public Handle_StepShape_TopologicalRep
     }
 };
 
+%extend StepShape_ConnectedEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ConnectedFaceSet;
 class StepShape_ConnectedFaceSet : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -5772,6 +6107,11 @@ class Handle_StepShape_ConnectedFaceSet : public Handle_StepShape_TopologicalRep
     }
 };
 
+%extend StepShape_ConnectedFaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_CsgShapeRepresentation;
 class StepShape_CsgShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -5830,6 +6170,11 @@ class Handle_StepShape_CsgShapeRepresentation : public Handle_StepShape_ShapeRep
     }
 };
 
+%extend StepShape_CsgShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_CsgSolid;
 class StepShape_CsgSolid : public StepShape_SolidModel {
 	public:
@@ -5912,6 +6257,11 @@ class Handle_StepShape_CsgSolid : public Handle_StepShape_SolidModel {
     }
 };
 
+%extend StepShape_CsgSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalLocationWithPath;
 class StepShape_DimensionalLocationWithPath : public StepShape_DimensionalLocation {
 	public:
@@ -6002,6 +6352,11 @@ class Handle_StepShape_DimensionalLocationWithPath : public Handle_StepShape_Dim
     }
 };
 
+%extend StepShape_DimensionalLocationWithPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DimensionalSizeWithPath;
 class StepShape_DimensionalSizeWithPath : public StepShape_DimensionalSize {
 	public:
@@ -6086,6 +6441,11 @@ class Handle_StepShape_DimensionalSizeWithPath : public Handle_StepShape_Dimensi
     }
 };
 
+%extend StepShape_DimensionalSizeWithPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_DirectedDimensionalLocation;
 class StepShape_DirectedDimensionalLocation : public StepShape_DimensionalLocation {
 	public:
@@ -6144,6 +6504,11 @@ class Handle_StepShape_DirectedDimensionalLocation : public Handle_StepShape_Dim
     }
 };
 
+%extend StepShape_DirectedDimensionalLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Edge;
 class StepShape_Edge : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -6238,6 +6603,11 @@ class Handle_StepShape_Edge : public Handle_StepShape_TopologicalRepresentationI
     }
 };
 
+%extend StepShape_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_EdgeBasedWireframeShapeRepresentation;
 class StepShape_EdgeBasedWireframeShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -6296,6 +6666,11 @@ class Handle_StepShape_EdgeBasedWireframeShapeRepresentation : public Handle_Ste
     }
 };
 
+%extend StepShape_EdgeBasedWireframeShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Face;
 class StepShape_Face : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -6388,6 +6763,11 @@ class Handle_StepShape_Face : public Handle_StepShape_TopologicalRepresentationI
     }
 };
 
+%extend StepShape_Face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FaceBound;
 class StepShape_FaceBound : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -6482,6 +6862,11 @@ class Handle_StepShape_FaceBound : public Handle_StepShape_TopologicalRepresenta
     }
 };
 
+%extend StepShape_FaceBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FacetedBrepShapeRepresentation;
 class StepShape_FacetedBrepShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -6540,6 +6925,11 @@ class Handle_StepShape_FacetedBrepShapeRepresentation : public Handle_StepShape_
     }
 };
 
+%extend StepShape_FacetedBrepShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_GeometricCurveSet;
 class StepShape_GeometricCurveSet : public StepShape_GeometricSet {
 	public:
@@ -6598,6 +6988,11 @@ class Handle_StepShape_GeometricCurveSet : public Handle_StepShape_GeometricSet 
     }
 };
 
+%extend StepShape_GeometricCurveSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_GeometricallyBoundedSurfaceShapeRepresentation;
 class StepShape_GeometricallyBoundedSurfaceShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -6656,6 +7051,11 @@ class Handle_StepShape_GeometricallyBoundedSurfaceShapeRepresentation : public H
     }
 };
 
+%extend StepShape_GeometricallyBoundedSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_GeometricallyBoundedWireframeShapeRepresentation;
 class StepShape_GeometricallyBoundedWireframeShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -6714,6 +7114,11 @@ class Handle_StepShape_GeometricallyBoundedWireframeShapeRepresentation : public
     }
 };
 
+%extend StepShape_GeometricallyBoundedWireframeShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Loop;
 class StepShape_Loop : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -6772,6 +7177,11 @@ class Handle_StepShape_Loop : public Handle_StepShape_TopologicalRepresentationI
     }
 };
 
+%extend StepShape_Loop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_LoopAndPath;
 class StepShape_LoopAndPath : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -6894,6 +7304,11 @@ class Handle_StepShape_LoopAndPath : public Handle_StepShape_TopologicalRepresen
     }
 };
 
+%extend StepShape_LoopAndPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ManifoldSolidBrep;
 class StepShape_ManifoldSolidBrep : public StepShape_SolidModel {
 	public:
@@ -6984,6 +7399,11 @@ class Handle_StepShape_ManifoldSolidBrep : public Handle_StepShape_SolidModel {
     }
 };
 
+%extend StepShape_ManifoldSolidBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ManifoldSurfaceShapeRepresentation;
 class StepShape_ManifoldSurfaceShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -7042,6 +7462,11 @@ class Handle_StepShape_ManifoldSurfaceShapeRepresentation : public Handle_StepSh
     }
 };
 
+%extend StepShape_ManifoldSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_NonManifoldSurfaceShapeRepresentation;
 class StepShape_NonManifoldSurfaceShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -7100,6 +7525,11 @@ class Handle_StepShape_NonManifoldSurfaceShapeRepresentation : public Handle_Ste
     }
 };
 
+%extend StepShape_NonManifoldSurfaceShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Path;
 class StepShape_Path : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -7192,6 +7622,11 @@ class Handle_StepShape_Path : public Handle_StepShape_TopologicalRepresentationI
     }
 };
 
+%extend StepShape_Path {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_PointRepresentation;
 class StepShape_PointRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -7250,6 +7685,11 @@ class Handle_StepShape_PointRepresentation : public Handle_StepShape_ShapeRepres
     }
 };
 
+%extend StepShape_PointRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ShapeDimensionRepresentation;
 class StepShape_ShapeDimensionRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -7308,6 +7748,11 @@ class Handle_StepShape_ShapeDimensionRepresentation : public Handle_StepShape_Sh
     }
 };
 
+%extend StepShape_ShapeDimensionRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ShapeRepresentationWithParameters;
 class StepShape_ShapeRepresentationWithParameters : public StepShape_ShapeRepresentation {
 	public:
@@ -7366,6 +7811,11 @@ class Handle_StepShape_ShapeRepresentationWithParameters : public Handle_StepSha
     }
 };
 
+%extend StepShape_ShapeRepresentationWithParameters {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SolidReplica;
 class StepShape_SolidReplica : public StepShape_SolidModel {
 	public:
@@ -7460,6 +7910,11 @@ class Handle_StepShape_SolidReplica : public Handle_StepShape_SolidModel {
     }
 };
 
+%extend StepShape_SolidReplica {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SweptAreaSolid;
 class StepShape_SweptAreaSolid : public StepShape_SolidModel {
 	public:
@@ -7542,6 +7997,11 @@ class Handle_StepShape_SweptAreaSolid : public Handle_StepShape_SolidModel {
     }
 };
 
+%extend StepShape_SweptAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SweptFaceSolid;
 class StepShape_SweptFaceSolid : public StepShape_SolidModel {
 	public:
@@ -7624,6 +8084,11 @@ class Handle_StepShape_SweptFaceSolid : public Handle_StepShape_SolidModel {
     }
 };
 
+%extend StepShape_SweptFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_TransitionalShapeRepresentation;
 class StepShape_TransitionalShapeRepresentation : public StepShape_ShapeRepresentation {
 	public:
@@ -7682,6 +8147,11 @@ class Handle_StepShape_TransitionalShapeRepresentation : public Handle_StepShape
     }
 };
 
+%extend StepShape_TransitionalShapeRepresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Vertex;
 class StepShape_Vertex : public StepShape_TopologicalRepresentationItem {
 	public:
@@ -7740,6 +8210,11 @@ class Handle_StepShape_Vertex : public Handle_StepShape_TopologicalRepresentatio
     }
 };
 
+%extend StepShape_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_BrepWithVoids;
 class StepShape_BrepWithVoids : public StepShape_ManifoldSolidBrep {
 	public:
@@ -7836,6 +8311,11 @@ class Handle_StepShape_BrepWithVoids : public Handle_StepShape_ManifoldSolidBrep
     }
 };
 
+%extend StepShape_BrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ClosedShell;
 class StepShape_ClosedShell : public StepShape_ConnectedFaceSet {
 	public:
@@ -7894,6 +8374,11 @@ class Handle_StepShape_ClosedShell : public Handle_StepShape_ConnectedFaceSet {
     }
 };
 
+%extend StepShape_ClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ConnectedFaceSubSet;
 class StepShape_ConnectedFaceSubSet : public StepShape_ConnectedFaceSet {
 	public:
@@ -7978,6 +8463,11 @@ class Handle_StepShape_ConnectedFaceSubSet : public Handle_StepShape_ConnectedFa
     }
 };
 
+%extend StepShape_ConnectedFaceSubSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_EdgeCurve;
 class StepShape_EdgeCurve : public StepShape_Edge {
 	public:
@@ -8080,6 +8570,11 @@ class Handle_StepShape_EdgeCurve : public Handle_StepShape_Edge {
     }
 };
 
+%extend StepShape_EdgeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_EdgeLoop;
 class StepShape_EdgeLoop : public StepShape_Loop {
 	public:
@@ -8172,6 +8667,11 @@ class Handle_StepShape_EdgeLoop : public Handle_StepShape_Loop {
     }
 };
 
+%extend StepShape_EdgeLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ExtrudedAreaSolid;
 class StepShape_ExtrudedAreaSolid : public StepShape_SweptAreaSolid {
 	public:
@@ -8270,6 +8770,11 @@ class Handle_StepShape_ExtrudedAreaSolid : public Handle_StepShape_SweptAreaSoli
     }
 };
 
+%extend StepShape_ExtrudedAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_ExtrudedFaceSolid;
 class StepShape_ExtrudedFaceSolid : public StepShape_SweptFaceSolid {
 	public:
@@ -8368,6 +8873,11 @@ class Handle_StepShape_ExtrudedFaceSolid : public Handle_StepShape_SweptFaceSoli
     }
 };
 
+%extend StepShape_ExtrudedFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FaceOuterBound;
 class StepShape_FaceOuterBound : public StepShape_FaceBound {
 	public:
@@ -8426,6 +8936,11 @@ class Handle_StepShape_FaceOuterBound : public Handle_StepShape_FaceBound {
     }
 };
 
+%extend StepShape_FaceOuterBound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FaceSurface;
 class StepShape_FaceSurface : public StepShape_Face {
 	public:
@@ -8524,6 +9039,11 @@ class Handle_StepShape_FaceSurface : public Handle_StepShape_Face {
     }
 };
 
+%extend StepShape_FaceSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FacetedBrep;
 class StepShape_FacetedBrep : public StepShape_ManifoldSolidBrep {
 	public:
@@ -8582,6 +9102,11 @@ class Handle_StepShape_FacetedBrep : public Handle_StepShape_ManifoldSolidBrep {
     }
 };
 
+%extend StepShape_FacetedBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_FacetedBrepAndBrepWithVoids;
 class StepShape_FacetedBrepAndBrepWithVoids : public StepShape_ManifoldSolidBrep {
 	public:
@@ -8710,6 +9235,11 @@ class Handle_StepShape_FacetedBrepAndBrepWithVoids : public Handle_StepShape_Man
     }
 };
 
+%extend StepShape_FacetedBrepAndBrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OpenShell;
 class StepShape_OpenShell : public StepShape_ConnectedFaceSet {
 	public:
@@ -8768,6 +9298,11 @@ class Handle_StepShape_OpenShell : public Handle_StepShape_ConnectedFaceSet {
     }
 };
 
+%extend StepShape_OpenShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OrientedEdge;
 class StepShape_OrientedEdge : public StepShape_Edge {
 	public:
@@ -8876,6 +9411,11 @@ class Handle_StepShape_OrientedEdge : public Handle_StepShape_Edge {
     }
 };
 
+%extend StepShape_OrientedEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OrientedFace;
 class StepShape_OrientedFace : public StepShape_Face {
 	public:
@@ -8992,6 +9532,11 @@ class Handle_StepShape_OrientedFace : public Handle_StepShape_Face {
     }
 };
 
+%extend StepShape_OrientedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OrientedPath;
 class StepShape_OrientedPath : public StepShape_Path {
 	public:
@@ -9108,6 +9653,11 @@ class Handle_StepShape_OrientedPath : public Handle_StepShape_Path {
     }
 };
 
+%extend StepShape_OrientedPath {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_PolyLoop;
 class StepShape_PolyLoop : public StepShape_Loop {
 	public:
@@ -9200,6 +9750,11 @@ class Handle_StepShape_PolyLoop : public Handle_StepShape_Loop {
     }
 };
 
+%extend StepShape_PolyLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_RevolvedAreaSolid;
 class StepShape_RevolvedAreaSolid : public StepShape_SweptAreaSolid {
 	public:
@@ -9298,6 +9853,11 @@ class Handle_StepShape_RevolvedAreaSolid : public Handle_StepShape_SweptAreaSoli
     }
 };
 
+%extend StepShape_RevolvedAreaSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_RevolvedFaceSolid;
 class StepShape_RevolvedFaceSolid : public StepShape_SweptFaceSolid {
 	public:
@@ -9396,6 +9956,11 @@ class Handle_StepShape_RevolvedFaceSolid : public Handle_StepShape_SweptFaceSoli
     }
 };
 
+%extend StepShape_RevolvedFaceSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Subedge;
 class StepShape_Subedge : public StepShape_Edge {
 	public:
@@ -9482,6 +10047,11 @@ class Handle_StepShape_Subedge : public Handle_StepShape_Edge {
     }
 };
 
+%extend StepShape_Subedge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_Subface;
 class StepShape_Subface : public StepShape_Face {
 	public:
@@ -9566,6 +10136,11 @@ class Handle_StepShape_Subface : public Handle_StepShape_Face {
     }
 };
 
+%extend StepShape_Subface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_VertexLoop;
 class StepShape_VertexLoop : public StepShape_Loop {
 	public:
@@ -9648,6 +10223,11 @@ class Handle_StepShape_VertexLoop : public Handle_StepShape_Loop {
     }
 };
 
+%extend StepShape_VertexLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_VertexPoint;
 class StepShape_VertexPoint : public StepShape_Vertex {
 	public:
@@ -9730,6 +10310,11 @@ class Handle_StepShape_VertexPoint : public Handle_StepShape_Vertex {
     }
 };
 
+%extend StepShape_VertexPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_AdvancedFace;
 class StepShape_AdvancedFace : public StepShape_FaceSurface {
 	public:
@@ -9788,6 +10373,11 @@ class Handle_StepShape_AdvancedFace : public Handle_StepShape_FaceSurface {
     }
 };
 
+%extend StepShape_AdvancedFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OrientedClosedShell;
 class StepShape_OrientedClosedShell : public StepShape_ClosedShell {
 	public:
@@ -9904,6 +10494,11 @@ class Handle_StepShape_OrientedClosedShell : public Handle_StepShape_ClosedShell
     }
 };
 
+%extend StepShape_OrientedClosedShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_OrientedOpenShell;
 class StepShape_OrientedOpenShell : public StepShape_OpenShell {
 	public:
@@ -10020,6 +10615,11 @@ class Handle_StepShape_OrientedOpenShell : public Handle_StepShape_OpenShell {
     }
 };
 
+%extend StepShape_OrientedOpenShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepShape_SeamEdge;
 class StepShape_SeamEdge : public StepShape_OrientedEdge {
 	public:
@@ -10106,3 +10706,8 @@ class Handle_StepShape_SeamEdge : public Handle_StepShape_OrientedEdge {
     }
 };
 
+%extend StepShape_SeamEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepToGeom.i
+++ b/src/SWIG_files/wrapper/StepToGeom.i
@@ -69,6 +69,11 @@ class StepToGeom_MakeAxis1Placement {
 };
 
 
+%extend StepToGeom_MakeAxis1Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeAxis2Placement {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -82,6 +87,11 @@ class StepToGeom_MakeAxis2Placement {
 };
 
 
+%extend StepToGeom_MakeAxis2Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeAxisPlacement {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -95,6 +105,11 @@ class StepToGeom_MakeAxisPlacement {
 };
 
 
+%extend StepToGeom_MakeAxisPlacement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBSplineCurve {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -108,6 +123,11 @@ class StepToGeom_MakeBSplineCurve {
 };
 
 
+%extend StepToGeom_MakeBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBSplineCurve2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -121,6 +141,11 @@ class StepToGeom_MakeBSplineCurve2d {
 };
 
 
+%extend StepToGeom_MakeBSplineCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBSplineSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -134,6 +159,11 @@ class StepToGeom_MakeBSplineSurface {
 };
 
 
+%extend StepToGeom_MakeBSplineSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBoundedCurve {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -147,6 +177,11 @@ class StepToGeom_MakeBoundedCurve {
 };
 
 
+%extend StepToGeom_MakeBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBoundedCurve2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -160,6 +195,11 @@ class StepToGeom_MakeBoundedCurve2d {
 };
 
 
+%extend StepToGeom_MakeBoundedCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeBoundedSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -173,6 +213,11 @@ class StepToGeom_MakeBoundedSurface {
 };
 
 
+%extend StepToGeom_MakeBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCartesianPoint {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -186,6 +231,11 @@ class StepToGeom_MakeCartesianPoint {
 };
 
 
+%extend StepToGeom_MakeCartesianPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCartesianPoint2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -199,6 +249,11 @@ class StepToGeom_MakeCartesianPoint2d {
 };
 
 
+%extend StepToGeom_MakeCartesianPoint2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCircle {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -212,6 +267,11 @@ class StepToGeom_MakeCircle {
 };
 
 
+%extend StepToGeom_MakeCircle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCircle2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -225,6 +285,11 @@ class StepToGeom_MakeCircle2d {
 };
 
 
+%extend StepToGeom_MakeCircle2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeConic {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -238,6 +303,11 @@ class StepToGeom_MakeConic {
 };
 
 
+%extend StepToGeom_MakeConic {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeConic2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -251,6 +321,11 @@ class StepToGeom_MakeConic2d {
 };
 
 
+%extend StepToGeom_MakeConic2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeConicalSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -264,6 +339,11 @@ class StepToGeom_MakeConicalSurface {
 };
 
 
+%extend StepToGeom_MakeConicalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCurve {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -277,6 +357,11 @@ class StepToGeom_MakeCurve {
 };
 
 
+%extend StepToGeom_MakeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCurve2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -290,6 +375,11 @@ class StepToGeom_MakeCurve2d {
 };
 
 
+%extend StepToGeom_MakeCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeCylindricalSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -303,6 +393,11 @@ class StepToGeom_MakeCylindricalSurface {
 };
 
 
+%extend StepToGeom_MakeCylindricalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeDirection {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -316,6 +411,11 @@ class StepToGeom_MakeDirection {
 };
 
 
+%extend StepToGeom_MakeDirection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeDirection2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -329,6 +429,11 @@ class StepToGeom_MakeDirection2d {
 };
 
 
+%extend StepToGeom_MakeDirection2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeElementarySurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -342,6 +447,11 @@ class StepToGeom_MakeElementarySurface {
 };
 
 
+%extend StepToGeom_MakeElementarySurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeEllipse {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -355,6 +465,11 @@ class StepToGeom_MakeEllipse {
 };
 
 
+%extend StepToGeom_MakeEllipse {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeEllipse2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -368,6 +483,11 @@ class StepToGeom_MakeEllipse2d {
 };
 
 
+%extend StepToGeom_MakeEllipse2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeHyperbola {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -381,6 +501,11 @@ class StepToGeom_MakeHyperbola {
 };
 
 
+%extend StepToGeom_MakeHyperbola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeHyperbola2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -394,6 +519,11 @@ class StepToGeom_MakeHyperbola2d {
 };
 
 
+%extend StepToGeom_MakeHyperbola2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeLine {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -407,6 +537,11 @@ class StepToGeom_MakeLine {
 };
 
 
+%extend StepToGeom_MakeLine {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeLine2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -420,6 +555,11 @@ class StepToGeom_MakeLine2d {
 };
 
 
+%extend StepToGeom_MakeLine2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeParabola {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -433,6 +573,11 @@ class StepToGeom_MakeParabola {
 };
 
 
+%extend StepToGeom_MakeParabola {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeParabola2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -446,6 +591,11 @@ class StepToGeom_MakeParabola2d {
 };
 
 
+%extend StepToGeom_MakeParabola2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakePlane {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -459,6 +609,11 @@ class StepToGeom_MakePlane {
 };
 
 
+%extend StepToGeom_MakePlane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakePolyline2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -472,6 +627,11 @@ class StepToGeom_MakePolyline2d {
 };
 
 
+%extend StepToGeom_MakePolyline2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeRectangularTrimmedSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -485,6 +645,11 @@ class StepToGeom_MakeRectangularTrimmedSurface {
 };
 
 
+%extend StepToGeom_MakeRectangularTrimmedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeSphericalSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -498,6 +663,11 @@ class StepToGeom_MakeSphericalSurface {
 };
 
 
+%extend StepToGeom_MakeSphericalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -511,6 +681,11 @@ class StepToGeom_MakeSurface {
 };
 
 
+%extend StepToGeom_MakeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeSurfaceOfLinearExtrusion {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -524,6 +699,11 @@ class StepToGeom_MakeSurfaceOfLinearExtrusion {
 };
 
 
+%extend StepToGeom_MakeSurfaceOfLinearExtrusion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeSurfaceOfRevolution {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -537,6 +717,11 @@ class StepToGeom_MakeSurfaceOfRevolution {
 };
 
 
+%extend StepToGeom_MakeSurfaceOfRevolution {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeSweptSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -550,6 +735,11 @@ class StepToGeom_MakeSweptSurface {
 };
 
 
+%extend StepToGeom_MakeSweptSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeToroidalSurface {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -563,6 +753,11 @@ class StepToGeom_MakeToroidalSurface {
 };
 
 
+%extend StepToGeom_MakeToroidalSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeTransformation2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -576,6 +771,11 @@ class StepToGeom_MakeTransformation2d {
 };
 
 
+%extend StepToGeom_MakeTransformation2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeTransformation3d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -589,6 +789,11 @@ class StepToGeom_MakeTransformation3d {
 };
 
 
+%extend StepToGeom_MakeTransformation3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeTrimmedCurve {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -602,6 +807,11 @@ class StepToGeom_MakeTrimmedCurve {
 };
 
 
+%extend StepToGeom_MakeTrimmedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeTrimmedCurve2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -615,6 +825,11 @@ class StepToGeom_MakeTrimmedCurve2d {
 };
 
 
+%extend StepToGeom_MakeTrimmedCurve2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeVectorWithMagnitude {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -628,6 +843,11 @@ class StepToGeom_MakeVectorWithMagnitude {
 };
 
 
+%extend StepToGeom_MakeVectorWithMagnitude {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakeVectorWithMagnitude2d {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -641,6 +861,11 @@ class StepToGeom_MakeVectorWithMagnitude2d {
 };
 
 
+%extend StepToGeom_MakeVectorWithMagnitude2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_Root {
 	public:
 		%feature("compactdefaultargs") IsDone;
@@ -650,6 +875,11 @@ class StepToGeom_Root {
 };
 
 
+%extend StepToGeom_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToGeom_MakePolyline : public StepToGeom_Root {
 	public:
 		%feature("compactdefaultargs") Convert;
@@ -663,3 +893,8 @@ class StepToGeom_MakePolyline : public StepToGeom_Root {
 };
 
 
+%extend StepToGeom_MakePolyline {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StepToTopoDS.i
+++ b/src/SWIG_files/wrapper/StepToTopoDS.i
@@ -159,6 +159,11 @@ class StepToTopoDS {
 };
 
 
+%extend StepToTopoDS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToTopoDS_CartesianPointHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -184,6 +189,11 @@ class StepToTopoDS_CartesianPointHasher {
 };
 
 
+%extend StepToTopoDS_CartesianPointHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapIteratorOfDataMapOfRI;
 class StepToTopoDS_DataMapIteratorOfDataMapOfRI : public TCollection_BasicMapIterator {
 	public:
@@ -214,6 +224,11 @@ class StepToTopoDS_DataMapIteratorOfDataMapOfRI : public TCollection_BasicMapIte
 };
 
 
+%extend StepToTopoDS_DataMapIteratorOfDataMapOfRI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapIteratorOfDataMapOfRINames;
 class StepToTopoDS_DataMapIteratorOfDataMapOfRINames : public TCollection_BasicMapIterator {
 	public:
@@ -244,6 +259,11 @@ class StepToTopoDS_DataMapIteratorOfDataMapOfRINames : public TCollection_BasicM
 };
 
 
+%extend StepToTopoDS_DataMapIteratorOfDataMapOfRINames {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapIteratorOfDataMapOfTRI;
 class StepToTopoDS_DataMapIteratorOfDataMapOfTRI : public TCollection_BasicMapIterator {
 	public:
@@ -274,6 +294,11 @@ class StepToTopoDS_DataMapIteratorOfDataMapOfTRI : public TCollection_BasicMapIt
 };
 
 
+%extend StepToTopoDS_DataMapIteratorOfDataMapOfTRI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapIteratorOfPointEdgeMap;
 class StepToTopoDS_DataMapIteratorOfPointEdgeMap : public TCollection_BasicMapIterator {
 	public:
@@ -304,6 +329,11 @@ class StepToTopoDS_DataMapIteratorOfPointEdgeMap : public TCollection_BasicMapIt
 };
 
 
+%extend StepToTopoDS_DataMapIteratorOfPointEdgeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapIteratorOfPointVertexMap;
 class StepToTopoDS_DataMapIteratorOfPointVertexMap : public TCollection_BasicMapIterator {
 	public:
@@ -334,6 +364,11 @@ class StepToTopoDS_DataMapIteratorOfPointVertexMap : public TCollection_BasicMap
 };
 
 
+%extend StepToTopoDS_DataMapIteratorOfPointVertexMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapNodeOfDataMapOfRI;
 class StepToTopoDS_DataMapNodeOfDataMapOfRI : public TCollection_MapNode {
 	public:
@@ -404,6 +439,11 @@ class Handle_StepToTopoDS_DataMapNodeOfDataMapOfRI : public Handle_TCollection_M
     }
 };
 
+%extend StepToTopoDS_DataMapNodeOfDataMapOfRI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapNodeOfDataMapOfRINames;
 class StepToTopoDS_DataMapNodeOfDataMapOfRINames : public TCollection_MapNode {
 	public:
@@ -474,6 +514,11 @@ class Handle_StepToTopoDS_DataMapNodeOfDataMapOfRINames : public Handle_TCollect
     }
 };
 
+%extend StepToTopoDS_DataMapNodeOfDataMapOfRINames {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapNodeOfDataMapOfTRI;
 class StepToTopoDS_DataMapNodeOfDataMapOfTRI : public TCollection_MapNode {
 	public:
@@ -544,6 +589,11 @@ class Handle_StepToTopoDS_DataMapNodeOfDataMapOfTRI : public Handle_TCollection_
     }
 };
 
+%extend StepToTopoDS_DataMapNodeOfDataMapOfTRI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapNodeOfPointEdgeMap;
 class StepToTopoDS_DataMapNodeOfPointEdgeMap : public TCollection_MapNode {
 	public:
@@ -614,6 +664,11 @@ class Handle_StepToTopoDS_DataMapNodeOfPointEdgeMap : public Handle_TCollection_
     }
 };
 
+%extend StepToTopoDS_DataMapNodeOfPointEdgeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_DataMapNodeOfPointVertexMap;
 class StepToTopoDS_DataMapNodeOfPointVertexMap : public TCollection_MapNode {
 	public:
@@ -684,6 +739,11 @@ class Handle_StepToTopoDS_DataMapNodeOfPointVertexMap : public Handle_TCollectio
     }
 };
 
+%extend StepToTopoDS_DataMapNodeOfPointVertexMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToTopoDS_GeometricTool {
 	public:
 		%feature("compactdefaultargs") PCurve;
@@ -737,6 +797,11 @@ class StepToTopoDS_GeometricTool {
 };
 
 
+%extend StepToTopoDS_GeometricTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_NMTool;
 class StepToTopoDS_NMTool {
 	public:
@@ -847,6 +912,11 @@ class StepToTopoDS_NMTool {
 };
 
 
+%extend StepToTopoDS_NMTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_PointPair;
 class StepToTopoDS_PointPair {
 	public:
@@ -861,6 +931,11 @@ class StepToTopoDS_PointPair {
 };
 
 
+%extend StepToTopoDS_PointPair {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class StepToTopoDS_PointPairHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -886,6 +961,11 @@ class StepToTopoDS_PointPairHasher {
 };
 
 
+%extend StepToTopoDS_PointPairHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_Root;
 class StepToTopoDS_Root {
 	public:
@@ -924,6 +1004,11 @@ class StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_Tool;
 class StepToTopoDS_Tool {
 	public:
@@ -1086,6 +1171,11 @@ class StepToTopoDS_Tool {
 };
 
 
+%extend StepToTopoDS_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_MakeTransformed;
 class StepToTopoDS_MakeTransformed : public StepToTopoDS_Root {
 	public:
@@ -1138,6 +1228,11 @@ class StepToTopoDS_MakeTransformed : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_MakeTransformed {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateCompositeCurve;
 class StepToTopoDS_TranslateCompositeCurve : public StepToTopoDS_Root {
 	public:
@@ -1210,6 +1305,11 @@ class StepToTopoDS_TranslateCompositeCurve : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateCompositeCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateCurveBoundedSurface;
 class StepToTopoDS_TranslateCurveBoundedSurface : public StepToTopoDS_Root {
 	public:
@@ -1248,6 +1348,11 @@ class StepToTopoDS_TranslateCurveBoundedSurface : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateCurveBoundedSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateEdge;
 class StepToTopoDS_TranslateEdge : public StepToTopoDS_Root {
 	public:
@@ -1316,6 +1421,11 @@ class StepToTopoDS_TranslateEdge : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateEdgeLoop;
 class StepToTopoDS_TranslateEdgeLoop : public StepToTopoDS_Root {
 	public:
@@ -1370,6 +1480,11 @@ class StepToTopoDS_TranslateEdgeLoop : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateEdgeLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateFace;
 class StepToTopoDS_TranslateFace : public StepToTopoDS_Root {
 	public:
@@ -1408,6 +1523,11 @@ class StepToTopoDS_TranslateFace : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslatePolyLoop;
 class StepToTopoDS_TranslatePolyLoop : public StepToTopoDS_Root {
 	public:
@@ -1450,6 +1570,11 @@ class StepToTopoDS_TranslatePolyLoop : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslatePolyLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateShell;
 class StepToTopoDS_TranslateShell : public StepToTopoDS_Root {
 	public:
@@ -1488,6 +1613,11 @@ class StepToTopoDS_TranslateShell : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateVertex;
 class StepToTopoDS_TranslateVertex : public StepToTopoDS_Root {
 	public:
@@ -1526,6 +1656,11 @@ class StepToTopoDS_TranslateVertex : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StepToTopoDS_TranslateVertexLoop;
 class StepToTopoDS_TranslateVertexLoop : public StepToTopoDS_Root {
 	public:
@@ -1564,3 +1699,8 @@ class StepToTopoDS_TranslateVertexLoop : public StepToTopoDS_Root {
 };
 
 
+%extend StepToTopoDS_TranslateVertexLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StlAPI.i
+++ b/src/SWIG_files/wrapper/StlAPI.i
@@ -84,6 +84,11 @@ class StlAPI {
 };
 
 
+%extend StlAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlAPI_Reader;
 class StlAPI_Reader {
 	public:
@@ -102,6 +107,11 @@ class StlAPI_Reader {
 };
 
 
+%extend StlAPI_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlAPI_Writer;
 class StlAPI_Writer {
 	public:
@@ -168,3 +178,8 @@ class StlAPI_Writer {
 };
 
 
+%extend StlAPI_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StlMesh.i
+++ b/src/SWIG_files/wrapper/StlMesh.i
@@ -72,6 +72,11 @@ class StlMesh {
 };
 
 
+%extend StlMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_Mesh;
 class StlMesh_Mesh : public MMgt_TShared {
 	public:
@@ -262,6 +267,11 @@ class Handle_StlMesh_Mesh : public Handle_MMgt_TShared {
     }
 };
 
+%extend StlMesh_Mesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_MeshDomain;
 class StlMesh_MeshDomain : public MMgt_TShared {
 	public:
@@ -400,6 +410,11 @@ class Handle_StlMesh_MeshDomain : public Handle_MMgt_TShared {
     }
 };
 
+%extend StlMesh_MeshDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_MeshExplorer;
 class StlMesh_MeshExplorer {
 	public:
@@ -472,6 +487,11 @@ class StlMesh_MeshExplorer {
 };
 
 
+%extend StlMesh_MeshExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_MeshTriangle;
 class StlMesh_MeshTriangle : public MMgt_TShared {
 	public:
@@ -608,6 +628,11 @@ class Handle_StlMesh_MeshTriangle : public Handle_MMgt_TShared {
     }
 };
 
+%extend StlMesh_MeshTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceNodeOfSequenceOfMesh;
 class StlMesh_SequenceNodeOfSequenceOfMesh : public TCollection_SeqNode {
 	public:
@@ -674,6 +699,11 @@ class Handle_StlMesh_SequenceNodeOfSequenceOfMesh : public Handle_TCollection_Se
     }
 };
 
+%extend StlMesh_SequenceNodeOfSequenceOfMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceNodeOfSequenceOfMeshDomain;
 class StlMesh_SequenceNodeOfSequenceOfMeshDomain : public TCollection_SeqNode {
 	public:
@@ -740,6 +770,11 @@ class Handle_StlMesh_SequenceNodeOfSequenceOfMeshDomain : public Handle_TCollect
     }
 };
 
+%extend StlMesh_SequenceNodeOfSequenceOfMeshDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceNodeOfSequenceOfMeshTriangle;
 class StlMesh_SequenceNodeOfSequenceOfMeshTriangle : public TCollection_SeqNode {
 	public:
@@ -806,6 +841,11 @@ class Handle_StlMesh_SequenceNodeOfSequenceOfMeshTriangle : public Handle_TColle
     }
 };
 
+%extend StlMesh_SequenceNodeOfSequenceOfMeshTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceOfMesh;
 class StlMesh_SequenceOfMesh : public TCollection_BaseSequence {
 	public:
@@ -944,6 +984,11 @@ class StlMesh_SequenceOfMesh : public TCollection_BaseSequence {
 };
 
 
+%extend StlMesh_SequenceOfMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceOfMeshDomain;
 class StlMesh_SequenceOfMeshDomain : public TCollection_BaseSequence {
 	public:
@@ -1082,6 +1127,11 @@ class StlMesh_SequenceOfMeshDomain : public TCollection_BaseSequence {
 };
 
 
+%extend StlMesh_SequenceOfMeshDomain {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor StlMesh_SequenceOfMeshTriangle;
 class StlMesh_SequenceOfMeshTriangle : public TCollection_BaseSequence {
 	public:
@@ -1220,3 +1270,8 @@ class StlMesh_SequenceOfMeshTriangle : public TCollection_BaseSequence {
 };
 
 
+%extend StlMesh_SequenceOfMeshTriangle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/StlTransfer.i
+++ b/src/SWIG_files/wrapper/StlTransfer.i
@@ -74,3 +74,8 @@ class StlTransfer {
 };
 
 
+%extend StlTransfer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Storage.i
+++ b/src/SWIG_files/wrapper/Storage.i
@@ -100,6 +100,11 @@ class Storage {
 };
 
 
+%extend Storage {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_ArrayOfCallBack;
 class Storage_ArrayOfCallBack {
 	public:
@@ -182,6 +187,11 @@ class Storage_ArrayOfCallBack {
 };
 
 
+%extend Storage_ArrayOfCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_ArrayOfSchema;
 class Storage_ArrayOfSchema {
 	public:
@@ -264,6 +274,11 @@ class Storage_ArrayOfSchema {
 };
 
 
+%extend Storage_ArrayOfSchema {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_BaseDriver;
 class Storage_BaseDriver {
 	public:
@@ -712,6 +727,11 @@ class Storage_BaseDriver {
 };
 
 
+%extend Storage_BaseDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_CallBack;
 class Storage_CallBack : public MMgt_TShared {
 	public:
@@ -796,6 +816,11 @@ class Handle_Storage_CallBack : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_CallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_Data;
 class Storage_Data : public MMgt_TShared {
 	public:
@@ -1044,6 +1069,11 @@ class Handle_Storage_Data : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_Data {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_DataMapIteratorOfMapOfCallBack;
 class Storage_DataMapIteratorOfMapOfCallBack : public TCollection_BasicMapIterator {
 	public:
@@ -1074,6 +1104,11 @@ class Storage_DataMapIteratorOfMapOfCallBack : public TCollection_BasicMapIterat
 };
 
 
+%extend Storage_DataMapIteratorOfMapOfCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_DataMapIteratorOfMapOfPers;
 class Storage_DataMapIteratorOfMapOfPers : public TCollection_BasicMapIterator {
 	public:
@@ -1104,6 +1139,11 @@ class Storage_DataMapIteratorOfMapOfPers : public TCollection_BasicMapIterator {
 };
 
 
+%extend Storage_DataMapIteratorOfMapOfPers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_DataMapNodeOfMapOfCallBack;
 class Storage_DataMapNodeOfMapOfCallBack : public TCollection_MapNode {
 	public:
@@ -1174,6 +1214,11 @@ class Handle_Storage_DataMapNodeOfMapOfCallBack : public Handle_TCollection_MapN
     }
 };
 
+%extend Storage_DataMapNodeOfMapOfCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_DataMapNodeOfMapOfPers;
 class Storage_DataMapNodeOfMapOfPers : public TCollection_MapNode {
 	public:
@@ -1244,6 +1289,11 @@ class Handle_Storage_DataMapNodeOfMapOfPers : public Handle_TCollection_MapNode 
     }
 };
 
+%extend Storage_DataMapNodeOfMapOfPers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_HArrayOfCallBack;
 class Storage_HArrayOfCallBack : public MMgt_TShared {
 	public:
@@ -1360,6 +1410,11 @@ class Handle_Storage_HArrayOfCallBack : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_HArrayOfCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_HArrayOfSchema;
 class Storage_HArrayOfSchema : public MMgt_TShared {
 	public:
@@ -1476,6 +1531,11 @@ class Handle_Storage_HArrayOfSchema : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_HArrayOfSchema {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_HPArray;
 class Storage_HPArray : public MMgt_TShared {
 	public:
@@ -1592,6 +1652,11 @@ class Handle_Storage_HPArray : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_HPArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_HSeqOfRoot;
 class Storage_HSeqOfRoot : public MMgt_TShared {
 	public:
@@ -1776,6 +1841,11 @@ class Handle_Storage_HSeqOfRoot : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_HSeqOfRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_HeaderData;
 class Storage_HeaderData : public MMgt_TShared {
 	public:
@@ -1944,6 +2014,11 @@ class Handle_Storage_HeaderData : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_HeaderData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_IndexedDataMapNodeOfPType;
 class Storage_IndexedDataMapNodeOfPType : public TCollection_MapNode {
 	public:
@@ -2044,6 +2119,11 @@ class Handle_Storage_IndexedDataMapNodeOfPType : public Handle_TCollection_MapNo
     }
 };
 
+%extend Storage_IndexedDataMapNodeOfPType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_InternalData;
 class Storage_InternalData : public MMgt_TShared {
 	public:
@@ -2104,6 +2184,11 @@ class Handle_Storage_InternalData : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_InternalData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_MapOfCallBack;
 class Storage_MapOfCallBack : public TCollection_BasicMap {
 	public:
@@ -2182,6 +2267,11 @@ class Storage_MapOfCallBack : public TCollection_BasicMap {
 };
 
 
+%extend Storage_MapOfCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_MapOfPers;
 class Storage_MapOfPers : public TCollection_BasicMap {
 	public:
@@ -2260,6 +2350,11 @@ class Storage_MapOfPers : public TCollection_BasicMap {
 };
 
 
+%extend Storage_MapOfPers {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_PArray;
 class Storage_PArray {
 	public:
@@ -2342,6 +2437,11 @@ class Storage_PArray {
 };
 
 
+%extend Storage_PArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_PType;
 class Storage_PType : public TCollection_BasicMap {
 	public:
@@ -2452,6 +2552,11 @@ class Storage_PType : public TCollection_BasicMap {
 };
 
 
+%extend Storage_PType {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_Root;
 class Storage_Root : public MMgt_TShared {
 	public:
@@ -2546,6 +2651,11 @@ class Handle_Storage_Root : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_RootData;
 class Storage_RootData : public MMgt_TShared {
 	public:
@@ -2656,6 +2766,11 @@ class Handle_Storage_RootData : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_RootData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_Schema;
 class Storage_Schema : public MMgt_TShared {
 	public:
@@ -2960,6 +3075,11 @@ class Handle_Storage_Schema : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_Schema {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_SeqOfRoot;
 class Storage_SeqOfRoot : public TCollection_BaseSequence {
 	public:
@@ -3098,6 +3218,11 @@ class Storage_SeqOfRoot : public TCollection_BaseSequence {
 };
 
 
+%extend Storage_SeqOfRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_SequenceNodeOfSeqOfRoot;
 class Storage_SequenceNodeOfSeqOfRoot : public TCollection_SeqNode {
 	public:
@@ -3164,6 +3289,11 @@ class Handle_Storage_SequenceNodeOfSeqOfRoot : public Handle_TCollection_SeqNode
     }
 };
 
+%extend Storage_SequenceNodeOfSeqOfRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_TypeData;
 class Storage_TypeData : public MMgt_TShared {
 	public:
@@ -3250,6 +3380,11 @@ class Handle_Storage_TypeData : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_TypeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_TypedCallBack;
 class Storage_TypedCallBack : public MMgt_TShared {
 	public:
@@ -3344,12 +3479,22 @@ class Handle_Storage_TypedCallBack : public Handle_MMgt_TShared {
     }
 };
 
+%extend Storage_TypedCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_stCONSTclCOM;
 class Storage_stCONSTclCOM {
 	public:
 };
 
 
+%extend Storage_stCONSTclCOM {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Storage_DefaultCallBack;
 class Storage_DefaultCallBack : public Storage_CallBack {
 	public:
@@ -3438,3 +3583,8 @@ class Handle_Storage_DefaultCallBack : public Handle_Storage_CallBack {
     }
 };
 
+%extend Storage_DefaultCallBack {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Sweep.i
+++ b/src/SWIG_files/wrapper/Sweep.i
@@ -124,6 +124,11 @@ class Sweep_NumShape {
 };
 
 
+%extend Sweep_NumShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Sweep_NumShapeIterator;
 class Sweep_NumShapeIterator {
 	public:
@@ -166,6 +171,11 @@ class Sweep_NumShapeIterator {
 };
 
 
+%extend Sweep_NumShapeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Sweep_NumShapeTool;
 class Sweep_NumShapeTool {
 	public:
@@ -242,3 +252,8 @@ class Sweep_NumShapeTool {
 };
 
 
+%extend Sweep_NumShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TColGeom.i
+++ b/src/SWIG_files/wrapper/TColGeom.i
@@ -138,6 +138,11 @@ class TColGeom_Array1OfBSplineCurve {
 };
 
 
+%extend TColGeom_Array1OfBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_Array1OfBezierCurve;
 class TColGeom_Array1OfBezierCurve {
 	public:
@@ -220,6 +225,11 @@ class TColGeom_Array1OfBezierCurve {
 };
 
 
+%extend TColGeom_Array1OfBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_Array1OfCurve;
 class TColGeom_Array1OfCurve {
 	public:
@@ -302,6 +312,11 @@ class TColGeom_Array1OfCurve {
 };
 
 
+%extend TColGeom_Array1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_Array1OfSurface;
 class TColGeom_Array1OfSurface {
 	public:
@@ -384,6 +399,11 @@ class TColGeom_Array1OfSurface {
 };
 
 
+%extend TColGeom_Array1OfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_Array2OfBezierSurface;
 class TColGeom_Array2OfBezierSurface {
 	public:
@@ -488,6 +508,11 @@ class TColGeom_Array2OfBezierSurface {
 };
 
 
+%extend TColGeom_Array2OfBezierSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_Array2OfSurface;
 class TColGeom_Array2OfSurface {
 	public:
@@ -592,6 +617,11 @@ class TColGeom_Array2OfSurface {
 };
 
 
+%extend TColGeom_Array2OfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HArray1OfBSplineCurve;
 class TColGeom_HArray1OfBSplineCurve : public MMgt_TShared {
 	public:
@@ -708,6 +738,11 @@ class Handle_TColGeom_HArray1OfBSplineCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HArray1OfBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HArray1OfBezierCurve;
 class TColGeom_HArray1OfBezierCurve : public MMgt_TShared {
 	public:
@@ -824,6 +859,11 @@ class Handle_TColGeom_HArray1OfBezierCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HArray1OfBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HArray1OfCurve;
 class TColGeom_HArray1OfCurve : public MMgt_TShared {
 	public:
@@ -940,6 +980,11 @@ class Handle_TColGeom_HArray1OfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HArray1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HArray1OfSurface;
 class TColGeom_HArray1OfSurface : public MMgt_TShared {
 	public:
@@ -1056,6 +1101,11 @@ class Handle_TColGeom_HArray1OfSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HArray1OfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HArray2OfSurface;
 class TColGeom_HArray2OfSurface : public MMgt_TShared {
 	public:
@@ -1198,6 +1248,11 @@ class Handle_TColGeom_HArray2OfSurface : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HArray2OfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HSequenceOfBoundedCurve;
 class TColGeom_HSequenceOfBoundedCurve : public MMgt_TShared {
 	public:
@@ -1382,6 +1437,11 @@ class Handle_TColGeom_HSequenceOfBoundedCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HSequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_HSequenceOfCurve;
 class TColGeom_HSequenceOfCurve : public MMgt_TShared {
 	public:
@@ -1566,6 +1626,11 @@ class Handle_TColGeom_HSequenceOfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom_HSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceNodeOfSequenceOfBoundedCurve;
 class TColGeom_SequenceNodeOfSequenceOfBoundedCurve : public TCollection_SeqNode {
 	public:
@@ -1632,6 +1697,11 @@ class Handle_TColGeom_SequenceNodeOfSequenceOfBoundedCurve : public Handle_TColl
     }
 };
 
+%extend TColGeom_SequenceNodeOfSequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceNodeOfSequenceOfCurve;
 class TColGeom_SequenceNodeOfSequenceOfCurve : public TCollection_SeqNode {
 	public:
@@ -1698,6 +1768,11 @@ class Handle_TColGeom_SequenceNodeOfSequenceOfCurve : public Handle_TCollection_
     }
 };
 
+%extend TColGeom_SequenceNodeOfSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceNodeOfSequenceOfSurface;
 class TColGeom_SequenceNodeOfSequenceOfSurface : public TCollection_SeqNode {
 	public:
@@ -1764,6 +1839,11 @@ class Handle_TColGeom_SequenceNodeOfSequenceOfSurface : public Handle_TCollectio
     }
 };
 
+%extend TColGeom_SequenceNodeOfSequenceOfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceOfBoundedCurve;
 class TColGeom_SequenceOfBoundedCurve : public TCollection_BaseSequence {
 	public:
@@ -1902,6 +1982,11 @@ class TColGeom_SequenceOfBoundedCurve : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom_SequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceOfCurve;
 class TColGeom_SequenceOfCurve : public TCollection_BaseSequence {
 	public:
@@ -2040,6 +2125,11 @@ class TColGeom_SequenceOfCurve : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom_SequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom_SequenceOfSurface;
 class TColGeom_SequenceOfSurface : public TCollection_BaseSequence {
 	public:
@@ -2178,3 +2268,8 @@ class TColGeom_SequenceOfSurface : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom_SequenceOfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TColGeom2d.i
+++ b/src/SWIG_files/wrapper/TColGeom2d.i
@@ -138,6 +138,11 @@ class TColGeom2d_Array1OfBSplineCurve {
 };
 
 
+%extend TColGeom2d_Array1OfBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_Array1OfBezierCurve;
 class TColGeom2d_Array1OfBezierCurve {
 	public:
@@ -220,6 +225,11 @@ class TColGeom2d_Array1OfBezierCurve {
 };
 
 
+%extend TColGeom2d_Array1OfBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_Array1OfCurve;
 class TColGeom2d_Array1OfCurve {
 	public:
@@ -302,6 +312,11 @@ class TColGeom2d_Array1OfCurve {
 };
 
 
+%extend TColGeom2d_Array1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_HArray1OfBSplineCurve;
 class TColGeom2d_HArray1OfBSplineCurve : public MMgt_TShared {
 	public:
@@ -418,6 +433,11 @@ class Handle_TColGeom2d_HArray1OfBSplineCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom2d_HArray1OfBSplineCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_HArray1OfBezierCurve;
 class TColGeom2d_HArray1OfBezierCurve : public MMgt_TShared {
 	public:
@@ -534,6 +554,11 @@ class Handle_TColGeom2d_HArray1OfBezierCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom2d_HArray1OfBezierCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_HArray1OfCurve;
 class TColGeom2d_HArray1OfCurve : public MMgt_TShared {
 	public:
@@ -650,6 +675,11 @@ class Handle_TColGeom2d_HArray1OfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom2d_HArray1OfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_HSequenceOfBoundedCurve;
 class TColGeom2d_HSequenceOfBoundedCurve : public MMgt_TShared {
 	public:
@@ -834,6 +864,11 @@ class Handle_TColGeom2d_HSequenceOfBoundedCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom2d_HSequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_HSequenceOfCurve;
 class TColGeom2d_HSequenceOfCurve : public MMgt_TShared {
 	public:
@@ -1018,6 +1053,11 @@ class Handle_TColGeom2d_HSequenceOfCurve : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColGeom2d_HSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceNodeOfSequenceOfBoundedCurve;
 class TColGeom2d_SequenceNodeOfSequenceOfBoundedCurve : public TCollection_SeqNode {
 	public:
@@ -1084,6 +1124,11 @@ class Handle_TColGeom2d_SequenceNodeOfSequenceOfBoundedCurve : public Handle_TCo
     }
 };
 
+%extend TColGeom2d_SequenceNodeOfSequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceNodeOfSequenceOfCurve;
 class TColGeom2d_SequenceNodeOfSequenceOfCurve : public TCollection_SeqNode {
 	public:
@@ -1150,6 +1195,11 @@ class Handle_TColGeom2d_SequenceNodeOfSequenceOfCurve : public Handle_TCollectio
     }
 };
 
+%extend TColGeom2d_SequenceNodeOfSequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceNodeOfSequenceOfGeometry;
 class TColGeom2d_SequenceNodeOfSequenceOfGeometry : public TCollection_SeqNode {
 	public:
@@ -1216,6 +1266,11 @@ class Handle_TColGeom2d_SequenceNodeOfSequenceOfGeometry : public Handle_TCollec
     }
 };
 
+%extend TColGeom2d_SequenceNodeOfSequenceOfGeometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceOfBoundedCurve;
 class TColGeom2d_SequenceOfBoundedCurve : public TCollection_BaseSequence {
 	public:
@@ -1354,6 +1409,11 @@ class TColGeom2d_SequenceOfBoundedCurve : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom2d_SequenceOfBoundedCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceOfCurve;
 class TColGeom2d_SequenceOfCurve : public TCollection_BaseSequence {
 	public:
@@ -1492,6 +1552,11 @@ class TColGeom2d_SequenceOfCurve : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom2d_SequenceOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColGeom2d_SequenceOfGeometry;
 class TColGeom2d_SequenceOfGeometry : public TCollection_BaseSequence {
 	public:
@@ -1630,3 +1695,8 @@ class TColGeom2d_SequenceOfGeometry : public TCollection_BaseSequence {
 };
 
 
+%extend TColGeom2d_SequenceOfGeometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TColQuantity.i
+++ b/src/SWIG_files/wrapper/TColQuantity.i
@@ -138,6 +138,11 @@ class TColQuantity_Array1OfLength {
 };
 
 
+%extend TColQuantity_Array1OfLength {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColQuantity_Array2OfLength;
 class TColQuantity_Array2OfLength {
 	public:
@@ -242,6 +247,11 @@ class TColQuantity_Array2OfLength {
 };
 
 
+%extend TColQuantity_Array2OfLength {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColQuantity_HArray1OfLength;
 class TColQuantity_HArray1OfLength : public MMgt_TShared {
 	public:
@@ -358,6 +368,11 @@ class Handle_TColQuantity_HArray1OfLength : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColQuantity_HArray1OfLength {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColQuantity_HArray2OfLength;
 class TColQuantity_HArray2OfLength : public MMgt_TShared {
 	public:
@@ -500,3 +515,8 @@ class Handle_TColQuantity_HArray2OfLength : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColQuantity_HArray2OfLength {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TColStd.i
+++ b/src/SWIG_files/wrapper/TColStd.i
@@ -138,6 +138,11 @@ class TColStd_Array1OfAsciiString {
 };
 
 
+%extend TColStd_Array1OfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfBoolean;
 class TColStd_Array1OfBoolean {
 	public:
@@ -220,6 +225,11 @@ class TColStd_Array1OfBoolean {
 };
 
 
+%extend TColStd_Array1OfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfByte;
 class TColStd_Array1OfByte {
 	public:
@@ -302,6 +312,11 @@ class TColStd_Array1OfByte {
 };
 
 
+%extend TColStd_Array1OfByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfCharacter;
 class TColStd_Array1OfCharacter {
 	public:
@@ -384,6 +399,11 @@ class TColStd_Array1OfCharacter {
 };
 
 
+%extend TColStd_Array1OfCharacter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfExtendedString;
 class TColStd_Array1OfExtendedString {
 	public:
@@ -466,6 +486,11 @@ class TColStd_Array1OfExtendedString {
 };
 
 
+%extend TColStd_Array1OfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfInteger;
 class TColStd_Array1OfInteger {
 	public:
@@ -548,6 +573,11 @@ class TColStd_Array1OfInteger {
 };
 
 
+%extend TColStd_Array1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfListOfInteger;
 class TColStd_Array1OfListOfInteger {
 	public:
@@ -630,6 +660,11 @@ class TColStd_Array1OfListOfInteger {
 };
 
 
+%extend TColStd_Array1OfListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfReal;
 class TColStd_Array1OfReal {
 	public:
@@ -712,6 +747,11 @@ class TColStd_Array1OfReal {
 };
 
 
+%extend TColStd_Array1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array1OfTransient;
 class TColStd_Array1OfTransient {
 	public:
@@ -794,6 +834,11 @@ class TColStd_Array1OfTransient {
 };
 
 
+%extend TColStd_Array1OfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array2OfBoolean;
 class TColStd_Array2OfBoolean {
 	public:
@@ -898,6 +943,11 @@ class TColStd_Array2OfBoolean {
 };
 
 
+%extend TColStd_Array2OfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array2OfCharacter;
 class TColStd_Array2OfCharacter {
 	public:
@@ -1002,6 +1052,11 @@ class TColStd_Array2OfCharacter {
 };
 
 
+%extend TColStd_Array2OfCharacter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array2OfInteger;
 class TColStd_Array2OfInteger {
 	public:
@@ -1106,6 +1161,11 @@ class TColStd_Array2OfInteger {
 };
 
 
+%extend TColStd_Array2OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array2OfReal;
 class TColStd_Array2OfReal {
 	public:
@@ -1210,6 +1270,11 @@ class TColStd_Array2OfReal {
 };
 
 
+%extend TColStd_Array2OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_Array2OfTransient;
 class TColStd_Array2OfTransient {
 	public:
@@ -1314,6 +1379,11 @@ class TColStd_Array2OfTransient {
 };
 
 
+%extend TColStd_Array2OfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfAsciiStringInteger;
 class TColStd_DataMapIteratorOfDataMapOfAsciiStringInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1344,6 +1414,11 @@ class TColStd_DataMapIteratorOfDataMapOfAsciiStringInteger : public TCollection_
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfAsciiStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfIntegerInteger;
 class TColStd_DataMapIteratorOfDataMapOfIntegerInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1374,6 +1449,11 @@ class TColStd_DataMapIteratorOfDataMapOfIntegerInteger : public TCollection_Basi
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfIntegerInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfIntegerListOfInteger;
 class TColStd_DataMapIteratorOfDataMapOfIntegerListOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1404,6 +1484,11 @@ class TColStd_DataMapIteratorOfDataMapOfIntegerListOfInteger : public TCollectio
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfIntegerListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfIntegerReal;
 class TColStd_DataMapIteratorOfDataMapOfIntegerReal : public TCollection_BasicMapIterator {
 	public:
@@ -1434,6 +1519,11 @@ class TColStd_DataMapIteratorOfDataMapOfIntegerReal : public TCollection_BasicMa
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfIntegerReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfIntegerTransient;
 class TColStd_DataMapIteratorOfDataMapOfIntegerTransient : public TCollection_BasicMapIterator {
 	public:
@@ -1464,6 +1554,11 @@ class TColStd_DataMapIteratorOfDataMapOfIntegerTransient : public TCollection_Ba
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfIntegerTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfStringInteger;
 class TColStd_DataMapIteratorOfDataMapOfStringInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1494,6 +1589,11 @@ class TColStd_DataMapIteratorOfDataMapOfStringInteger : public TCollection_Basic
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapIteratorOfDataMapOfTransientTransient;
 class TColStd_DataMapIteratorOfDataMapOfTransientTransient : public TCollection_BasicMapIterator {
 	public:
@@ -1524,6 +1624,11 @@ class TColStd_DataMapIteratorOfDataMapOfTransientTransient : public TCollection_
 };
 
 
+%extend TColStd_DataMapIteratorOfDataMapOfTransientTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfAsciiStringInteger;
 class TColStd_DataMapNodeOfDataMapOfAsciiStringInteger : public TCollection_MapNode {
 	public:
@@ -1603,6 +1708,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfAsciiStringInteger : public Handle_TC
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfAsciiStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfIntegerInteger;
 class TColStd_DataMapNodeOfDataMapOfIntegerInteger : public TCollection_MapNode {
 	public:
@@ -1691,6 +1801,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfIntegerInteger : public Handle_TColle
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfIntegerInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfIntegerListOfInteger;
 class TColStd_DataMapNodeOfDataMapOfIntegerListOfInteger : public TCollection_MapNode {
 	public:
@@ -1770,6 +1885,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfIntegerListOfInteger : public Handle_
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfIntegerListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfIntegerReal;
 class TColStd_DataMapNodeOfDataMapOfIntegerReal : public TCollection_MapNode {
 	public:
@@ -1858,6 +1978,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfIntegerReal : public Handle_TCollecti
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfIntegerReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfIntegerTransient;
 class TColStd_DataMapNodeOfDataMapOfIntegerTransient : public TCollection_MapNode {
 	public:
@@ -1937,6 +2062,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfIntegerTransient : public Handle_TCol
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfIntegerTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfStringInteger;
 class TColStd_DataMapNodeOfDataMapOfStringInteger : public TCollection_MapNode {
 	public:
@@ -2016,6 +2146,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfStringInteger : public Handle_TCollec
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapNodeOfDataMapOfTransientTransient;
 class TColStd_DataMapNodeOfDataMapOfTransientTransient : public TCollection_MapNode {
 	public:
@@ -2086,6 +2221,11 @@ class Handle_TColStd_DataMapNodeOfDataMapOfTransientTransient : public Handle_TC
     }
 };
 
+%extend TColStd_DataMapNodeOfDataMapOfTransientTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfAsciiStringInteger;
 class TColStd_DataMapOfAsciiStringInteger : public TCollection_BasicMap {
 	public:
@@ -2164,6 +2304,11 @@ class TColStd_DataMapOfAsciiStringInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfAsciiStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfIntegerInteger;
 class TColStd_DataMapOfIntegerInteger : public TCollection_BasicMap {
 	public:
@@ -2242,6 +2387,11 @@ class TColStd_DataMapOfIntegerInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfIntegerInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfIntegerListOfInteger;
 class TColStd_DataMapOfIntegerListOfInteger : public TCollection_BasicMap {
 	public:
@@ -2320,6 +2470,11 @@ class TColStd_DataMapOfIntegerListOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfIntegerListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfIntegerReal;
 class TColStd_DataMapOfIntegerReal : public TCollection_BasicMap {
 	public:
@@ -2398,6 +2553,11 @@ class TColStd_DataMapOfIntegerReal : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfIntegerReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfIntegerTransient;
 class TColStd_DataMapOfIntegerTransient : public TCollection_BasicMap {
 	public:
@@ -2476,6 +2636,11 @@ class TColStd_DataMapOfIntegerTransient : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfIntegerTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfStringInteger;
 class TColStd_DataMapOfStringInteger : public TCollection_BasicMap {
 	public:
@@ -2554,6 +2719,11 @@ class TColStd_DataMapOfStringInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_DataMapOfTransientTransient;
 class TColStd_DataMapOfTransientTransient : public TCollection_BasicMap {
 	public:
@@ -2632,6 +2802,11 @@ class TColStd_DataMapOfTransientTransient : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_DataMapOfTransientTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfAsciiString;
 class TColStd_HArray1OfAsciiString : public MMgt_TShared {
 	public:
@@ -2748,6 +2923,11 @@ class Handle_TColStd_HArray1OfAsciiString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfBoolean;
 class TColStd_HArray1OfBoolean : public MMgt_TShared {
 	public:
@@ -2864,6 +3044,11 @@ class Handle_TColStd_HArray1OfBoolean : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfByte;
 class TColStd_HArray1OfByte : public MMgt_TShared {
 	public:
@@ -2980,6 +3165,11 @@ class Handle_TColStd_HArray1OfByte : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfCharacter;
 class TColStd_HArray1OfCharacter : public MMgt_TShared {
 	public:
@@ -3096,6 +3286,11 @@ class Handle_TColStd_HArray1OfCharacter : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfCharacter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfExtendedString;
 class TColStd_HArray1OfExtendedString : public MMgt_TShared {
 	public:
@@ -3212,6 +3407,11 @@ class Handle_TColStd_HArray1OfExtendedString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfInteger;
 class TColStd_HArray1OfInteger : public MMgt_TShared {
 	public:
@@ -3328,6 +3528,11 @@ class Handle_TColStd_HArray1OfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfListOfInteger;
 class TColStd_HArray1OfListOfInteger : public MMgt_TShared {
 	public:
@@ -3444,6 +3649,11 @@ class Handle_TColStd_HArray1OfListOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfReal;
 class TColStd_HArray1OfReal : public MMgt_TShared {
 	public:
@@ -3560,6 +3770,11 @@ class Handle_TColStd_HArray1OfReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray1OfTransient;
 class TColStd_HArray1OfTransient : public MMgt_TShared {
 	public:
@@ -3676,6 +3891,11 @@ class Handle_TColStd_HArray1OfTransient : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray1OfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray2OfBoolean;
 class TColStd_HArray2OfBoolean : public MMgt_TShared {
 	public:
@@ -3818,6 +4038,11 @@ class Handle_TColStd_HArray2OfBoolean : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray2OfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray2OfCharacter;
 class TColStd_HArray2OfCharacter : public MMgt_TShared {
 	public:
@@ -3960,6 +4185,11 @@ class Handle_TColStd_HArray2OfCharacter : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray2OfCharacter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray2OfInteger;
 class TColStd_HArray2OfInteger : public MMgt_TShared {
 	public:
@@ -4102,6 +4332,11 @@ class Handle_TColStd_HArray2OfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray2OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray2OfReal;
 class TColStd_HArray2OfReal : public MMgt_TShared {
 	public:
@@ -4244,6 +4479,11 @@ class Handle_TColStd_HArray2OfReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray2OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HArray2OfTransient;
 class TColStd_HArray2OfTransient : public MMgt_TShared {
 	public:
@@ -4386,6 +4626,11 @@ class Handle_TColStd_HArray2OfTransient : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HArray2OfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HPackedMapOfInteger;
 class TColStd_HPackedMapOfInteger : public MMgt_TShared {
 	public:
@@ -4458,6 +4703,11 @@ class Handle_TColStd_HPackedMapOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HPackedMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfAsciiString;
 class TColStd_HSequenceOfAsciiString : public MMgt_TShared {
 	public:
@@ -4642,6 +4892,11 @@ class Handle_TColStd_HSequenceOfAsciiString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfExtendedString;
 class TColStd_HSequenceOfExtendedString : public MMgt_TShared {
 	public:
@@ -4826,6 +5081,11 @@ class Handle_TColStd_HSequenceOfExtendedString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfHAsciiString;
 class TColStd_HSequenceOfHAsciiString : public MMgt_TShared {
 	public:
@@ -5010,6 +5270,11 @@ class Handle_TColStd_HSequenceOfHAsciiString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfHAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfHExtendedString;
 class TColStd_HSequenceOfHExtendedString : public MMgt_TShared {
 	public:
@@ -5194,6 +5459,11 @@ class Handle_TColStd_HSequenceOfHExtendedString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfHExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfInteger;
 class TColStd_HSequenceOfInteger : public MMgt_TShared {
 	public:
@@ -5378,6 +5648,11 @@ class Handle_TColStd_HSequenceOfInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfReal;
 class TColStd_HSequenceOfReal : public MMgt_TShared {
 	public:
@@ -5562,6 +5837,11 @@ class Handle_TColStd_HSequenceOfReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_HSequenceOfTransient;
 class TColStd_HSequenceOfTransient : public MMgt_TShared {
 	public:
@@ -5746,6 +6026,11 @@ class Handle_TColStd_HSequenceOfTransient : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColStd_HSequenceOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedDataMapNodeOfIndexedDataMapOfTransientTransient;
 class TColStd_IndexedDataMapNodeOfIndexedDataMapOfTransientTransient : public TCollection_MapNode {
 	public:
@@ -5837,6 +6122,11 @@ class Handle_TColStd_IndexedDataMapNodeOfIndexedDataMapOfTransientTransient : pu
     }
 };
 
+%extend TColStd_IndexedDataMapNodeOfIndexedDataMapOfTransientTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedDataMapOfTransientTransient;
 class TColStd_IndexedDataMapOfTransientTransient : public TCollection_BasicMap {
 	public:
@@ -5947,6 +6237,11 @@ class TColStd_IndexedDataMapOfTransientTransient : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_IndexedDataMapOfTransientTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapNodeOfIndexedMapOfInteger;
 class TColStd_IndexedMapNodeOfIndexedMapOfInteger : public TCollection_MapNode {
 	public:
@@ -6041,6 +6336,11 @@ class Handle_TColStd_IndexedMapNodeOfIndexedMapOfInteger : public Handle_TCollec
     }
 };
 
+%extend TColStd_IndexedMapNodeOfIndexedMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapNodeOfIndexedMapOfReal;
 class TColStd_IndexedMapNodeOfIndexedMapOfReal : public TCollection_MapNode {
 	public:
@@ -6135,6 +6435,11 @@ class Handle_TColStd_IndexedMapNodeOfIndexedMapOfReal : public Handle_TCollectio
     }
 };
 
+%extend TColStd_IndexedMapNodeOfIndexedMapOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapNodeOfIndexedMapOfTransient;
 class TColStd_IndexedMapNodeOfIndexedMapOfTransient : public TCollection_MapNode {
 	public:
@@ -6220,6 +6525,11 @@ class Handle_TColStd_IndexedMapNodeOfIndexedMapOfTransient : public Handle_TColl
     }
 };
 
+%extend TColStd_IndexedMapNodeOfIndexedMapOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapOfInteger;
 class TColStd_IndexedMapOfInteger : public TCollection_BasicMap {
 	public:
@@ -6296,6 +6606,11 @@ class TColStd_IndexedMapOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_IndexedMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapOfReal;
 class TColStd_IndexedMapOfReal : public TCollection_BasicMap {
 	public:
@@ -6372,6 +6687,11 @@ class TColStd_IndexedMapOfReal : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_IndexedMapOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_IndexedMapOfTransient;
 class TColStd_IndexedMapOfTransient : public TCollection_BasicMap {
 	public:
@@ -6448,6 +6768,11 @@ class TColStd_IndexedMapOfTransient : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_IndexedMapOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListIteratorOfListOfAsciiString;
 class TColStd_ListIteratorOfListOfAsciiString {
 	public:
@@ -6482,6 +6807,11 @@ class TColStd_ListIteratorOfListOfAsciiString {
 };
 
 
+%extend TColStd_ListIteratorOfListOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListIteratorOfListOfInteger;
 class TColStd_ListIteratorOfListOfInteger {
 	public:
@@ -6525,6 +6855,11 @@ class TColStd_ListIteratorOfListOfInteger {
             };
 
 
+%extend TColStd_ListIteratorOfListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListIteratorOfListOfReal;
 class TColStd_ListIteratorOfListOfReal {
 	public:
@@ -6568,6 +6903,11 @@ class TColStd_ListIteratorOfListOfReal {
             };
 
 
+%extend TColStd_ListIteratorOfListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListIteratorOfListOfTransient;
 class TColStd_ListIteratorOfListOfTransient {
 	public:
@@ -6602,6 +6942,11 @@ class TColStd_ListIteratorOfListOfTransient {
 };
 
 
+%extend TColStd_ListIteratorOfListOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListNodeOfListOfAsciiString;
 class TColStd_ListNodeOfListOfAsciiString : public TCollection_MapNode {
 	public:
@@ -6666,6 +7011,11 @@ class Handle_TColStd_ListNodeOfListOfAsciiString : public Handle_TCollection_Map
     }
 };
 
+%extend TColStd_ListNodeOfListOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListNodeOfListOfInteger;
 class TColStd_ListNodeOfListOfInteger : public TCollection_MapNode {
 	public:
@@ -6739,6 +7089,11 @@ class Handle_TColStd_ListNodeOfListOfInteger : public Handle_TCollection_MapNode
     }
 };
 
+%extend TColStd_ListNodeOfListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListNodeOfListOfReal;
 class TColStd_ListNodeOfListOfReal : public TCollection_MapNode {
 	public:
@@ -6812,6 +7167,11 @@ class Handle_TColStd_ListNodeOfListOfReal : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TColStd_ListNodeOfListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListNodeOfListOfTransient;
 class TColStd_ListNodeOfListOfTransient : public TCollection_MapNode {
 	public:
@@ -6876,6 +7236,11 @@ class Handle_TColStd_ListNodeOfListOfTransient : public Handle_TCollection_MapNo
     }
 };
 
+%extend TColStd_ListNodeOfListOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListOfAsciiString;
 class TColStd_ListOfAsciiString {
 	public:
@@ -7006,6 +7371,11 @@ class TColStd_ListOfAsciiString {
 };
 
 
+%extend TColStd_ListOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListOfInteger;
 class TColStd_ListOfInteger {
 	public:
@@ -7154,6 +7524,11 @@ class TColStd_ListOfInteger {
 };
 
 
+%extend TColStd_ListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListOfReal;
 class TColStd_ListOfReal {
 	public:
@@ -7302,6 +7677,11 @@ class TColStd_ListOfReal {
 };
 
 
+%extend TColStd_ListOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_ListOfTransient;
 class TColStd_ListOfTransient {
 	public:
@@ -7432,6 +7812,11 @@ class TColStd_ListOfTransient {
 };
 
 
+%extend TColStd_ListOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TColStd_MapIntegerHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -7453,6 +7838,11 @@ class TColStd_MapIntegerHasher {
 };
 
 
+%extend TColStd_MapIntegerHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapIteratorOfMapOfAsciiString;
 class TColStd_MapIteratorOfMapOfAsciiString : public TCollection_BasicMapIterator {
 	public:
@@ -7479,6 +7869,11 @@ class TColStd_MapIteratorOfMapOfAsciiString : public TCollection_BasicMapIterato
 };
 
 
+%extend TColStd_MapIteratorOfMapOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapIteratorOfMapOfInteger;
 class TColStd_MapIteratorOfMapOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -7505,6 +7900,11 @@ class TColStd_MapIteratorOfMapOfInteger : public TCollection_BasicMapIterator {
 };
 
 
+%extend TColStd_MapIteratorOfMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapIteratorOfMapOfReal;
 class TColStd_MapIteratorOfMapOfReal : public TCollection_BasicMapIterator {
 	public:
@@ -7531,6 +7931,11 @@ class TColStd_MapIteratorOfMapOfReal : public TCollection_BasicMapIterator {
 };
 
 
+%extend TColStd_MapIteratorOfMapOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapIteratorOfMapOfTransient;
 class TColStd_MapIteratorOfMapOfTransient : public TCollection_BasicMapIterator {
 	public:
@@ -7557,6 +7962,11 @@ class TColStd_MapIteratorOfMapOfTransient : public TCollection_BasicMapIterator 
 };
 
 
+%extend TColStd_MapIteratorOfMapOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapIteratorOfPackedMapOfInteger;
 class TColStd_MapIteratorOfPackedMapOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -7603,6 +8013,11 @@ class TColStd_MapIteratorOfPackedMapOfInteger : public TCollection_BasicMapItera
 };
 
 
+%extend TColStd_MapIteratorOfPackedMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapOfAsciiString;
 class TColStd_MapOfAsciiString : public TCollection_BasicMap {
 	public:
@@ -7661,6 +8076,11 @@ class TColStd_MapOfAsciiString : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_MapOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapOfInteger;
 class TColStd_MapOfInteger : public TCollection_BasicMap {
 	public:
@@ -7719,6 +8139,11 @@ class TColStd_MapOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_MapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapOfReal;
 class TColStd_MapOfReal : public TCollection_BasicMap {
 	public:
@@ -7777,6 +8202,11 @@ class TColStd_MapOfReal : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_MapOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_MapOfTransient;
 class TColStd_MapOfTransient : public TCollection_BasicMap {
 	public:
@@ -7835,6 +8265,11 @@ class TColStd_MapOfTransient : public TCollection_BasicMap {
 };
 
 
+%extend TColStd_MapOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TColStd_MapRealHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -7856,6 +8291,11 @@ class TColStd_MapRealHasher {
 };
 
 
+%extend TColStd_MapRealHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TColStd_MapTransientHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -7877,6 +8317,11 @@ class TColStd_MapTransientHasher {
 };
 
 
+%extend TColStd_MapTransientHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfAddress;
 class TColStd_SequenceNodeOfSequenceOfAddress : public TCollection_SeqNode {
 	public:
@@ -7943,6 +8388,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfAddress : public Handle_TCollection
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfAsciiString;
 class TColStd_SequenceNodeOfSequenceOfAsciiString : public TCollection_SeqNode {
 	public:
@@ -8009,6 +8459,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfAsciiString : public Handle_TCollec
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfBoolean;
 class TColStd_SequenceNodeOfSequenceOfBoolean : public TCollection_SeqNode {
 	public:
@@ -8084,6 +8539,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfBoolean : public Handle_TCollection
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfExtendedString;
 class TColStd_SequenceNodeOfSequenceOfExtendedString : public TCollection_SeqNode {
 	public:
@@ -8150,6 +8610,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfExtendedString : public Handle_TCol
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfHAsciiString;
 class TColStd_SequenceNodeOfSequenceOfHAsciiString : public TCollection_SeqNode {
 	public:
@@ -8216,6 +8681,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfHAsciiString : public Handle_TColle
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfHAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfHExtendedString;
 class TColStd_SequenceNodeOfSequenceOfHExtendedString : public TCollection_SeqNode {
 	public:
@@ -8282,6 +8752,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfHExtendedString : public Handle_TCo
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfHExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfInteger;
 class TColStd_SequenceNodeOfSequenceOfInteger : public TCollection_SeqNode {
 	public:
@@ -8357,6 +8832,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfInteger : public Handle_TCollection
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfReal;
 class TColStd_SequenceNodeOfSequenceOfReal : public TCollection_SeqNode {
 	public:
@@ -8432,6 +8912,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfReal : public Handle_TCollection_Se
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceNodeOfSequenceOfTransient;
 class TColStd_SequenceNodeOfSequenceOfTransient : public TCollection_SeqNode {
 	public:
@@ -8498,6 +8983,11 @@ class Handle_TColStd_SequenceNodeOfSequenceOfTransient : public Handle_TCollecti
     }
 };
 
+%extend TColStd_SequenceNodeOfSequenceOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfAddress;
 class TColStd_SequenceOfAddress : public TCollection_BaseSequence {
 	public:
@@ -8636,6 +9126,11 @@ class TColStd_SequenceOfAddress : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfAsciiString;
 class TColStd_SequenceOfAsciiString : public TCollection_BaseSequence {
 	public:
@@ -8774,6 +9269,11 @@ class TColStd_SequenceOfAsciiString : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfBoolean;
 class TColStd_SequenceOfBoolean : public TCollection_BaseSequence {
 	public:
@@ -8912,6 +9412,11 @@ class TColStd_SequenceOfBoolean : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfBoolean {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfExtendedString;
 class TColStd_SequenceOfExtendedString : public TCollection_BaseSequence {
 	public:
@@ -9050,6 +9555,11 @@ class TColStd_SequenceOfExtendedString : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfHAsciiString;
 class TColStd_SequenceOfHAsciiString : public TCollection_BaseSequence {
 	public:
@@ -9188,6 +9698,11 @@ class TColStd_SequenceOfHAsciiString : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfHAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfHExtendedString;
 class TColStd_SequenceOfHExtendedString : public TCollection_BaseSequence {
 	public:
@@ -9326,6 +9841,11 @@ class TColStd_SequenceOfHExtendedString : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfHExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfInteger;
 class TColStd_SequenceOfInteger : public TCollection_BaseSequence {
 	public:
@@ -9464,6 +9984,11 @@ class TColStd_SequenceOfInteger : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfReal;
 class TColStd_SequenceOfReal : public TCollection_BaseSequence {
 	public:
@@ -9602,6 +10127,11 @@ class TColStd_SequenceOfReal : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_SequenceOfTransient;
 class TColStd_SequenceOfTransient : public TCollection_BaseSequence {
 	public:
@@ -9740,6 +10270,11 @@ class TColStd_SequenceOfTransient : public TCollection_BaseSequence {
 };
 
 
+%extend TColStd_SequenceOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_StdMapNodeOfMapOfAsciiString;
 class TColStd_StdMapNodeOfMapOfAsciiString : public TCollection_MapNode {
 	public:
@@ -9804,6 +10339,11 @@ class Handle_TColStd_StdMapNodeOfMapOfAsciiString : public Handle_TCollection_Ma
     }
 };
 
+%extend TColStd_StdMapNodeOfMapOfAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_StdMapNodeOfMapOfInteger;
 class TColStd_StdMapNodeOfMapOfInteger : public TCollection_MapNode {
 	public:
@@ -9877,6 +10417,11 @@ class Handle_TColStd_StdMapNodeOfMapOfInteger : public Handle_TCollection_MapNod
     }
 };
 
+%extend TColStd_StdMapNodeOfMapOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_StdMapNodeOfMapOfReal;
 class TColStd_StdMapNodeOfMapOfReal : public TCollection_MapNode {
 	public:
@@ -9950,6 +10495,11 @@ class Handle_TColStd_StdMapNodeOfMapOfReal : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TColStd_StdMapNodeOfMapOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColStd_StdMapNodeOfMapOfTransient;
 class TColStd_StdMapNodeOfMapOfTransient : public TCollection_MapNode {
 	public:
@@ -10014,3 +10564,8 @@ class Handle_TColStd_StdMapNodeOfMapOfTransient : public Handle_TCollection_MapN
     }
 };
 
+%extend TColStd_StdMapNodeOfMapOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TColgp.i
+++ b/src/SWIG_files/wrapper/TColgp.i
@@ -138,6 +138,11 @@ class TColgp_Array1OfCirc2d {
 };
 
 
+%extend TColgp_Array1OfCirc2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfDir;
 class TColgp_Array1OfDir {
 	public:
@@ -220,6 +225,11 @@ class TColgp_Array1OfDir {
 };
 
 
+%extend TColgp_Array1OfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfDir2d;
 class TColgp_Array1OfDir2d {
 	public:
@@ -302,6 +312,11 @@ class TColgp_Array1OfDir2d {
 };
 
 
+%extend TColgp_Array1OfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfLin2d;
 class TColgp_Array1OfLin2d {
 	public:
@@ -384,6 +399,11 @@ class TColgp_Array1OfLin2d {
 };
 
 
+%extend TColgp_Array1OfLin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfPnt;
 class TColgp_Array1OfPnt {
 	public:
@@ -466,6 +486,11 @@ class TColgp_Array1OfPnt {
 };
 
 
+%extend TColgp_Array1OfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfPnt2d;
 class TColgp_Array1OfPnt2d {
 	public:
@@ -548,6 +573,11 @@ class TColgp_Array1OfPnt2d {
 };
 
 
+%extend TColgp_Array1OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfVec;
 class TColgp_Array1OfVec {
 	public:
@@ -630,6 +660,11 @@ class TColgp_Array1OfVec {
 };
 
 
+%extend TColgp_Array1OfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfVec2d;
 class TColgp_Array1OfVec2d {
 	public:
@@ -712,6 +747,11 @@ class TColgp_Array1OfVec2d {
 };
 
 
+%extend TColgp_Array1OfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfXY;
 class TColgp_Array1OfXY {
 	public:
@@ -794,6 +834,11 @@ class TColgp_Array1OfXY {
 };
 
 
+%extend TColgp_Array1OfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array1OfXYZ;
 class TColgp_Array1OfXYZ {
 	public:
@@ -876,6 +921,11 @@ class TColgp_Array1OfXYZ {
 };
 
 
+%extend TColgp_Array1OfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfCirc2d;
 class TColgp_Array2OfCirc2d {
 	public:
@@ -980,6 +1030,11 @@ class TColgp_Array2OfCirc2d {
 };
 
 
+%extend TColgp_Array2OfCirc2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfDir;
 class TColgp_Array2OfDir {
 	public:
@@ -1084,6 +1139,11 @@ class TColgp_Array2OfDir {
 };
 
 
+%extend TColgp_Array2OfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfDir2d;
 class TColgp_Array2OfDir2d {
 	public:
@@ -1188,6 +1248,11 @@ class TColgp_Array2OfDir2d {
 };
 
 
+%extend TColgp_Array2OfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfLin2d;
 class TColgp_Array2OfLin2d {
 	public:
@@ -1292,6 +1357,11 @@ class TColgp_Array2OfLin2d {
 };
 
 
+%extend TColgp_Array2OfLin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfPnt;
 class TColgp_Array2OfPnt {
 	public:
@@ -1396,6 +1466,11 @@ class TColgp_Array2OfPnt {
 };
 
 
+%extend TColgp_Array2OfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfPnt2d;
 class TColgp_Array2OfPnt2d {
 	public:
@@ -1500,6 +1575,11 @@ class TColgp_Array2OfPnt2d {
 };
 
 
+%extend TColgp_Array2OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfVec;
 class TColgp_Array2OfVec {
 	public:
@@ -1604,6 +1684,11 @@ class TColgp_Array2OfVec {
 };
 
 
+%extend TColgp_Array2OfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfVec2d;
 class TColgp_Array2OfVec2d {
 	public:
@@ -1708,6 +1793,11 @@ class TColgp_Array2OfVec2d {
 };
 
 
+%extend TColgp_Array2OfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfXY;
 class TColgp_Array2OfXY {
 	public:
@@ -1812,6 +1902,11 @@ class TColgp_Array2OfXY {
 };
 
 
+%extend TColgp_Array2OfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_Array2OfXYZ;
 class TColgp_Array2OfXYZ {
 	public:
@@ -1916,6 +2011,11 @@ class TColgp_Array2OfXYZ {
 };
 
 
+%extend TColgp_Array2OfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfCirc2d;
 class TColgp_HArray1OfCirc2d : public MMgt_TShared {
 	public:
@@ -2032,6 +2132,11 @@ class Handle_TColgp_HArray1OfCirc2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfCirc2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfDir;
 class TColgp_HArray1OfDir : public MMgt_TShared {
 	public:
@@ -2148,6 +2253,11 @@ class Handle_TColgp_HArray1OfDir : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfDir2d;
 class TColgp_HArray1OfDir2d : public MMgt_TShared {
 	public:
@@ -2264,6 +2374,11 @@ class Handle_TColgp_HArray1OfDir2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfLin2d;
 class TColgp_HArray1OfLin2d : public MMgt_TShared {
 	public:
@@ -2380,6 +2495,11 @@ class Handle_TColgp_HArray1OfLin2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfLin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfPnt;
 class TColgp_HArray1OfPnt : public MMgt_TShared {
 	public:
@@ -2496,6 +2616,11 @@ class Handle_TColgp_HArray1OfPnt : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfPnt2d;
 class TColgp_HArray1OfPnt2d : public MMgt_TShared {
 	public:
@@ -2612,6 +2737,11 @@ class Handle_TColgp_HArray1OfPnt2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfVec;
 class TColgp_HArray1OfVec : public MMgt_TShared {
 	public:
@@ -2728,6 +2858,11 @@ class Handle_TColgp_HArray1OfVec : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfVec2d;
 class TColgp_HArray1OfVec2d : public MMgt_TShared {
 	public:
@@ -2844,6 +2979,11 @@ class Handle_TColgp_HArray1OfVec2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfXY;
 class TColgp_HArray1OfXY : public MMgt_TShared {
 	public:
@@ -2960,6 +3100,11 @@ class Handle_TColgp_HArray1OfXY : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray1OfXYZ;
 class TColgp_HArray1OfXYZ : public MMgt_TShared {
 	public:
@@ -3076,6 +3221,11 @@ class Handle_TColgp_HArray1OfXYZ : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray1OfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfCirc2d;
 class TColgp_HArray2OfCirc2d : public MMgt_TShared {
 	public:
@@ -3218,6 +3368,11 @@ class Handle_TColgp_HArray2OfCirc2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfCirc2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfDir;
 class TColgp_HArray2OfDir : public MMgt_TShared {
 	public:
@@ -3360,6 +3515,11 @@ class Handle_TColgp_HArray2OfDir : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfDir2d;
 class TColgp_HArray2OfDir2d : public MMgt_TShared {
 	public:
@@ -3502,6 +3662,11 @@ class Handle_TColgp_HArray2OfDir2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfLin2d;
 class TColgp_HArray2OfLin2d : public MMgt_TShared {
 	public:
@@ -3644,6 +3809,11 @@ class Handle_TColgp_HArray2OfLin2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfLin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfPnt;
 class TColgp_HArray2OfPnt : public MMgt_TShared {
 	public:
@@ -3786,6 +3956,11 @@ class Handle_TColgp_HArray2OfPnt : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfPnt2d;
 class TColgp_HArray2OfPnt2d : public MMgt_TShared {
 	public:
@@ -3928,6 +4103,11 @@ class Handle_TColgp_HArray2OfPnt2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfVec;
 class TColgp_HArray2OfVec : public MMgt_TShared {
 	public:
@@ -4070,6 +4250,11 @@ class Handle_TColgp_HArray2OfVec : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfVec2d;
 class TColgp_HArray2OfVec2d : public MMgt_TShared {
 	public:
@@ -4212,6 +4397,11 @@ class Handle_TColgp_HArray2OfVec2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfXY;
 class TColgp_HArray2OfXY : public MMgt_TShared {
 	public:
@@ -4354,6 +4544,11 @@ class Handle_TColgp_HArray2OfXY : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HArray2OfXYZ;
 class TColgp_HArray2OfXYZ : public MMgt_TShared {
 	public:
@@ -4496,6 +4691,11 @@ class Handle_TColgp_HArray2OfXYZ : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HArray2OfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfDir;
 class TColgp_HSequenceOfDir : public MMgt_TShared {
 	public:
@@ -4680,6 +4880,11 @@ class Handle_TColgp_HSequenceOfDir : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfDir2d;
 class TColgp_HSequenceOfDir2d : public MMgt_TShared {
 	public:
@@ -4864,6 +5069,11 @@ class Handle_TColgp_HSequenceOfDir2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfPnt;
 class TColgp_HSequenceOfPnt : public MMgt_TShared {
 	public:
@@ -5048,6 +5258,11 @@ class Handle_TColgp_HSequenceOfPnt : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfPnt2d;
 class TColgp_HSequenceOfPnt2d : public MMgt_TShared {
 	public:
@@ -5232,6 +5447,11 @@ class Handle_TColgp_HSequenceOfPnt2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfVec;
 class TColgp_HSequenceOfVec : public MMgt_TShared {
 	public:
@@ -5416,6 +5636,11 @@ class Handle_TColgp_HSequenceOfVec : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfVec2d;
 class TColgp_HSequenceOfVec2d : public MMgt_TShared {
 	public:
@@ -5600,6 +5825,11 @@ class Handle_TColgp_HSequenceOfVec2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfXY;
 class TColgp_HSequenceOfXY : public MMgt_TShared {
 	public:
@@ -5784,6 +6014,11 @@ class Handle_TColgp_HSequenceOfXY : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_HSequenceOfXYZ;
 class TColgp_HSequenceOfXYZ : public MMgt_TShared {
 	public:
@@ -5968,6 +6203,11 @@ class Handle_TColgp_HSequenceOfXYZ : public Handle_MMgt_TShared {
     }
 };
 
+%extend TColgp_HSequenceOfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfArray1OfPnt2d;
 class TColgp_SequenceNodeOfSequenceOfArray1OfPnt2d : public TCollection_SeqNode {
 	public:
@@ -6034,6 +6274,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfArray1OfPnt2d : public Handle_TColle
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfArray1OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfDir;
 class TColgp_SequenceNodeOfSequenceOfDir : public TCollection_SeqNode {
 	public:
@@ -6100,6 +6345,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfDir : public Handle_TCollection_SeqN
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfDir2d;
 class TColgp_SequenceNodeOfSequenceOfDir2d : public TCollection_SeqNode {
 	public:
@@ -6166,6 +6416,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfDir2d : public Handle_TCollection_Se
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfPnt;
 class TColgp_SequenceNodeOfSequenceOfPnt : public TCollection_SeqNode {
 	public:
@@ -6232,6 +6487,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfPnt : public Handle_TCollection_SeqN
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfPnt2d;
 class TColgp_SequenceNodeOfSequenceOfPnt2d : public TCollection_SeqNode {
 	public:
@@ -6298,6 +6558,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfPnt2d : public Handle_TCollection_Se
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfVec;
 class TColgp_SequenceNodeOfSequenceOfVec : public TCollection_SeqNode {
 	public:
@@ -6364,6 +6629,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfVec : public Handle_TCollection_SeqN
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfVec2d;
 class TColgp_SequenceNodeOfSequenceOfVec2d : public TCollection_SeqNode {
 	public:
@@ -6430,6 +6700,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfVec2d : public Handle_TCollection_Se
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfXY;
 class TColgp_SequenceNodeOfSequenceOfXY : public TCollection_SeqNode {
 	public:
@@ -6496,6 +6771,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfXY : public Handle_TCollection_SeqNo
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceNodeOfSequenceOfXYZ;
 class TColgp_SequenceNodeOfSequenceOfXYZ : public TCollection_SeqNode {
 	public:
@@ -6562,6 +6842,11 @@ class Handle_TColgp_SequenceNodeOfSequenceOfXYZ : public Handle_TCollection_SeqN
     }
 };
 
+%extend TColgp_SequenceNodeOfSequenceOfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfArray1OfPnt2d;
 class TColgp_SequenceOfArray1OfPnt2d : public TCollection_BaseSequence {
 	public:
@@ -6700,6 +6985,11 @@ class TColgp_SequenceOfArray1OfPnt2d : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfArray1OfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfDir;
 class TColgp_SequenceOfDir : public TCollection_BaseSequence {
 	public:
@@ -6838,6 +7128,11 @@ class TColgp_SequenceOfDir : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfDir2d;
 class TColgp_SequenceOfDir2d : public TCollection_BaseSequence {
 	public:
@@ -6976,6 +7271,11 @@ class TColgp_SequenceOfDir2d : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfPnt;
 class TColgp_SequenceOfPnt : public TCollection_BaseSequence {
 	public:
@@ -7114,6 +7414,11 @@ class TColgp_SequenceOfPnt : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfPnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfPnt2d;
 class TColgp_SequenceOfPnt2d : public TCollection_BaseSequence {
 	public:
@@ -7252,6 +7557,11 @@ class TColgp_SequenceOfPnt2d : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfPnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfVec;
 class TColgp_SequenceOfVec : public TCollection_BaseSequence {
 	public:
@@ -7390,6 +7700,11 @@ class TColgp_SequenceOfVec : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfVec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfVec2d;
 class TColgp_SequenceOfVec2d : public TCollection_BaseSequence {
 	public:
@@ -7528,6 +7843,11 @@ class TColgp_SequenceOfVec2d : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfVec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfXY;
 class TColgp_SequenceOfXY : public TCollection_BaseSequence {
 	public:
@@ -7666,6 +7986,11 @@ class TColgp_SequenceOfXY : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfXY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TColgp_SequenceOfXYZ;
 class TColgp_SequenceOfXYZ : public TCollection_BaseSequence {
 	public:
@@ -7804,3 +8129,8 @@ class TColgp_SequenceOfXYZ : public TCollection_BaseSequence {
 };
 
 
+%extend TColgp_SequenceOfXYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TCollection.i
+++ b/src/SWIG_files/wrapper/TCollection.i
@@ -77,6 +77,11 @@ class TCollection {
 };
 
 
+%extend TCollection {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_AsciiString;
 class TCollection_AsciiString {
 	public:
@@ -926,6 +931,11 @@ class TCollection_AsciiString {
 };
 
 
+%extend TCollection_AsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_BaseSequence;
 class TCollection_BaseSequence {
 	public:
@@ -960,6 +970,11 @@ class TCollection_BaseSequence {
 };
 
 
+%extend TCollection_BaseSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_BasicMap;
 class TCollection_BasicMap {
 	public:
@@ -992,6 +1007,11 @@ class TCollection_BasicMap {
         };
 
 
+%extend TCollection_BasicMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_BasicMapIterator;
 class TCollection_BasicMapIterator {
 	public:
@@ -1016,6 +1036,11 @@ class TCollection_BasicMapIterator {
 };
 
 
+%extend TCollection_BasicMapIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_ExtendedString;
 class TCollection_ExtendedString {
 	public:
@@ -1480,6 +1505,11 @@ class TCollection_ExtendedString {
 };
 
 
+%extend TCollection_ExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_HAsciiString;
 class TCollection_HAsciiString : public MMgt_TShared {
 	public:
@@ -2074,6 +2104,11 @@ class Handle_TCollection_HAsciiString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TCollection_HAsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_HExtendedString;
 class TCollection_HExtendedString : public MMgt_TShared {
 	public:
@@ -2390,6 +2425,11 @@ class Handle_TCollection_HExtendedString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TCollection_HExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_MapNode;
 class TCollection_MapNode : public MMgt_TShared {
 	public:
@@ -2452,6 +2492,11 @@ class Handle_TCollection_MapNode : public Handle_MMgt_TShared {
     }
 };
 
+%extend TCollection_MapNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TCollection_PrivCompareOfInteger {
 	public:
 		%feature("compactdefaultargs") IsLower;
@@ -2481,6 +2526,11 @@ class TCollection_PrivCompareOfInteger {
 };
 
 
+%extend TCollection_PrivCompareOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TCollection_PrivCompareOfReal {
 	public:
 		%feature("compactdefaultargs") IsLower;
@@ -2510,6 +2560,11 @@ class TCollection_PrivCompareOfReal {
 };
 
 
+%extend TCollection_PrivCompareOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_SeqNode;
 class TCollection_SeqNode : public MMgt_TShared {
 	public:
@@ -2578,6 +2633,11 @@ class Handle_TCollection_SeqNode : public Handle_MMgt_TShared {
     }
 };
 
+%extend TCollection_SeqNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_CompareOfInteger;
 class TCollection_CompareOfInteger : public TCollection_PrivCompareOfInteger {
 	public:
@@ -2608,6 +2668,11 @@ class TCollection_CompareOfInteger : public TCollection_PrivCompareOfInteger {
 };
 
 
+%extend TCollection_CompareOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TCollection_CompareOfReal;
 class TCollection_CompareOfReal : public TCollection_PrivCompareOfReal {
 	public:
@@ -2638,3 +2703,8 @@ class TCollection_CompareOfReal : public TCollection_PrivCompareOfReal {
 };
 
 
+%extend TCollection_CompareOfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TDF.i
+++ b/src/SWIG_files/wrapper/TDF.i
@@ -113,6 +113,11 @@ class TDF {
 };
 
 
+%extend TDF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Attribute;
 class TDF_Attribute : public MMgt_TShared {
 	public:
@@ -425,6 +430,11 @@ class Handle_TDF_Attribute : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_Attribute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeArray1;
 class TDF_AttributeArray1 {
 	public:
@@ -507,6 +517,11 @@ class TDF_AttributeArray1 {
 };
 
 
+%extend TDF_AttributeArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeDataMap;
 class TDF_AttributeDataMap : public TCollection_BasicMap {
 	public:
@@ -585,6 +600,11 @@ class TDF_AttributeDataMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_AttributeDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeDelta;
 class TDF_AttributeDelta : public MMgt_TShared {
 	public:
@@ -669,6 +689,11 @@ class Handle_TDF_AttributeDelta : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_AttributeDelta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeDeltaList;
 class TDF_AttributeDeltaList {
 	public:
@@ -799,6 +824,11 @@ class TDF_AttributeDeltaList {
 };
 
 
+%extend TDF_AttributeDeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeDoubleMap;
 class TDF_AttributeDoubleMap : public TCollection_BasicMap {
 	public:
@@ -885,6 +915,11 @@ class TDF_AttributeDoubleMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_AttributeDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeIndexedMap;
 class TDF_AttributeIndexedMap : public TCollection_BasicMap {
 	public:
@@ -961,6 +996,11 @@ class TDF_AttributeIndexedMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_AttributeIndexedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeIterator;
 class TDF_AttributeIterator {
 	public:
@@ -1007,6 +1047,11 @@ class TDF_AttributeIterator {
 };
 
 
+%extend TDF_AttributeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeList;
 class TDF_AttributeList {
 	public:
@@ -1137,6 +1182,11 @@ class TDF_AttributeList {
 };
 
 
+%extend TDF_AttributeList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeMap;
 class TDF_AttributeMap : public TCollection_BasicMap {
 	public:
@@ -1195,6 +1245,11 @@ class TDF_AttributeMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_AttributeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_AttributeSequence;
 class TDF_AttributeSequence : public TCollection_BaseSequence {
 	public:
@@ -1333,6 +1388,11 @@ class TDF_AttributeSequence : public TCollection_BaseSequence {
 };
 
 
+%extend TDF_AttributeSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ChildIDIterator;
 class TDF_ChildIDIterator {
 	public:
@@ -1393,6 +1453,11 @@ class TDF_ChildIDIterator {
 };
 
 
+%extend TDF_ChildIDIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ChildIterator;
 class TDF_ChildIterator {
 	public:
@@ -1449,6 +1514,11 @@ class TDF_ChildIterator {
 };
 
 
+%extend TDF_ChildIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ClosureMode;
 class TDF_ClosureMode {
 	public:
@@ -1491,6 +1561,11 @@ class TDF_ClosureMode {
 };
 
 
+%extend TDF_ClosureMode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TDF_ClosureTool {
 	public:
 		%feature("compactdefaultargs") Closure;
@@ -1532,6 +1607,11 @@ class TDF_ClosureTool {
 };
 
 
+%extend TDF_ClosureTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TDF_ComparisonTool {
 	public:
 		%feature("compactdefaultargs") Compare;
@@ -1601,6 +1681,11 @@ class TDF_ComparisonTool {
 };
 
 
+%extend TDF_ComparisonTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_CopyLabel;
 class TDF_CopyLabel {
 	public:
@@ -1685,6 +1770,11 @@ class TDF_CopyLabel {
 };
 
 
+%extend TDF_CopyLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TDF_CopyTool {
 	public:
 		%feature("compactdefaultargs") Copy;
@@ -1728,6 +1818,11 @@ class TDF_CopyTool {
 };
 
 
+%extend TDF_CopyTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Data;
 class TDF_Data : public MMgt_TShared {
 	public:
@@ -1860,6 +1955,11 @@ class Handle_TDF_Data : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_Data {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapIteratorOfAttributeDataMap;
 class TDF_DataMapIteratorOfAttributeDataMap : public TCollection_BasicMapIterator {
 	public:
@@ -1890,6 +1990,11 @@ class TDF_DataMapIteratorOfAttributeDataMap : public TCollection_BasicMapIterato
 };
 
 
+%extend TDF_DataMapIteratorOfAttributeDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapIteratorOfLabelDataMap;
 class TDF_DataMapIteratorOfLabelDataMap : public TCollection_BasicMapIterator {
 	public:
@@ -1920,6 +2025,11 @@ class TDF_DataMapIteratorOfLabelDataMap : public TCollection_BasicMapIterator {
 };
 
 
+%extend TDF_DataMapIteratorOfLabelDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapIteratorOfLabelIntegerMap;
 class TDF_DataMapIteratorOfLabelIntegerMap : public TCollection_BasicMapIterator {
 	public:
@@ -1950,6 +2060,11 @@ class TDF_DataMapIteratorOfLabelIntegerMap : public TCollection_BasicMapIterator
 };
 
 
+%extend TDF_DataMapIteratorOfLabelIntegerMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapNodeOfAttributeDataMap;
 class TDF_DataMapNodeOfAttributeDataMap : public TCollection_MapNode {
 	public:
@@ -2020,6 +2135,11 @@ class Handle_TDF_DataMapNodeOfAttributeDataMap : public Handle_TCollection_MapNo
     }
 };
 
+%extend TDF_DataMapNodeOfAttributeDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapNodeOfLabelDataMap;
 class TDF_DataMapNodeOfLabelDataMap : public TCollection_MapNode {
 	public:
@@ -2090,6 +2210,11 @@ class Handle_TDF_DataMapNodeOfLabelDataMap : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_DataMapNodeOfLabelDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataMapNodeOfLabelIntegerMap;
 class TDF_DataMapNodeOfLabelIntegerMap : public TCollection_MapNode {
 	public:
@@ -2169,6 +2294,11 @@ class Handle_TDF_DataMapNodeOfLabelIntegerMap : public Handle_TCollection_MapNod
     }
 };
 
+%extend TDF_DataMapNodeOfLabelIntegerMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DataSet;
 class TDF_DataSet : public MMgt_TShared {
 	public:
@@ -2305,6 +2435,11 @@ class Handle_TDF_DataSet : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_DataSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Delta;
 class TDF_Delta : public MMgt_TShared {
 	public:
@@ -2425,6 +2560,11 @@ class Handle_TDF_Delta : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_Delta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaList;
 class TDF_DeltaList {
 	public:
@@ -2555,6 +2695,11 @@ class TDF_DeltaList {
 };
 
 
+%extend TDF_DeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapIteratorOfAttributeDoubleMap;
 class TDF_DoubleMapIteratorOfAttributeDoubleMap : public TCollection_BasicMapIterator {
 	public:
@@ -2585,6 +2730,11 @@ class TDF_DoubleMapIteratorOfAttributeDoubleMap : public TCollection_BasicMapIte
 };
 
 
+%extend TDF_DoubleMapIteratorOfAttributeDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapIteratorOfGUIDProgIDMap;
 class TDF_DoubleMapIteratorOfGUIDProgIDMap : public TCollection_BasicMapIterator {
 	public:
@@ -2615,6 +2765,11 @@ class TDF_DoubleMapIteratorOfGUIDProgIDMap : public TCollection_BasicMapIterator
 };
 
 
+%extend TDF_DoubleMapIteratorOfGUIDProgIDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapIteratorOfLabelDoubleMap;
 class TDF_DoubleMapIteratorOfLabelDoubleMap : public TCollection_BasicMapIterator {
 	public:
@@ -2645,6 +2800,11 @@ class TDF_DoubleMapIteratorOfLabelDoubleMap : public TCollection_BasicMapIterato
 };
 
 
+%extend TDF_DoubleMapIteratorOfLabelDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapNodeOfAttributeDoubleMap;
 class TDF_DoubleMapNodeOfAttributeDoubleMap : public TCollection_MapNode {
 	public:
@@ -2721,6 +2881,11 @@ class Handle_TDF_DoubleMapNodeOfAttributeDoubleMap : public Handle_TCollection_M
     }
 };
 
+%extend TDF_DoubleMapNodeOfAttributeDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapNodeOfGUIDProgIDMap;
 class TDF_DoubleMapNodeOfGUIDProgIDMap : public TCollection_MapNode {
 	public:
@@ -2797,6 +2962,11 @@ class Handle_TDF_DoubleMapNodeOfGUIDProgIDMap : public Handle_TCollection_MapNod
     }
 };
 
+%extend TDF_DoubleMapNodeOfGUIDProgIDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DoubleMapNodeOfLabelDoubleMap;
 class TDF_DoubleMapNodeOfLabelDoubleMap : public TCollection_MapNode {
 	public:
@@ -2873,6 +3043,11 @@ class Handle_TDF_DoubleMapNodeOfLabelDoubleMap : public Handle_TCollection_MapNo
     }
 };
 
+%extend TDF_DoubleMapNodeOfLabelDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_GUIDProgIDMap;
 class TDF_GUIDProgIDMap : public TCollection_BasicMap {
 	public:
@@ -2959,6 +3134,11 @@ class TDF_GUIDProgIDMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_GUIDProgIDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_HAttributeArray1;
 class TDF_HAttributeArray1 : public MMgt_TShared {
 	public:
@@ -3075,6 +3255,11 @@ class Handle_TDF_HAttributeArray1 : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_HAttributeArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_IDFilter;
 class TDF_IDFilter {
 	public:
@@ -3191,6 +3376,11 @@ class TDF_IDFilter {
         };
 
 
+%extend TDF_IDFilter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_IDList;
 class TDF_IDList {
 	public:
@@ -3321,6 +3511,11 @@ class TDF_IDList {
 };
 
 
+%extend TDF_IDList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_IDMap;
 class TDF_IDMap : public TCollection_BasicMap {
 	public:
@@ -3379,6 +3574,11 @@ class TDF_IDMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_IDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_IndexedMapNodeOfAttributeIndexedMap;
 class TDF_IndexedMapNodeOfAttributeIndexedMap : public TCollection_MapNode {
 	public:
@@ -3464,6 +3664,11 @@ class Handle_TDF_IndexedMapNodeOfAttributeIndexedMap : public Handle_TCollection
     }
 };
 
+%extend TDF_IndexedMapNodeOfAttributeIndexedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_IndexedMapNodeOfLabelIndexedMap;
 class TDF_IndexedMapNodeOfLabelIndexedMap : public TCollection_MapNode {
 	public:
@@ -3549,6 +3754,11 @@ class Handle_TDF_IndexedMapNodeOfLabelIndexedMap : public Handle_TCollection_Map
     }
 };
 
+%extend TDF_IndexedMapNodeOfLabelIndexedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Label;
 class TDF_Label {
 	public:
@@ -3843,6 +4053,11 @@ class TDF_Label {
         };
 
 
+%extend TDF_Label {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelDataMap;
 class TDF_LabelDataMap : public TCollection_BasicMap {
 	public:
@@ -3921,6 +4136,11 @@ class TDF_LabelDataMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_LabelDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelDoubleMap;
 class TDF_LabelDoubleMap : public TCollection_BasicMap {
 	public:
@@ -4007,6 +4227,11 @@ class TDF_LabelDoubleMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_LabelDoubleMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelIndexedMap;
 class TDF_LabelIndexedMap : public TCollection_BasicMap {
 	public:
@@ -4083,6 +4308,11 @@ class TDF_LabelIndexedMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_LabelIndexedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelIntegerMap;
 class TDF_LabelIntegerMap : public TCollection_BasicMap {
 	public:
@@ -4161,6 +4391,11 @@ class TDF_LabelIntegerMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_LabelIntegerMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelList;
 class TDF_LabelList {
 	public:
@@ -4291,6 +4526,11 @@ class TDF_LabelList {
 };
 
 
+%extend TDF_LabelList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelMap;
 class TDF_LabelMap : public TCollection_BasicMap {
 	public:
@@ -4349,6 +4589,11 @@ class TDF_LabelMap : public TCollection_BasicMap {
 };
 
 
+%extend TDF_LabelMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_LabelSequence;
 class TDF_LabelSequence : public TCollection_BaseSequence {
 	public:
@@ -4487,6 +4732,11 @@ class TDF_LabelSequence : public TCollection_BaseSequence {
 };
 
 
+%extend TDF_LabelSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListIteratorOfAttributeDeltaList;
 class TDF_ListIteratorOfAttributeDeltaList {
 	public:
@@ -4521,6 +4771,11 @@ class TDF_ListIteratorOfAttributeDeltaList {
 };
 
 
+%extend TDF_ListIteratorOfAttributeDeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListIteratorOfAttributeList;
 class TDF_ListIteratorOfAttributeList {
 	public:
@@ -4555,6 +4810,11 @@ class TDF_ListIteratorOfAttributeList {
 };
 
 
+%extend TDF_ListIteratorOfAttributeList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListIteratorOfDeltaList;
 class TDF_ListIteratorOfDeltaList {
 	public:
@@ -4589,6 +4849,11 @@ class TDF_ListIteratorOfDeltaList {
 };
 
 
+%extend TDF_ListIteratorOfDeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListIteratorOfIDList;
 class TDF_ListIteratorOfIDList {
 	public:
@@ -4623,6 +4888,11 @@ class TDF_ListIteratorOfIDList {
 };
 
 
+%extend TDF_ListIteratorOfIDList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListIteratorOfLabelList;
 class TDF_ListIteratorOfLabelList {
 	public:
@@ -4657,6 +4927,11 @@ class TDF_ListIteratorOfLabelList {
 };
 
 
+%extend TDF_ListIteratorOfLabelList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListNodeOfAttributeDeltaList;
 class TDF_ListNodeOfAttributeDeltaList : public TCollection_MapNode {
 	public:
@@ -4721,6 +4996,11 @@ class Handle_TDF_ListNodeOfAttributeDeltaList : public Handle_TCollection_MapNod
     }
 };
 
+%extend TDF_ListNodeOfAttributeDeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListNodeOfAttributeList;
 class TDF_ListNodeOfAttributeList : public TCollection_MapNode {
 	public:
@@ -4785,6 +5065,11 @@ class Handle_TDF_ListNodeOfAttributeList : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_ListNodeOfAttributeList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListNodeOfDeltaList;
 class TDF_ListNodeOfDeltaList : public TCollection_MapNode {
 	public:
@@ -4849,6 +5134,11 @@ class Handle_TDF_ListNodeOfDeltaList : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_ListNodeOfDeltaList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListNodeOfIDList;
 class TDF_ListNodeOfIDList : public TCollection_MapNode {
 	public:
@@ -4913,6 +5203,11 @@ class Handle_TDF_ListNodeOfIDList : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_ListNodeOfIDList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_ListNodeOfLabelList;
 class TDF_ListNodeOfLabelList : public TCollection_MapNode {
 	public:
@@ -4977,6 +5272,11 @@ class Handle_TDF_ListNodeOfLabelList : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_ListNodeOfLabelList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_MapIteratorOfAttributeMap;
 class TDF_MapIteratorOfAttributeMap : public TCollection_BasicMapIterator {
 	public:
@@ -5003,6 +5303,11 @@ class TDF_MapIteratorOfAttributeMap : public TCollection_BasicMapIterator {
 };
 
 
+%extend TDF_MapIteratorOfAttributeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_MapIteratorOfIDMap;
 class TDF_MapIteratorOfIDMap : public TCollection_BasicMapIterator {
 	public:
@@ -5029,6 +5334,11 @@ class TDF_MapIteratorOfIDMap : public TCollection_BasicMapIterator {
 };
 
 
+%extend TDF_MapIteratorOfIDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_MapIteratorOfLabelMap;
 class TDF_MapIteratorOfLabelMap : public TCollection_BasicMapIterator {
 	public:
@@ -5055,6 +5365,11 @@ class TDF_MapIteratorOfLabelMap : public TCollection_BasicMapIterator {
 };
 
 
+%extend TDF_MapIteratorOfLabelMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_RelocationTable;
 class TDF_RelocationTable : public MMgt_TShared {
 	public:
@@ -5255,6 +5570,11 @@ class Handle_TDF_RelocationTable : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDF_RelocationTable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_SequenceNodeOfAttributeSequence;
 class TDF_SequenceNodeOfAttributeSequence : public TCollection_SeqNode {
 	public:
@@ -5321,6 +5641,11 @@ class Handle_TDF_SequenceNodeOfAttributeSequence : public Handle_TCollection_Seq
     }
 };
 
+%extend TDF_SequenceNodeOfAttributeSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_SequenceNodeOfLabelSequence;
 class TDF_SequenceNodeOfLabelSequence : public TCollection_SeqNode {
 	public:
@@ -5387,6 +5712,11 @@ class Handle_TDF_SequenceNodeOfLabelSequence : public Handle_TCollection_SeqNode
     }
 };
 
+%extend TDF_SequenceNodeOfLabelSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_StdMapNodeOfAttributeMap;
 class TDF_StdMapNodeOfAttributeMap : public TCollection_MapNode {
 	public:
@@ -5451,6 +5781,11 @@ class Handle_TDF_StdMapNodeOfAttributeMap : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_StdMapNodeOfAttributeMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_StdMapNodeOfIDMap;
 class TDF_StdMapNodeOfIDMap : public TCollection_MapNode {
 	public:
@@ -5515,6 +5850,11 @@ class Handle_TDF_StdMapNodeOfIDMap : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_StdMapNodeOfIDMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_StdMapNodeOfLabelMap;
 class TDF_StdMapNodeOfLabelMap : public TCollection_MapNode {
 	public:
@@ -5579,6 +5919,11 @@ class Handle_TDF_StdMapNodeOfLabelMap : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDF_StdMapNodeOfLabelMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TDF_Tool {
 	public:
 		%feature("compactdefaultargs") NbLabels;
@@ -5828,6 +6173,11 @@ class TDF_Tool {
 };
 
 
+%extend TDF_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Transaction;
 class TDF_Transaction {
 	public:
@@ -5904,6 +6254,11 @@ class TDF_Transaction {
 };
 
 
+%extend TDF_Transaction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaOnAddition;
 class TDF_DeltaOnAddition : public TDF_AttributeDelta {
 	public:
@@ -5970,6 +6325,11 @@ class Handle_TDF_DeltaOnAddition : public Handle_TDF_AttributeDelta {
     }
 };
 
+%extend TDF_DeltaOnAddition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaOnForget;
 class TDF_DeltaOnForget : public TDF_AttributeDelta {
 	public:
@@ -6036,6 +6396,11 @@ class Handle_TDF_DeltaOnForget : public Handle_TDF_AttributeDelta {
     }
 };
 
+%extend TDF_DeltaOnForget {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaOnModification;
 class TDF_DeltaOnModification : public TDF_AttributeDelta {
 	public:
@@ -6094,6 +6459,11 @@ class Handle_TDF_DeltaOnModification : public Handle_TDF_AttributeDelta {
     }
 };
 
+%extend TDF_DeltaOnModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaOnRemoval;
 class TDF_DeltaOnRemoval : public TDF_AttributeDelta {
 	public:
@@ -6146,6 +6516,11 @@ class Handle_TDF_DeltaOnRemoval : public Handle_TDF_AttributeDelta {
     }
 };
 
+%extend TDF_DeltaOnRemoval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DeltaOnResume;
 class TDF_DeltaOnResume : public TDF_AttributeDelta {
 	public:
@@ -6212,6 +6587,11 @@ class Handle_TDF_DeltaOnResume : public Handle_TDF_AttributeDelta {
     }
 };
 
+%extend TDF_DeltaOnResume {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_Reference;
 class TDF_Reference : public TDF_Attribute {
 	public:
@@ -6326,6 +6706,11 @@ class Handle_TDF_Reference : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDF_Reference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_TagSource;
 class TDF_TagSource : public TDF_Attribute {
 	public:
@@ -6446,6 +6831,11 @@ class Handle_TDF_TagSource : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDF_TagSource {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DefaultDeltaOnModification;
 class TDF_DefaultDeltaOnModification : public TDF_DeltaOnModification {
 	public:
@@ -6512,6 +6902,11 @@ class Handle_TDF_DefaultDeltaOnModification : public Handle_TDF_DeltaOnModificat
     }
 };
 
+%extend TDF_DefaultDeltaOnModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDF_DefaultDeltaOnRemoval;
 class TDF_DefaultDeltaOnRemoval : public TDF_DeltaOnRemoval {
 	public:
@@ -6578,3 +6973,8 @@ class Handle_TDF_DefaultDeltaOnRemoval : public Handle_TDF_DeltaOnRemoval {
     }
 };
 
+%extend TDF_DefaultDeltaOnRemoval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TDataStd.i
+++ b/src/SWIG_files/wrapper/TDataStd.i
@@ -87,6 +87,11 @@ class TDataStd {
 };
 
 
+%extend TDataStd {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_AsciiString;
 class TDataStd_AsciiString : public TDF_Attribute {
 	public:
@@ -203,6 +208,11 @@ class Handle_TDataStd_AsciiString : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_AsciiString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_BooleanArray;
 class TDataStd_BooleanArray : public TDF_Attribute {
 	public:
@@ -363,6 +373,11 @@ class Handle_TDataStd_BooleanArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_BooleanArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_BooleanList;
 class TDataStd_BooleanList : public TDF_Attribute {
 	public:
@@ -501,6 +516,11 @@ class Handle_TDataStd_BooleanList : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_BooleanList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ByteArray;
 class TDataStd_ByteArray : public TDF_Attribute {
 	public:
@@ -687,6 +707,11 @@ class Handle_TDataStd_ByteArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_ByteArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ChildNodeIterator;
 class TDataStd_ChildNodeIterator {
 	public:
@@ -743,6 +768,11 @@ class TDataStd_ChildNodeIterator {
 };
 
 
+%extend TDataStd_ChildNodeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Comment;
 class TDataStd_Comment : public TDF_Attribute {
 	public:
@@ -871,6 +901,11 @@ class Handle_TDataStd_Comment : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Comment {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Current;
 class TDataStd_Current : public TDF_Attribute {
 	public:
@@ -997,6 +1032,11 @@ class Handle_TDataStd_Current : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Current {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapIteratorOfDataMapOfStringByte;
 class TDataStd_DataMapIteratorOfDataMapOfStringByte : public TCollection_BasicMapIterator {
 	public:
@@ -1027,6 +1067,11 @@ class TDataStd_DataMapIteratorOfDataMapOfStringByte : public TCollection_BasicMa
 };
 
 
+%extend TDataStd_DataMapIteratorOfDataMapOfStringByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfInteger;
 class TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -1057,6 +1102,11 @@ class TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfInteger : public TCollec
 };
 
 
+%extend TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfReal;
 class TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfReal : public TCollection_BasicMapIterator {
 	public:
@@ -1087,6 +1137,11 @@ class TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfReal : public TCollectio
 };
 
 
+%extend TDataStd_DataMapIteratorOfDataMapOfStringHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapIteratorOfDataMapOfStringReal;
 class TDataStd_DataMapIteratorOfDataMapOfStringReal : public TCollection_BasicMapIterator {
 	public:
@@ -1117,6 +1172,11 @@ class TDataStd_DataMapIteratorOfDataMapOfStringReal : public TCollection_BasicMa
 };
 
 
+%extend TDataStd_DataMapIteratorOfDataMapOfStringReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapIteratorOfDataMapOfStringString;
 class TDataStd_DataMapIteratorOfDataMapOfStringString : public TCollection_BasicMapIterator {
 	public:
@@ -1147,6 +1207,11 @@ class TDataStd_DataMapIteratorOfDataMapOfStringString : public TCollection_Basic
 };
 
 
+%extend TDataStd_DataMapIteratorOfDataMapOfStringString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapNodeOfDataMapOfStringByte;
 class TDataStd_DataMapNodeOfDataMapOfStringByte : public TCollection_MapNode {
 	public:
@@ -1217,6 +1282,11 @@ class Handle_TDataStd_DataMapNodeOfDataMapOfStringByte : public Handle_TCollecti
     }
 };
 
+%extend TDataStd_DataMapNodeOfDataMapOfStringByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapNodeOfDataMapOfStringHArray1OfInteger;
 class TDataStd_DataMapNodeOfDataMapOfStringHArray1OfInteger : public TCollection_MapNode {
 	public:
@@ -1287,6 +1357,11 @@ class Handle_TDataStd_DataMapNodeOfDataMapOfStringHArray1OfInteger : public Hand
     }
 };
 
+%extend TDataStd_DataMapNodeOfDataMapOfStringHArray1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapNodeOfDataMapOfStringHArray1OfReal;
 class TDataStd_DataMapNodeOfDataMapOfStringHArray1OfReal : public TCollection_MapNode {
 	public:
@@ -1357,6 +1432,11 @@ class Handle_TDataStd_DataMapNodeOfDataMapOfStringHArray1OfReal : public Handle_
     }
 };
 
+%extend TDataStd_DataMapNodeOfDataMapOfStringHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapNodeOfDataMapOfStringReal;
 class TDataStd_DataMapNodeOfDataMapOfStringReal : public TCollection_MapNode {
 	public:
@@ -1436,6 +1516,11 @@ class Handle_TDataStd_DataMapNodeOfDataMapOfStringReal : public Handle_TCollecti
     }
 };
 
+%extend TDataStd_DataMapNodeOfDataMapOfStringReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapNodeOfDataMapOfStringString;
 class TDataStd_DataMapNodeOfDataMapOfStringString : public TCollection_MapNode {
 	public:
@@ -1506,6 +1591,11 @@ class Handle_TDataStd_DataMapNodeOfDataMapOfStringString : public Handle_TCollec
     }
 };
 
+%extend TDataStd_DataMapNodeOfDataMapOfStringString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapOfStringByte;
 class TDataStd_DataMapOfStringByte : public TCollection_BasicMap {
 	public:
@@ -1584,6 +1674,11 @@ class TDataStd_DataMapOfStringByte : public TCollection_BasicMap {
 };
 
 
+%extend TDataStd_DataMapOfStringByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapOfStringHArray1OfInteger;
 class TDataStd_DataMapOfStringHArray1OfInteger : public TCollection_BasicMap {
 	public:
@@ -1662,6 +1757,11 @@ class TDataStd_DataMapOfStringHArray1OfInteger : public TCollection_BasicMap {
 };
 
 
+%extend TDataStd_DataMapOfStringHArray1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapOfStringHArray1OfReal;
 class TDataStd_DataMapOfStringHArray1OfReal : public TCollection_BasicMap {
 	public:
@@ -1740,6 +1840,11 @@ class TDataStd_DataMapOfStringHArray1OfReal : public TCollection_BasicMap {
 };
 
 
+%extend TDataStd_DataMapOfStringHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapOfStringReal;
 class TDataStd_DataMapOfStringReal : public TCollection_BasicMap {
 	public:
@@ -1818,6 +1923,11 @@ class TDataStd_DataMapOfStringReal : public TCollection_BasicMap {
 };
 
 
+%extend TDataStd_DataMapOfStringReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DataMapOfStringString;
 class TDataStd_DataMapOfStringString : public TCollection_BasicMap {
 	public:
@@ -1896,6 +2006,11 @@ class TDataStd_DataMapOfStringString : public TCollection_BasicMap {
 };
 
 
+%extend TDataStd_DataMapOfStringString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DeltaOnModificationOfByteArray;
 class TDataStd_DeltaOnModificationOfByteArray : public TDF_DeltaOnModification {
 	public:
@@ -1962,6 +2077,11 @@ class Handle_TDataStd_DeltaOnModificationOfByteArray : public Handle_TDF_DeltaOn
     }
 };
 
+%extend TDataStd_DeltaOnModificationOfByteArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DeltaOnModificationOfExtStringArray;
 class TDataStd_DeltaOnModificationOfExtStringArray : public TDF_DeltaOnModification {
 	public:
@@ -2028,6 +2148,11 @@ class Handle_TDataStd_DeltaOnModificationOfExtStringArray : public Handle_TDF_De
     }
 };
 
+%extend TDataStd_DeltaOnModificationOfExtStringArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DeltaOnModificationOfIntArray;
 class TDataStd_DeltaOnModificationOfIntArray : public TDF_DeltaOnModification {
 	public:
@@ -2094,6 +2219,11 @@ class Handle_TDataStd_DeltaOnModificationOfIntArray : public Handle_TDF_DeltaOnM
     }
 };
 
+%extend TDataStd_DeltaOnModificationOfIntArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DeltaOnModificationOfIntPackedMap;
 class TDataStd_DeltaOnModificationOfIntPackedMap : public TDF_DeltaOnModification {
 	public:
@@ -2160,6 +2290,11 @@ class Handle_TDataStd_DeltaOnModificationOfIntPackedMap : public Handle_TDF_Delt
     }
 };
 
+%extend TDataStd_DeltaOnModificationOfIntPackedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_DeltaOnModificationOfRealArray;
 class TDataStd_DeltaOnModificationOfRealArray : public TDF_DeltaOnModification {
 	public:
@@ -2226,6 +2361,11 @@ class Handle_TDataStd_DeltaOnModificationOfRealArray : public Handle_TDF_DeltaOn
     }
 };
 
+%extend TDataStd_DeltaOnModificationOfRealArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Directory;
 class TDataStd_Directory : public TDF_Attribute {
 	public:
@@ -2358,6 +2498,11 @@ class Handle_TDataStd_Directory : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Directory {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Expression;
 class TDataStd_Expression : public TDF_Attribute {
 	public:
@@ -2478,6 +2623,11 @@ class Handle_TDataStd_Expression : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Expression {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ExtStringArray;
 class TDataStd_ExtStringArray : public TDF_Attribute {
 	public:
@@ -2666,6 +2816,11 @@ class Handle_TDataStd_ExtStringArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_ExtStringArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ExtStringList;
 class TDataStd_ExtStringList : public TDF_Attribute {
 	public:
@@ -2830,6 +2985,11 @@ class Handle_TDataStd_ExtStringList : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_ExtStringList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringByte;
 class TDataStd_HDataMapOfStringByte : public MMgt_TShared {
 	public:
@@ -2902,6 +3062,11 @@ class Handle_TDataStd_HDataMapOfStringByte : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataStd_HDataMapOfStringByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringHArray1OfInteger;
 class TDataStd_HDataMapOfStringHArray1OfInteger : public MMgt_TShared {
 	public:
@@ -2974,6 +3139,11 @@ class Handle_TDataStd_HDataMapOfStringHArray1OfInteger : public Handle_MMgt_TSha
     }
 };
 
+%extend TDataStd_HDataMapOfStringHArray1OfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringHArray1OfReal;
 class TDataStd_HDataMapOfStringHArray1OfReal : public MMgt_TShared {
 	public:
@@ -3046,6 +3216,11 @@ class Handle_TDataStd_HDataMapOfStringHArray1OfReal : public Handle_MMgt_TShared
     }
 };
 
+%extend TDataStd_HDataMapOfStringHArray1OfReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringInteger;
 class TDataStd_HDataMapOfStringInteger : public MMgt_TShared {
 	public:
@@ -3118,6 +3293,11 @@ class Handle_TDataStd_HDataMapOfStringInteger : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataStd_HDataMapOfStringInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringReal;
 class TDataStd_HDataMapOfStringReal : public MMgt_TShared {
 	public:
@@ -3190,6 +3370,11 @@ class Handle_TDataStd_HDataMapOfStringReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataStd_HDataMapOfStringReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HDataMapOfStringString;
 class TDataStd_HDataMapOfStringString : public MMgt_TShared {
 	public:
@@ -3262,6 +3447,11 @@ class Handle_TDataStd_HDataMapOfStringString : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataStd_HDataMapOfStringString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_HLabelArray1;
 class TDataStd_HLabelArray1 : public MMgt_TShared {
 	public:
@@ -3378,6 +3568,11 @@ class Handle_TDataStd_HLabelArray1 : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataStd_HLabelArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_IntPackedMap;
 class TDataStd_IntPackedMap : public TDF_Attribute {
 	public:
@@ -3544,6 +3739,11 @@ class Handle_TDataStd_IntPackedMap : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_IntPackedMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Integer;
 class TDataStd_Integer : public TDF_Attribute {
 	public:
@@ -3664,6 +3864,11 @@ class Handle_TDataStd_Integer : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Integer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_IntegerArray;
 class TDataStd_IntegerArray : public TDF_Attribute {
 	public:
@@ -3854,6 +4059,11 @@ class Handle_TDataStd_IntegerArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_IntegerArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_IntegerList;
 class TDataStd_IntegerList : public TDF_Attribute {
 	public:
@@ -4018,6 +4228,11 @@ class Handle_TDataStd_IntegerList : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_IntegerList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_LabelArray1;
 class TDataStd_LabelArray1 {
 	public:
@@ -4100,6 +4315,11 @@ class TDataStd_LabelArray1 {
 };
 
 
+%extend TDataStd_LabelArray1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListIteratorOfListOfByte;
 class TDataStd_ListIteratorOfListOfByte {
 	public:
@@ -4134,6 +4354,11 @@ class TDataStd_ListIteratorOfListOfByte {
 };
 
 
+%extend TDataStd_ListIteratorOfListOfByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListIteratorOfListOfExtendedString;
 class TDataStd_ListIteratorOfListOfExtendedString {
 	public:
@@ -4168,6 +4393,11 @@ class TDataStd_ListIteratorOfListOfExtendedString {
 };
 
 
+%extend TDataStd_ListIteratorOfListOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListNodeOfListOfByte;
 class TDataStd_ListNodeOfListOfByte : public TCollection_MapNode {
 	public:
@@ -4232,6 +4462,11 @@ class Handle_TDataStd_ListNodeOfListOfByte : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TDataStd_ListNodeOfListOfByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListNodeOfListOfExtendedString;
 class TDataStd_ListNodeOfListOfExtendedString : public TCollection_MapNode {
 	public:
@@ -4296,6 +4531,11 @@ class Handle_TDataStd_ListNodeOfListOfExtendedString : public Handle_TCollection
     }
 };
 
+%extend TDataStd_ListNodeOfListOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListOfByte;
 class TDataStd_ListOfByte {
 	public:
@@ -4426,6 +4666,11 @@ class TDataStd_ListOfByte {
 };
 
 
+%extend TDataStd_ListOfByte {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ListOfExtendedString;
 class TDataStd_ListOfExtendedString {
 	public:
@@ -4556,6 +4801,11 @@ class TDataStd_ListOfExtendedString {
 };
 
 
+%extend TDataStd_ListOfExtendedString {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Name;
 class TDataStd_Name : public TDF_Attribute {
 	public:
@@ -4672,6 +4922,11 @@ class Handle_TDataStd_Name : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Name {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_NamedData;
 class TDataStd_NamedData : public TDF_Attribute {
 	public:
@@ -5048,6 +5303,11 @@ class Handle_TDataStd_NamedData : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_NamedData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_NoteBook;
 class TDataStd_NoteBook : public TDF_Attribute {
 	public:
@@ -5178,6 +5438,11 @@ class Handle_TDataStd_NoteBook : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_NoteBook {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Real;
 class TDataStd_Real : public TDF_Attribute {
 	public:
@@ -5310,6 +5575,11 @@ class Handle_TDataStd_Real : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Real {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_RealArray;
 class TDataStd_RealArray : public TDF_Attribute {
 	public:
@@ -5500,6 +5770,11 @@ class Handle_TDataStd_RealArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_RealArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_RealList;
 class TDataStd_RealList : public TDF_Attribute {
 	public:
@@ -5664,6 +5939,11 @@ class Handle_TDataStd_RealList : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_RealList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ReferenceArray;
 class TDataStd_ReferenceArray : public TDF_Attribute {
 	public:
@@ -5832,6 +6112,11 @@ class Handle_TDataStd_ReferenceArray : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_ReferenceArray {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_ReferenceList;
 class TDataStd_ReferenceList : public TDF_Attribute {
 	public:
@@ -6002,6 +6287,11 @@ class Handle_TDataStd_ReferenceList : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_ReferenceList {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Relation;
 class TDataStd_Relation : public TDF_Attribute {
 	public:
@@ -6122,6 +6412,11 @@ class Handle_TDataStd_Relation : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Relation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Tick;
 class TDataStd_Tick : public TDF_Attribute {
 	public:
@@ -6222,6 +6517,11 @@ class Handle_TDataStd_Tick : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Tick {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_TreeNode;
 class TDataStd_TreeNode : public TDF_Attribute {
 	public:
@@ -6588,6 +6888,11 @@ class Handle_TDataStd_TreeNode : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_TreeNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_UAttribute;
 class TDataStd_UAttribute : public TDF_Attribute {
 	public:
@@ -6696,6 +7001,11 @@ class Handle_TDataStd_UAttribute : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_UAttribute {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataStd_Variable;
 class TDataStd_Variable : public TDF_Attribute {
 	public:
@@ -6902,3 +7212,8 @@ class Handle_TDataStd_Variable : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataStd_Variable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TDataXtd.i
+++ b/src/SWIG_files/wrapper/TDataXtd.i
@@ -130,6 +130,11 @@ class TDataXtd {
 };
 
 
+%extend TDataXtd {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Array1OfTrsf;
 class TDataXtd_Array1OfTrsf {
 	public:
@@ -212,6 +217,11 @@ class TDataXtd_Array1OfTrsf {
 };
 
 
+%extend TDataXtd_Array1OfTrsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Axis;
 class TDataXtd_Axis : public TDF_Attribute {
 	public:
@@ -322,6 +332,11 @@ class Handle_TDataXtd_Axis : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Axis {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Constraint;
 class TDataXtd_Constraint : public TDF_Attribute {
 	public:
@@ -608,6 +623,11 @@ class Handle_TDataXtd_Constraint : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Constraint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Geometry;
 class TDataXtd_Geometry : public TDF_Attribute {
 	public:
@@ -880,6 +900,11 @@ class Handle_TDataXtd_Geometry : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Geometry {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_HArray1OfTrsf;
 class TDataXtd_HArray1OfTrsf : public MMgt_TShared {
 	public:
@@ -996,6 +1021,11 @@ class Handle_TDataXtd_HArray1OfTrsf : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDataXtd_HArray1OfTrsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Pattern;
 class TDataXtd_Pattern : public TDF_Attribute {
 	public:
@@ -1078,6 +1108,11 @@ class Handle_TDataXtd_Pattern : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Pattern {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Placement;
 class TDataXtd_Placement : public TDF_Attribute {
 	public:
@@ -1178,6 +1213,11 @@ class Handle_TDataXtd_Placement : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Placement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Plane;
 class TDataXtd_Plane : public TDF_Attribute {
 	public:
@@ -1288,6 +1328,11 @@ class Handle_TDataXtd_Plane : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Point;
 class TDataXtd_Point : public TDF_Attribute {
 	public:
@@ -1398,6 +1443,11 @@ class Handle_TDataXtd_Point : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Position;
 class TDataXtd_Position : public TDF_Attribute {
 	public:
@@ -1528,6 +1578,11 @@ class Handle_TDataXtd_Position : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Position {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_Shape;
 class TDataXtd_Shape : public TDF_Attribute {
 	public:
@@ -1662,6 +1717,11 @@ class Handle_TDataXtd_Shape : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDataXtd_Shape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDataXtd_PatternStd;
 class TDataXtd_PatternStd : public TDataXtd_Pattern {
 	public:
@@ -1876,3 +1936,8 @@ class Handle_TDataXtd_PatternStd : public Handle_TDataXtd_Pattern {
     }
 };
 
+%extend TDataXtd_PatternStd {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TDocStd.i
+++ b/src/SWIG_files/wrapper/TDocStd.i
@@ -71,6 +71,11 @@ class TDocStd {
 };
 
 
+%extend TDocStd {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_Application;
 class TDocStd_Application : public CDF_Application {
 	public:
@@ -249,6 +254,11 @@ class Handle_TDocStd_Application : public Handle_CDF_Application {
     }
 };
 
+%extend TDocStd_Application {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_ApplicationDelta;
 class TDocStd_ApplicationDelta : public MMgt_TShared {
 	public:
@@ -327,6 +337,11 @@ class Handle_TDocStd_ApplicationDelta : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDocStd_ApplicationDelta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_CompoundDelta;
 class TDocStd_CompoundDelta : public TDF_Delta {
 	public:
@@ -385,6 +400,11 @@ class Handle_TDocStd_CompoundDelta : public Handle_TDF_Delta {
     }
 };
 
+%extend TDocStd_CompoundDelta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_Context;
 class TDocStd_Context {
 	public:
@@ -405,6 +425,11 @@ class TDocStd_Context {
 };
 
 
+%extend TDocStd_Context {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_DataMapIteratorOfLabelIDMapDataMap;
 class TDocStd_DataMapIteratorOfLabelIDMapDataMap : public TCollection_BasicMapIterator {
 	public:
@@ -435,6 +460,11 @@ class TDocStd_DataMapIteratorOfLabelIDMapDataMap : public TCollection_BasicMapIt
 };
 
 
+%extend TDocStd_DataMapIteratorOfLabelIDMapDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_DataMapNodeOfLabelIDMapDataMap;
 class TDocStd_DataMapNodeOfLabelIDMapDataMap : public TCollection_MapNode {
 	public:
@@ -505,6 +535,11 @@ class Handle_TDocStd_DataMapNodeOfLabelIDMapDataMap : public Handle_TCollection_
     }
 };
 
+%extend TDocStd_DataMapNodeOfLabelIDMapDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_Document;
 class TDocStd_Document : public CDM_Document {
 	public:
@@ -843,6 +878,11 @@ class Handle_TDocStd_Document : public Handle_CDM_Document {
     }
 };
 
+%extend TDocStd_Document {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_LabelIDMapDataMap;
 class TDocStd_LabelIDMapDataMap : public TCollection_BasicMap {
 	public:
@@ -921,6 +961,11 @@ class TDocStd_LabelIDMapDataMap : public TCollection_BasicMap {
 };
 
 
+%extend TDocStd_LabelIDMapDataMap {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_Modified;
 class TDocStd_Modified : public TDF_Attribute {
 	public:
@@ -1085,6 +1130,11 @@ class Handle_TDocStd_Modified : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDocStd_Modified {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_MultiTransactionManager;
 class TDocStd_MultiTransactionManager : public MMgt_TShared {
 	public:
@@ -1289,6 +1339,11 @@ class Handle_TDocStd_MultiTransactionManager : public Handle_MMgt_TShared {
     }
 };
 
+%extend TDocStd_MultiTransactionManager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_Owner;
 class TDocStd_Owner : public TDF_Attribute {
 	public:
@@ -1407,6 +1462,11 @@ class Handle_TDocStd_Owner : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDocStd_Owner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_PathParser;
 class TDocStd_PathParser {
 	public:
@@ -1443,6 +1503,11 @@ class TDocStd_PathParser {
 };
 
 
+%extend TDocStd_PathParser {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_SequenceNodeOfSequenceOfApplicationDelta;
 class TDocStd_SequenceNodeOfSequenceOfApplicationDelta : public TCollection_SeqNode {
 	public:
@@ -1509,6 +1574,11 @@ class Handle_TDocStd_SequenceNodeOfSequenceOfApplicationDelta : public Handle_TC
     }
 };
 
+%extend TDocStd_SequenceNodeOfSequenceOfApplicationDelta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_SequenceNodeOfSequenceOfDocument;
 class TDocStd_SequenceNodeOfSequenceOfDocument : public TCollection_SeqNode {
 	public:
@@ -1575,6 +1645,11 @@ class Handle_TDocStd_SequenceNodeOfSequenceOfDocument : public Handle_TCollectio
     }
 };
 
+%extend TDocStd_SequenceNodeOfSequenceOfDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_SequenceOfApplicationDelta;
 class TDocStd_SequenceOfApplicationDelta : public TCollection_BaseSequence {
 	public:
@@ -1713,6 +1788,11 @@ class TDocStd_SequenceOfApplicationDelta : public TCollection_BaseSequence {
 };
 
 
+%extend TDocStd_SequenceOfApplicationDelta {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_SequenceOfDocument;
 class TDocStd_SequenceOfDocument : public TCollection_BaseSequence {
 	public:
@@ -1851,6 +1931,11 @@ class TDocStd_SequenceOfDocument : public TCollection_BaseSequence {
 };
 
 
+%extend TDocStd_SequenceOfDocument {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_XLink;
 class TDocStd_XLink : public TDF_Attribute {
 	public:
@@ -2041,6 +2126,11 @@ class Handle_TDocStd_XLink : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDocStd_XLink {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_XLinkIterator;
 class TDocStd_XLinkIterator {
 	public:
@@ -2087,6 +2177,11 @@ class TDocStd_XLinkIterator {
 };
 
 
+%extend TDocStd_XLinkIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_XLinkRoot;
 class TDocStd_XLinkRoot : public TDF_Attribute {
 	public:
@@ -2213,6 +2308,11 @@ class Handle_TDocStd_XLinkRoot : public Handle_TDF_Attribute {
     }
 };
 
+%extend TDocStd_XLinkRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TDocStd_XLinkTool;
 class TDocStd_XLinkTool {
 	public:
@@ -2263,3 +2363,8 @@ class TDocStd_XLinkTool {
 };
 
 
+%extend TDocStd_XLinkTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TFunction.i
+++ b/src/SWIG_files/wrapper/TFunction.i
@@ -146,6 +146,11 @@ class TFunction_Array1OfDataMapOfGUIDDriver {
 };
 
 
+%extend TFunction_Array1OfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapIteratorOfDataMapOfGUIDDriver;
 class TFunction_DataMapIteratorOfDataMapOfGUIDDriver : public TCollection_BasicMapIterator {
 	public:
@@ -176,6 +181,11 @@ class TFunction_DataMapIteratorOfDataMapOfGUIDDriver : public TCollection_BasicM
 };
 
 
+%extend TFunction_DataMapIteratorOfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapIteratorOfDataMapOfLabelListOfLabel;
 class TFunction_DataMapIteratorOfDataMapOfLabelListOfLabel : public TCollection_BasicMapIterator {
 	public:
@@ -206,6 +216,11 @@ class TFunction_DataMapIteratorOfDataMapOfLabelListOfLabel : public TCollection_
 };
 
 
+%extend TFunction_DataMapIteratorOfDataMapOfLabelListOfLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapNodeOfDataMapOfGUIDDriver;
 class TFunction_DataMapNodeOfDataMapOfGUIDDriver : public TCollection_MapNode {
 	public:
@@ -276,6 +291,11 @@ class Handle_TFunction_DataMapNodeOfDataMapOfGUIDDriver : public Handle_TCollect
     }
 };
 
+%extend TFunction_DataMapNodeOfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapNodeOfDataMapOfLabelListOfLabel;
 class TFunction_DataMapNodeOfDataMapOfLabelListOfLabel : public TCollection_MapNode {
 	public:
@@ -346,6 +366,11 @@ class Handle_TFunction_DataMapNodeOfDataMapOfLabelListOfLabel : public Handle_TC
     }
 };
 
+%extend TFunction_DataMapNodeOfDataMapOfLabelListOfLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapOfGUIDDriver;
 class TFunction_DataMapOfGUIDDriver : public TCollection_BasicMap {
 	public:
@@ -424,6 +449,11 @@ class TFunction_DataMapOfGUIDDriver : public TCollection_BasicMap {
 };
 
 
+%extend TFunction_DataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DataMapOfLabelListOfLabel;
 class TFunction_DataMapOfLabelListOfLabel : public TCollection_BasicMap {
 	public:
@@ -502,6 +532,11 @@ class TFunction_DataMapOfLabelListOfLabel : public TCollection_BasicMap {
 };
 
 
+%extend TFunction_DataMapOfLabelListOfLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DoubleMapIteratorOfDoubleMapOfIntegerLabel;
 class TFunction_DoubleMapIteratorOfDoubleMapOfIntegerLabel : public TCollection_BasicMapIterator {
 	public:
@@ -532,6 +567,11 @@ class TFunction_DoubleMapIteratorOfDoubleMapOfIntegerLabel : public TCollection_
 };
 
 
+%extend TFunction_DoubleMapIteratorOfDoubleMapOfIntegerLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DoubleMapNodeOfDoubleMapOfIntegerLabel;
 class TFunction_DoubleMapNodeOfDoubleMapOfIntegerLabel : public TCollection_MapNode {
 	public:
@@ -617,6 +657,11 @@ class Handle_TFunction_DoubleMapNodeOfDoubleMapOfIntegerLabel : public Handle_TC
     }
 };
 
+%extend TFunction_DoubleMapNodeOfDoubleMapOfIntegerLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DoubleMapOfIntegerLabel;
 class TFunction_DoubleMapOfIntegerLabel : public TCollection_BasicMap {
 	public:
@@ -703,6 +748,11 @@ class TFunction_DoubleMapOfIntegerLabel : public TCollection_BasicMap {
 };
 
 
+%extend TFunction_DoubleMapOfIntegerLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_Driver;
 class TFunction_Driver : public MMgt_TShared {
 	public:
@@ -809,6 +859,11 @@ class Handle_TFunction_Driver : public Handle_MMgt_TShared {
     }
 };
 
+%extend TFunction_Driver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_DriverTable;
 class TFunction_DriverTable : public MMgt_TShared {
 	public:
@@ -931,6 +986,11 @@ class Handle_TFunction_DriverTable : public Handle_MMgt_TShared {
     }
 };
 
+%extend TFunction_DriverTable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_Function;
 class TFunction_Function : public TDF_Attribute {
 	public:
@@ -1081,6 +1141,11 @@ class Handle_TFunction_Function : public Handle_TDF_Attribute {
     }
 };
 
+%extend TFunction_Function {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_GraphNode;
 class TFunction_GraphNode : public TDF_Attribute {
 	public:
@@ -1289,6 +1354,11 @@ class Handle_TFunction_GraphNode : public Handle_TDF_Attribute {
     }
 };
 
+%extend TFunction_GraphNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_HArray1OfDataMapOfGUIDDriver;
 class TFunction_HArray1OfDataMapOfGUIDDriver : public MMgt_TShared {
 	public:
@@ -1405,6 +1475,11 @@ class Handle_TFunction_HArray1OfDataMapOfGUIDDriver : public Handle_MMgt_TShared
     }
 };
 
+%extend TFunction_HArray1OfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TFunction_IFunction {
 	public:
 		%feature("compactdefaultargs") NewFunction;
@@ -1540,6 +1615,11 @@ class TFunction_IFunction {
 };
 
 
+%extend TFunction_IFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_Iterator;
 class TFunction_Iterator {
 	public:
@@ -1632,6 +1712,11 @@ class TFunction_Iterator {
         };
 
 
+%extend TFunction_Iterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_Logbook;
 class TFunction_Logbook {
 	public:
@@ -1734,6 +1819,11 @@ class TFunction_Logbook {
         };
 
 
+%extend TFunction_Logbook {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TFunction_Scope;
 class TFunction_Scope : public TDF_Attribute {
 	public:
@@ -1924,3 +2014,8 @@ class Handle_TFunction_Scope : public Handle_TDF_Attribute {
     }
 };
 
+%extend TFunction_Scope {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TNaming.i
+++ b/src/SWIG_files/wrapper/TNaming.i
@@ -272,6 +272,11 @@ class TNaming {
 };
 
 
+%extend TNaming {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Builder;
 class TNaming_Builder {
 	public:
@@ -338,6 +343,11 @@ class TNaming_Builder {
 };
 
 
+%extend TNaming_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TNaming_CopyShape {
 	public:
 		%feature("compactdefaultargs") CopyTool;
@@ -379,6 +389,11 @@ class TNaming_CopyShape {
 };
 
 
+%extend TNaming_CopyShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapIteratorOfDataMapOfShapePtrRefShape;
 class TNaming_DataMapIteratorOfDataMapOfShapePtrRefShape : public TCollection_BasicMapIterator {
 	public:
@@ -409,6 +424,11 @@ class TNaming_DataMapIteratorOfDataMapOfShapePtrRefShape : public TCollection_Ba
 };
 
 
+%extend TNaming_DataMapIteratorOfDataMapOfShapePtrRefShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapIteratorOfDataMapOfShapeShapesSet;
 class TNaming_DataMapIteratorOfDataMapOfShapeShapesSet : public TCollection_BasicMapIterator {
 	public:
@@ -439,6 +459,11 @@ class TNaming_DataMapIteratorOfDataMapOfShapeShapesSet : public TCollection_Basi
 };
 
 
+%extend TNaming_DataMapIteratorOfDataMapOfShapeShapesSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapNodeOfDataMapOfShapePtrRefShape;
 class TNaming_DataMapNodeOfDataMapOfShapePtrRefShape : public TCollection_MapNode {
 	public:
@@ -509,6 +534,11 @@ class Handle_TNaming_DataMapNodeOfDataMapOfShapePtrRefShape : public Handle_TCol
     }
 };
 
+%extend TNaming_DataMapNodeOfDataMapOfShapePtrRefShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapNodeOfDataMapOfShapeShapesSet;
 class TNaming_DataMapNodeOfDataMapOfShapeShapesSet : public TCollection_MapNode {
 	public:
@@ -579,6 +609,11 @@ class Handle_TNaming_DataMapNodeOfDataMapOfShapeShapesSet : public Handle_TColle
     }
 };
 
+%extend TNaming_DataMapNodeOfDataMapOfShapeShapesSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapOfShapePtrRefShape;
 class TNaming_DataMapOfShapePtrRefShape : public TCollection_BasicMap {
 	public:
@@ -657,6 +692,11 @@ class TNaming_DataMapOfShapePtrRefShape : public TCollection_BasicMap {
 };
 
 
+%extend TNaming_DataMapOfShapePtrRefShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DataMapOfShapeShapesSet;
 class TNaming_DataMapOfShapeShapesSet : public TCollection_BasicMap {
 	public:
@@ -735,6 +775,11 @@ class TNaming_DataMapOfShapeShapesSet : public TCollection_BasicMap {
 };
 
 
+%extend TNaming_DataMapOfShapeShapesSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DeltaOnModification;
 class TNaming_DeltaOnModification : public TDF_DeltaOnModification {
 	public:
@@ -801,6 +846,11 @@ class Handle_TNaming_DeltaOnModification : public Handle_TDF_DeltaOnModification
     }
 };
 
+%extend TNaming_DeltaOnModification {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_DeltaOnRemoval;
 class TNaming_DeltaOnRemoval : public TDF_DeltaOnRemoval {
 	public:
@@ -867,6 +917,11 @@ class Handle_TNaming_DeltaOnRemoval : public Handle_TDF_DeltaOnRemoval {
     }
 };
 
+%extend TNaming_DeltaOnRemoval {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Identifier;
 class TNaming_Identifier {
 	public:
@@ -977,6 +1032,11 @@ class TNaming_Identifier {
 };
 
 
+%extend TNaming_Identifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Iterator;
 class TNaming_Iterator {
 	public:
@@ -1043,6 +1103,11 @@ class TNaming_Iterator {
 };
 
 
+%extend TNaming_Iterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_IteratorOnShapesSet;
 class TNaming_IteratorOnShapesSet {
 	public:
@@ -1083,6 +1148,11 @@ class TNaming_IteratorOnShapesSet {
 };
 
 
+%extend TNaming_IteratorOnShapesSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListIteratorOfListOfIndexedDataMapOfShapeListOfShape;
 class TNaming_ListIteratorOfListOfIndexedDataMapOfShapeListOfShape {
 	public:
@@ -1117,6 +1187,11 @@ class TNaming_ListIteratorOfListOfIndexedDataMapOfShapeListOfShape {
 };
 
 
+%extend TNaming_ListIteratorOfListOfIndexedDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListIteratorOfListOfMapOfShape;
 class TNaming_ListIteratorOfListOfMapOfShape {
 	public:
@@ -1151,6 +1226,11 @@ class TNaming_ListIteratorOfListOfMapOfShape {
 };
 
 
+%extend TNaming_ListIteratorOfListOfMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListIteratorOfListOfNamedShape;
 class TNaming_ListIteratorOfListOfNamedShape {
 	public:
@@ -1185,6 +1265,11 @@ class TNaming_ListIteratorOfListOfNamedShape {
 };
 
 
+%extend TNaming_ListIteratorOfListOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListNodeOfListOfIndexedDataMapOfShapeListOfShape;
 class TNaming_ListNodeOfListOfIndexedDataMapOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -1249,6 +1334,11 @@ class Handle_TNaming_ListNodeOfListOfIndexedDataMapOfShapeListOfShape : public H
     }
 };
 
+%extend TNaming_ListNodeOfListOfIndexedDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListNodeOfListOfMapOfShape;
 class TNaming_ListNodeOfListOfMapOfShape : public TCollection_MapNode {
 	public:
@@ -1313,6 +1403,11 @@ class Handle_TNaming_ListNodeOfListOfMapOfShape : public Handle_TCollection_MapN
     }
 };
 
+%extend TNaming_ListNodeOfListOfMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListNodeOfListOfNamedShape;
 class TNaming_ListNodeOfListOfNamedShape : public TCollection_MapNode {
 	public:
@@ -1377,6 +1472,11 @@ class Handle_TNaming_ListNodeOfListOfNamedShape : public Handle_TCollection_MapN
     }
 };
 
+%extend TNaming_ListNodeOfListOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListOfIndexedDataMapOfShapeListOfShape;
 class TNaming_ListOfIndexedDataMapOfShapeListOfShape {
 	public:
@@ -1507,6 +1607,11 @@ class TNaming_ListOfIndexedDataMapOfShapeListOfShape {
 };
 
 
+%extend TNaming_ListOfIndexedDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListOfMapOfShape;
 class TNaming_ListOfMapOfShape {
 	public:
@@ -1637,6 +1742,11 @@ class TNaming_ListOfMapOfShape {
 };
 
 
+%extend TNaming_ListOfMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ListOfNamedShape;
 class TNaming_ListOfNamedShape {
 	public:
@@ -1767,6 +1877,11 @@ class TNaming_ListOfNamedShape {
 };
 
 
+%extend TNaming_ListOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Localizer;
 class TNaming_Localizer {
 	public:
@@ -1877,6 +1992,11 @@ class TNaming_Localizer {
 };
 
 
+%extend TNaming_Localizer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_MapIteratorOfMapOfNamedShape;
 class TNaming_MapIteratorOfMapOfNamedShape : public TCollection_BasicMapIterator {
 	public:
@@ -1903,6 +2023,11 @@ class TNaming_MapIteratorOfMapOfNamedShape : public TCollection_BasicMapIterator
 };
 
 
+%extend TNaming_MapIteratorOfMapOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_MapOfNamedShape;
 class TNaming_MapOfNamedShape : public TCollection_BasicMap {
 	public:
@@ -1961,6 +2086,11 @@ class TNaming_MapOfNamedShape : public TCollection_BasicMap {
 };
 
 
+%extend TNaming_MapOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Name;
 class TNaming_Name {
 	public:
@@ -2067,6 +2197,11 @@ class TNaming_Name {
 };
 
 
+%extend TNaming_Name {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_NamedShape;
 class TNaming_NamedShape : public TDF_Attribute {
 	public:
@@ -2261,6 +2396,11 @@ class Handle_TNaming_NamedShape : public Handle_TDF_Attribute {
     }
 };
 
+%extend TNaming_NamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TNaming_NamedShapeHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -2282,6 +2422,11 @@ class TNaming_NamedShapeHasher {
 };
 
 
+%extend TNaming_NamedShapeHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Naming;
 class TNaming_Naming : public TDF_Attribute {
 	public:
@@ -2444,6 +2589,11 @@ class Handle_TNaming_Naming : public Handle_TDF_Attribute {
     }
 };
 
+%extend TNaming_Naming {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TNaming_NamingTool {
 	public:
 		%feature("compactdefaultargs") CurrentShape;
@@ -2483,6 +2633,11 @@ class TNaming_NamingTool {
 };
 
 
+%extend TNaming_NamingTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_NewShapeIterator;
 class TNaming_NewShapeIterator {
 	public:
@@ -2551,6 +2706,11 @@ class TNaming_NewShapeIterator {
 };
 
 
+%extend TNaming_NewShapeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_OldShapeIterator;
 class TNaming_OldShapeIterator {
 	public:
@@ -2617,6 +2777,11 @@ class TNaming_OldShapeIterator {
 };
 
 
+%extend TNaming_OldShapeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_RefShape;
 class TNaming_RefShape {
 	public:
@@ -2661,6 +2826,11 @@ class TNaming_RefShape {
 };
 
 
+%extend TNaming_RefShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_SameShapeIterator;
 class TNaming_SameShapeIterator {
 	public:
@@ -2687,6 +2857,11 @@ class TNaming_SameShapeIterator {
 };
 
 
+%extend TNaming_SameShapeIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Scope;
 class TNaming_Scope {
 	public:
@@ -2779,6 +2954,11 @@ class TNaming_Scope {
 };
 
 
+%extend TNaming_Scope {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TNaming_Selector {
 	public:
 		%feature("compactdefaultargs") IsIdentified;
@@ -2854,6 +3034,11 @@ class TNaming_Selector {
 };
 
 
+%extend TNaming_Selector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_ShapesSet;
 class TNaming_ShapesSet {
 	public:
@@ -2942,6 +3127,11 @@ class TNaming_ShapesSet {
 };
 
 
+%extend TNaming_ShapesSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_StdMapNodeOfMapOfNamedShape;
 class TNaming_StdMapNodeOfMapOfNamedShape : public TCollection_MapNode {
 	public:
@@ -3006,6 +3196,11 @@ class Handle_TNaming_StdMapNodeOfMapOfNamedShape : public Handle_TCollection_Map
     }
 };
 
+%extend TNaming_StdMapNodeOfMapOfNamedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TNaming_Tool {
 	public:
 		%feature("compactdefaultargs") CurrentShape;
@@ -3151,6 +3346,11 @@ class TNaming_Tool {
 };
 
 
+%extend TNaming_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_TranslateTool;
 class TNaming_TranslateTool : public MMgt_TShared {
 	public:
@@ -3297,6 +3497,11 @@ class Handle_TNaming_TranslateTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend TNaming_TranslateTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_Translator;
 class TNaming_Translator {
 	public:
@@ -3341,6 +3546,11 @@ class TNaming_Translator {
 };
 
 
+%extend TNaming_Translator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TNaming_UsedShapes;
 class TNaming_UsedShapes : public TDF_Attribute {
 	public:
@@ -3487,3 +3697,8 @@ class Handle_TNaming_UsedShapes : public Handle_TDF_Attribute {
     }
 };
 
+%extend TNaming_UsedShapes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TPrsStd.i
+++ b/src/SWIG_files/wrapper/TPrsStd.i
@@ -388,6 +388,11 @@ class Handle_TPrsStd_AISPresentation : public Handle_TDF_Attribute {
     }
 };
 
+%extend TPrsStd_AISPresentation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_AISViewer;
 class TPrsStd_AISViewer : public TDF_Attribute {
 	public:
@@ -554,6 +559,11 @@ class Handle_TPrsStd_AISViewer : public Handle_TDF_Attribute {
     }
 };
 
+%extend TPrsStd_AISViewer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TPrsStd_ConstraintTools {
 	public:
 		%feature("compactdefaultargs") UpdateOnlyValue;
@@ -747,6 +757,11 @@ class TPrsStd_ConstraintTools {
 };
 
 
+%extend TPrsStd_ConstraintTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_DataMapIteratorOfDataMapOfGUIDDriver;
 class TPrsStd_DataMapIteratorOfDataMapOfGUIDDriver : public TCollection_BasicMapIterator {
 	public:
@@ -777,6 +792,11 @@ class TPrsStd_DataMapIteratorOfDataMapOfGUIDDriver : public TCollection_BasicMap
 };
 
 
+%extend TPrsStd_DataMapIteratorOfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_DataMapNodeOfDataMapOfGUIDDriver;
 class TPrsStd_DataMapNodeOfDataMapOfGUIDDriver : public TCollection_MapNode {
 	public:
@@ -847,6 +867,11 @@ class Handle_TPrsStd_DataMapNodeOfDataMapOfGUIDDriver : public Handle_TCollectio
     }
 };
 
+%extend TPrsStd_DataMapNodeOfDataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_DataMapOfGUIDDriver;
 class TPrsStd_DataMapOfGUIDDriver : public TCollection_BasicMap {
 	public:
@@ -925,6 +950,11 @@ class TPrsStd_DataMapOfGUIDDriver : public TCollection_BasicMap {
 };
 
 
+%extend TPrsStd_DataMapOfGUIDDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_Driver;
 class TPrsStd_Driver : public MMgt_TShared {
 	public:
@@ -987,6 +1017,11 @@ class Handle_TPrsStd_Driver : public Handle_MMgt_TShared {
     }
 };
 
+%extend TPrsStd_Driver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_DriverTable;
 class TPrsStd_DriverTable : public MMgt_TShared {
 	public:
@@ -1091,6 +1126,11 @@ class Handle_TPrsStd_DriverTable : public Handle_MMgt_TShared {
     }
 };
 
+%extend TPrsStd_DriverTable {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_AxisDriver;
 class TPrsStd_AxisDriver : public TPrsStd_Driver {
 	public:
@@ -1159,6 +1199,11 @@ class Handle_TPrsStd_AxisDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_AxisDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_ConstraintDriver;
 class TPrsStd_ConstraintDriver : public TPrsStd_Driver {
 	public:
@@ -1227,6 +1272,11 @@ class Handle_TPrsStd_ConstraintDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_ConstraintDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_GeometryDriver;
 class TPrsStd_GeometryDriver : public TPrsStd_Driver {
 	public:
@@ -1295,6 +1345,11 @@ class Handle_TPrsStd_GeometryDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_GeometryDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_NamedShapeDriver;
 class TPrsStd_NamedShapeDriver : public TPrsStd_Driver {
 	public:
@@ -1363,6 +1418,11 @@ class Handle_TPrsStd_NamedShapeDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_NamedShapeDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_PlaneDriver;
 class TPrsStd_PlaneDriver : public TPrsStd_Driver {
 	public:
@@ -1431,6 +1491,11 @@ class Handle_TPrsStd_PlaneDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_PlaneDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TPrsStd_PointDriver;
 class TPrsStd_PointDriver : public TPrsStd_Driver {
 	public:
@@ -1499,3 +1564,8 @@ class Handle_TPrsStd_PointDriver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend TPrsStd_PointDriver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TShort.i
+++ b/src/SWIG_files/wrapper/TShort.i
@@ -138,6 +138,11 @@ class TShort_Array1OfShortReal {
 };
 
 
+%extend TShort_Array1OfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_Array2OfShortReal;
 class TShort_Array2OfShortReal {
 	public:
@@ -242,6 +247,11 @@ class TShort_Array2OfShortReal {
 };
 
 
+%extend TShort_Array2OfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_HArray1OfShortReal;
 class TShort_HArray1OfShortReal : public MMgt_TShared {
 	public:
@@ -358,6 +368,11 @@ class Handle_TShort_HArray1OfShortReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TShort_HArray1OfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_HArray2OfShortReal;
 class TShort_HArray2OfShortReal : public MMgt_TShared {
 	public:
@@ -500,6 +515,11 @@ class Handle_TShort_HArray2OfShortReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TShort_HArray2OfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_HSequenceOfShortReal;
 class TShort_HSequenceOfShortReal : public MMgt_TShared {
 	public:
@@ -684,6 +704,11 @@ class Handle_TShort_HSequenceOfShortReal : public Handle_MMgt_TShared {
     }
 };
 
+%extend TShort_HSequenceOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_SequenceNodeOfSequenceOfShortReal;
 class TShort_SequenceNodeOfSequenceOfShortReal : public TCollection_SeqNode {
 	public:
@@ -750,6 +775,11 @@ class Handle_TShort_SequenceNodeOfSequenceOfShortReal : public Handle_TCollectio
     }
 };
 
+%extend TShort_SequenceNodeOfSequenceOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TShort_SequenceOfShortReal;
 class TShort_SequenceOfShortReal : public TCollection_BaseSequence {
 	public:
@@ -888,3 +918,8 @@ class TShort_SequenceOfShortReal : public TCollection_BaseSequence {
 };
 
 
+%extend TShort_SequenceOfShortReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopAbs.i
+++ b/src/SWIG_files/wrapper/TopAbs.i
@@ -144,3 +144,8 @@ class TopAbs {
 };
 
 
+%extend TopAbs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopBas.i
+++ b/src/SWIG_files/wrapper/TopBas.i
@@ -90,6 +90,11 @@ class TopBas_ListIteratorOfListOfTestInterference {
 };
 
 
+%extend TopBas_ListIteratorOfListOfTestInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopBas_ListNodeOfListOfTestInterference;
 class TopBas_ListNodeOfListOfTestInterference : public TCollection_MapNode {
 	public:
@@ -154,6 +159,11 @@ class Handle_TopBas_ListNodeOfListOfTestInterference : public Handle_TCollection
     }
 };
 
+%extend TopBas_ListNodeOfListOfTestInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopBas_ListOfTestInterference;
 class TopBas_ListOfTestInterference {
 	public:
@@ -284,6 +294,11 @@ class TopBas_ListOfTestInterference {
 };
 
 
+%extend TopBas_ListOfTestInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopBas_TestInterference;
 class TopBas_TestInterference {
 	public:
@@ -384,3 +399,8 @@ class TopBas_TestInterference {
 };
 
 
+%extend TopBas_TestInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopClass.i
+++ b/src/SWIG_files/wrapper/TopClass.i
@@ -100,6 +100,11 @@ class TopClass_Intersection3d {
 };
 
 
+%extend TopClass_Intersection3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopClass_SolidExplorer;
 class TopClass_SolidExplorer {
 	public:
@@ -200,3 +205,8 @@ class TopClass_SolidExplorer {
 };
 
 
+%extend TopClass_SolidExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopCnx.i
+++ b/src/SWIG_files/wrapper/TopCnx.i
@@ -120,3 +120,8 @@ class TopCnx_EdgeFaceTransition {
 };
 
 
+%extend TopCnx_EdgeFaceTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopExp.i
+++ b/src/SWIG_files/wrapper/TopExp.i
@@ -157,6 +157,11 @@ class TopExp {
 };
 
 
+%extend TopExp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopExp_Explorer;
 class TopExp_Explorer {
 	public:
@@ -233,3 +238,8 @@ class TopExp_Explorer {
 };
 
 
+%extend TopExp_Explorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopLoc.i
+++ b/src/SWIG_files/wrapper/TopLoc.i
@@ -137,6 +137,11 @@ class Handle_TopLoc_Datum3D : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopLoc_Datum3D {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_IndexedMapNodeOfIndexedMapOfLocation;
 class TopLoc_IndexedMapNodeOfIndexedMapOfLocation : public TCollection_MapNode {
 	public:
@@ -222,6 +227,11 @@ class Handle_TopLoc_IndexedMapNodeOfIndexedMapOfLocation : public Handle_TCollec
     }
 };
 
+%extend TopLoc_IndexedMapNodeOfIndexedMapOfLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_IndexedMapOfLocation;
 class TopLoc_IndexedMapOfLocation : public TCollection_BasicMap {
 	public:
@@ -298,6 +308,11 @@ class TopLoc_IndexedMapOfLocation : public TCollection_BasicMap {
 };
 
 
+%extend TopLoc_IndexedMapOfLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_ItemLocation;
 class TopLoc_ItemLocation {
 	public:
@@ -338,6 +353,11 @@ class TopLoc_ItemLocation {
 };
 
 
+%extend TopLoc_ItemLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_Location;
 class TopLoc_Location {
 	public:
@@ -522,6 +542,11 @@ class TopLoc_Location {
         };
 
 
+%extend TopLoc_Location {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_MapIteratorOfMapOfLocation;
 class TopLoc_MapIteratorOfMapOfLocation : public TCollection_BasicMapIterator {
 	public:
@@ -548,6 +573,11 @@ class TopLoc_MapIteratorOfMapOfLocation : public TCollection_BasicMapIterator {
 };
 
 
+%extend TopLoc_MapIteratorOfMapOfLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopLoc_MapLocationHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -569,6 +599,11 @@ class TopLoc_MapLocationHasher {
 };
 
 
+%extend TopLoc_MapLocationHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_MapOfLocation;
 class TopLoc_MapOfLocation : public TCollection_BasicMap {
 	public:
@@ -627,6 +662,11 @@ class TopLoc_MapOfLocation : public TCollection_BasicMap {
 };
 
 
+%extend TopLoc_MapOfLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_SListNodeOfItemLocation;
 class TopLoc_SListNodeOfItemLocation : public MMgt_TShared {
 	public:
@@ -695,6 +735,11 @@ class Handle_TopLoc_SListNodeOfItemLocation : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopLoc_SListNodeOfItemLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_SListOfItemLocation;
 class TopLoc_SListOfItemLocation {
 	public:
@@ -831,6 +876,11 @@ class TopLoc_SListOfItemLocation {
 };
 
 
+%extend TopLoc_SListOfItemLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopLoc_StdMapNodeOfMapOfLocation;
 class TopLoc_StdMapNodeOfMapOfLocation : public TCollection_MapNode {
 	public:
@@ -895,3 +945,8 @@ class Handle_TopLoc_StdMapNodeOfMapOfLocation : public Handle_TCollection_MapNod
     }
 };
 
+%extend TopLoc_StdMapNodeOfMapOfLocation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopOpeBRep.i
+++ b/src/SWIG_files/wrapper/TopOpeBRep.i
@@ -99,6 +99,11 @@ class TopOpeBRep {
 };
 
 
+%extend TopOpeBRep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Array1OfLineInter;
 class TopOpeBRep_Array1OfLineInter {
 	public:
@@ -181,6 +186,11 @@ class TopOpeBRep_Array1OfLineInter {
 };
 
 
+%extend TopOpeBRep_Array1OfLineInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Array1OfVPointInter;
 class TopOpeBRep_Array1OfVPointInter {
 	public:
@@ -263,6 +273,11 @@ class TopOpeBRep_Array1OfVPointInter {
 };
 
 
+%extend TopOpeBRep_Array1OfVPointInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Bipoint;
 class TopOpeBRep_Bipoint {
 	public:
@@ -289,6 +304,11 @@ class TopOpeBRep_Bipoint {
 };
 
 
+%extend TopOpeBRep_Bipoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_DSFiller;
 class TopOpeBRep_DSFiller {
 	public:
@@ -463,6 +483,11 @@ class TopOpeBRep_DSFiller {
 };
 
 
+%extend TopOpeBRep_DSFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_DataMapIteratorOfDataMapOfTopolTool;
 class TopOpeBRep_DataMapIteratorOfDataMapOfTopolTool : public TCollection_BasicMapIterator {
 	public:
@@ -493,6 +518,11 @@ class TopOpeBRep_DataMapIteratorOfDataMapOfTopolTool : public TCollection_BasicM
 };
 
 
+%extend TopOpeBRep_DataMapIteratorOfDataMapOfTopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_DataMapNodeOfDataMapOfTopolTool;
 class TopOpeBRep_DataMapNodeOfDataMapOfTopolTool : public TCollection_MapNode {
 	public:
@@ -563,6 +593,11 @@ class Handle_TopOpeBRep_DataMapNodeOfDataMapOfTopolTool : public Handle_TCollect
     }
 };
 
+%extend TopOpeBRep_DataMapNodeOfDataMapOfTopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_DataMapOfTopolTool;
 class TopOpeBRep_DataMapOfTopolTool : public TCollection_BasicMap {
 	public:
@@ -641,6 +676,11 @@ class TopOpeBRep_DataMapOfTopolTool : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRep_DataMapOfTopolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_EdgesFiller;
 class TopOpeBRep_EdgesFiller {
 	public:
@@ -677,6 +717,11 @@ class TopOpeBRep_EdgesFiller {
 };
 
 
+%extend TopOpeBRep_EdgesFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_EdgesIntersector;
 class TopOpeBRep_EdgesIntersector {
 	public:
@@ -861,6 +906,11 @@ class TopOpeBRep_EdgesIntersector {
 };
 
 
+%extend TopOpeBRep_EdgesIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_FFDumper;
 class TopOpeBRep_FFDumper : public MMgt_TShared {
 	public:
@@ -975,6 +1025,11 @@ class Handle_TopOpeBRep_FFDumper : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRep_FFDumper {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRep_FFTransitionTool {
 	public:
 		%feature("compactdefaultargs") ProcessLineTransition;
@@ -1034,6 +1089,11 @@ class TopOpeBRep_FFTransitionTool {
 };
 
 
+%extend TopOpeBRep_FFTransitionTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_FaceEdgeFiller;
 class TopOpeBRep_FaceEdgeFiller {
 	public:
@@ -1056,6 +1116,11 @@ class TopOpeBRep_FaceEdgeFiller {
 };
 
 
+%extend TopOpeBRep_FaceEdgeFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_FaceEdgeIntersector;
 class TopOpeBRep_FaceEdgeIntersector {
 	public:
@@ -1178,6 +1243,11 @@ class TopOpeBRep_FaceEdgeIntersector {
 };
 
 
+%extend TopOpeBRep_FaceEdgeIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_FacesFiller;
 class TopOpeBRep_FacesFiller {
 	public:
@@ -1602,6 +1672,11 @@ class TopOpeBRep_FacesFiller {
 };
 
 
+%extend TopOpeBRep_FacesFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_FacesIntersector;
 class TopOpeBRep_FacesIntersector {
 	public:
@@ -1736,6 +1811,11 @@ class TopOpeBRep_FacesIntersector {
 };
 
 
+%extend TopOpeBRep_FacesIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRep_GeomTool {
 	public:
 		%feature("compactdefaultargs") MakeCurves;
@@ -1789,6 +1869,11 @@ class TopOpeBRep_GeomTool {
 };
 
 
+%extend TopOpeBRep_GeomTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_HArray1OfLineInter;
 class TopOpeBRep_HArray1OfLineInter : public MMgt_TShared {
 	public:
@@ -1905,6 +1990,11 @@ class Handle_TopOpeBRep_HArray1OfLineInter : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRep_HArray1OfLineInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_HArray1OfVPointInter;
 class TopOpeBRep_HArray1OfVPointInter : public MMgt_TShared {
 	public:
@@ -2021,6 +2111,11 @@ class Handle_TopOpeBRep_HArray1OfVPointInter : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRep_HArray1OfVPointInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Hctxee2d;
 class TopOpeBRep_Hctxee2d : public MMgt_TShared {
 	public:
@@ -2107,6 +2202,11 @@ class Handle_TopOpeBRep_Hctxee2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRep_Hctxee2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Hctxff2d;
 class TopOpeBRep_Hctxff2d : public MMgt_TShared {
 	public:
@@ -2225,6 +2325,11 @@ class Handle_TopOpeBRep_Hctxff2d : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRep_Hctxff2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_LineInter;
 class TopOpeBRep_LineInter {
 	public:
@@ -2481,6 +2586,11 @@ class TopOpeBRep_LineInter {
         };
 
 
+%extend TopOpeBRep_LineInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ListIteratorOfListOfBipoint;
 class TopOpeBRep_ListIteratorOfListOfBipoint {
 	public:
@@ -2515,6 +2625,11 @@ class TopOpeBRep_ListIteratorOfListOfBipoint {
 };
 
 
+%extend TopOpeBRep_ListIteratorOfListOfBipoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ListNodeOfListOfBipoint;
 class TopOpeBRep_ListNodeOfListOfBipoint : public TCollection_MapNode {
 	public:
@@ -2579,6 +2694,11 @@ class Handle_TopOpeBRep_ListNodeOfListOfBipoint : public Handle_TCollection_MapN
     }
 };
 
+%extend TopOpeBRep_ListNodeOfListOfBipoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ListOfBipoint;
 class TopOpeBRep_ListOfBipoint {
 	public:
@@ -2709,6 +2829,11 @@ class TopOpeBRep_ListOfBipoint {
 };
 
 
+%extend TopOpeBRep_ListOfBipoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_Point2d;
 class TopOpeBRep_Point2d {
 	public:
@@ -2919,6 +3044,11 @@ class TopOpeBRep_Point2d {
 };
 
 
+%extend TopOpeBRep_Point2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_PointClassifier;
 class TopOpeBRep_PointClassifier {
 	public:
@@ -2955,6 +3085,11 @@ class TopOpeBRep_PointClassifier {
 };
 
 
+%extend TopOpeBRep_PointClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRep_PointGeomTool {
 	public:
 		%feature("compactdefaultargs") MakePoint;
@@ -2992,6 +3127,11 @@ class TopOpeBRep_PointGeomTool {
 };
 
 
+%extend TopOpeBRep_PointGeomTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_SequenceNodeOfSequenceOfPoint2d;
 class TopOpeBRep_SequenceNodeOfSequenceOfPoint2d : public TCollection_SeqNode {
 	public:
@@ -3058,6 +3198,11 @@ class Handle_TopOpeBRep_SequenceNodeOfSequenceOfPoint2d : public Handle_TCollect
     }
 };
 
+%extend TopOpeBRep_SequenceNodeOfSequenceOfPoint2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_SequenceOfPoint2d;
 class TopOpeBRep_SequenceOfPoint2d : public TCollection_BaseSequence {
 	public:
@@ -3196,6 +3341,11 @@ class TopOpeBRep_SequenceOfPoint2d : public TCollection_BaseSequence {
 };
 
 
+%extend TopOpeBRep_SequenceOfPoint2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ShapeIntersector;
 class TopOpeBRep_ShapeIntersector {
 	public:
@@ -3308,6 +3458,11 @@ class TopOpeBRep_ShapeIntersector {
 };
 
 
+%extend TopOpeBRep_ShapeIntersector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ShapeIntersector2d;
 class TopOpeBRep_ShapeIntersector2d {
 	public:
@@ -3374,6 +3529,11 @@ class TopOpeBRep_ShapeIntersector2d {
 };
 
 
+%extend TopOpeBRep_ShapeIntersector2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_ShapeScanner;
 class TopOpeBRep_ShapeScanner {
 	public:
@@ -3442,6 +3602,11 @@ class TopOpeBRep_ShapeScanner {
         };
 
 
+%extend TopOpeBRep_ShapeScanner {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_VPointInter;
 class TopOpeBRep_VPointInter {
 	public:
@@ -3744,6 +3909,11 @@ class TopOpeBRep_VPointInter {
 };
 
 
+%extend TopOpeBRep_VPointInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_VPointInterClassifier;
 class TopOpeBRep_VPointInterClassifier {
 	public:
@@ -3784,6 +3954,11 @@ class TopOpeBRep_VPointInterClassifier {
 };
 
 
+%extend TopOpeBRep_VPointInterClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_VPointInterIterator;
 class TopOpeBRep_VPointInterIterator {
 	public:
@@ -3836,6 +4011,11 @@ class TopOpeBRep_VPointInterIterator {
 };
 
 
+%extend TopOpeBRep_VPointInterIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_WPointInter;
 class TopOpeBRep_WPointInter {
 	public:
@@ -3896,6 +4076,11 @@ class TopOpeBRep_WPointInter {
 };
 
 
+%extend TopOpeBRep_WPointInter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRep_WPointInterIterator;
 class TopOpeBRep_WPointInterIterator {
 	public:
@@ -3938,3 +4123,8 @@ class TopOpeBRep_WPointInterIterator {
 };
 
 
+%extend TopOpeBRep_WPointInterIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopOpeBRepBuild.i
+++ b/src/SWIG_files/wrapper/TopOpeBRepBuild.i
@@ -171,6 +171,11 @@ class TopOpeBRepBuild_AreaBuilder {
 };
 
 
+%extend TopOpeBRepBuild_AreaBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_BlockBuilder;
 class TopOpeBRepBuild_BlockBuilder {
 	public:
@@ -267,6 +272,11 @@ class TopOpeBRepBuild_BlockBuilder {
 };
 
 
+%extend TopOpeBRepBuild_BlockBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_BlockIterator;
 class TopOpeBRepBuild_BlockIterator {
 	public:
@@ -305,6 +315,11 @@ class TopOpeBRepBuild_BlockIterator {
 };
 
 
+%extend TopOpeBRepBuild_BlockIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_BuilderON;
 class TopOpeBRepBuild_BuilderON {
 	public:
@@ -385,6 +400,11 @@ class TopOpeBRepBuild_BuilderON {
 };
 
 
+%extend TopOpeBRepBuild_BuilderON {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_CorrectFace2d;
 class TopOpeBRepBuild_CorrectFace2d {
 	public:
@@ -455,6 +475,11 @@ class TopOpeBRepBuild_CorrectFace2d {
 };
 
 
+%extend TopOpeBRepBuild_CorrectFace2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_DataMapIteratorOfDataMapOfShapeListOfShapeListOfShape;
 class TopOpeBRepBuild_DataMapIteratorOfDataMapOfShapeListOfShapeListOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -485,6 +510,11 @@ class TopOpeBRepBuild_DataMapIteratorOfDataMapOfShapeListOfShapeListOfShape : pu
 };
 
 
+%extend TopOpeBRepBuild_DataMapIteratorOfDataMapOfShapeListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_DataMapNodeOfDataMapOfShapeListOfShapeListOfShape;
 class TopOpeBRepBuild_DataMapNodeOfDataMapOfShapeListOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -555,6 +585,11 @@ class Handle_TopOpeBRepBuild_DataMapNodeOfDataMapOfShapeListOfShapeListOfShape :
     }
 };
 
+%extend TopOpeBRepBuild_DataMapNodeOfDataMapOfShapeListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_DataMapOfShapeListOfShapeListOfShape;
 class TopOpeBRepBuild_DataMapOfShapeListOfShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -633,6 +668,11 @@ class TopOpeBRepBuild_DataMapOfShapeListOfShapeListOfShape : public TCollection_
 };
 
 
+%extend TopOpeBRepBuild_DataMapOfShapeListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_FaceBuilder;
 class TopOpeBRepBuild_FaceBuilder {
 	public:
@@ -771,6 +811,11 @@ class TopOpeBRepBuild_FaceBuilder {
 };
 
 
+%extend TopOpeBRepBuild_FaceBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_FuseFace;
 class TopOpeBRepBuild_FuseFace {
 	public:
@@ -853,6 +898,11 @@ class TopOpeBRepBuild_FuseFace {
 };
 
 
+%extend TopOpeBRepBuild_FuseFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_GIter;
 class TopOpeBRepBuild_GIter {
 	public:
@@ -903,6 +953,11 @@ class TopOpeBRepBuild_GIter {
         };
 
 
+%extend TopOpeBRepBuild_GIter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepBuild_GTool {
 	public:
 		%feature("compactdefaultargs") GFusUnsh;
@@ -988,6 +1043,11 @@ class TopOpeBRepBuild_GTool {
         };
 
 
+%extend TopOpeBRepBuild_GTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_GTopo;
 class TopOpeBRepBuild_GTopo {
 	public:
@@ -1218,6 +1278,11 @@ class TopOpeBRepBuild_GTopo {
 };
 
 
+%extend TopOpeBRepBuild_GTopo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_HBuilder;
 class TopOpeBRepBuild_HBuilder : public MMgt_TShared {
 	public:
@@ -1538,6 +1603,11 @@ class Handle_TopOpeBRepBuild_HBuilder : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepBuild_HBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_IndexedDataMapNodeOfIndexedDataMapOfShapeVertexInfo;
 class TopOpeBRepBuild_IndexedDataMapNodeOfIndexedDataMapOfShapeVertexInfo : public TCollection_MapNode {
 	public:
@@ -1629,6 +1699,11 @@ class Handle_TopOpeBRepBuild_IndexedDataMapNodeOfIndexedDataMapOfShapeVertexInfo
     }
 };
 
+%extend TopOpeBRepBuild_IndexedDataMapNodeOfIndexedDataMapOfShapeVertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_IndexedDataMapOfShapeVertexInfo;
 class TopOpeBRepBuild_IndexedDataMapOfShapeVertexInfo : public TCollection_BasicMap {
 	public:
@@ -1739,6 +1814,11 @@ class TopOpeBRepBuild_IndexedDataMapOfShapeVertexInfo : public TCollection_Basic
 };
 
 
+%extend TopOpeBRepBuild_IndexedDataMapOfShapeVertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListIteratorOfListOfListOfLoop;
 class TopOpeBRepBuild_ListIteratorOfListOfListOfLoop {
 	public:
@@ -1773,6 +1853,11 @@ class TopOpeBRepBuild_ListIteratorOfListOfListOfLoop {
 };
 
 
+%extend TopOpeBRepBuild_ListIteratorOfListOfListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListIteratorOfListOfLoop;
 class TopOpeBRepBuild_ListIteratorOfListOfLoop {
 	public:
@@ -1807,6 +1892,11 @@ class TopOpeBRepBuild_ListIteratorOfListOfLoop {
 };
 
 
+%extend TopOpeBRepBuild_ListIteratorOfListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListIteratorOfListOfPave;
 class TopOpeBRepBuild_ListIteratorOfListOfPave {
 	public:
@@ -1841,6 +1931,11 @@ class TopOpeBRepBuild_ListIteratorOfListOfPave {
 };
 
 
+%extend TopOpeBRepBuild_ListIteratorOfListOfPave {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListIteratorOfListOfShapeListOfShape;
 class TopOpeBRepBuild_ListIteratorOfListOfShapeListOfShape {
 	public:
@@ -1875,6 +1970,11 @@ class TopOpeBRepBuild_ListIteratorOfListOfShapeListOfShape {
 };
 
 
+%extend TopOpeBRepBuild_ListIteratorOfListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListNodeOfListOfListOfLoop;
 class TopOpeBRepBuild_ListNodeOfListOfListOfLoop : public TCollection_MapNode {
 	public:
@@ -1939,6 +2039,11 @@ class Handle_TopOpeBRepBuild_ListNodeOfListOfListOfLoop : public Handle_TCollect
     }
 };
 
+%extend TopOpeBRepBuild_ListNodeOfListOfListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListNodeOfListOfLoop;
 class TopOpeBRepBuild_ListNodeOfListOfLoop : public TCollection_MapNode {
 	public:
@@ -2003,6 +2108,11 @@ class Handle_TopOpeBRepBuild_ListNodeOfListOfLoop : public Handle_TCollection_Ma
     }
 };
 
+%extend TopOpeBRepBuild_ListNodeOfListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListNodeOfListOfPave;
 class TopOpeBRepBuild_ListNodeOfListOfPave : public TCollection_MapNode {
 	public:
@@ -2067,6 +2177,11 @@ class Handle_TopOpeBRepBuild_ListNodeOfListOfPave : public Handle_TCollection_Ma
     }
 };
 
+%extend TopOpeBRepBuild_ListNodeOfListOfPave {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListNodeOfListOfShapeListOfShape;
 class TopOpeBRepBuild_ListNodeOfListOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -2131,6 +2246,11 @@ class Handle_TopOpeBRepBuild_ListNodeOfListOfShapeListOfShape : public Handle_TC
     }
 };
 
+%extend TopOpeBRepBuild_ListNodeOfListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListOfListOfLoop;
 class TopOpeBRepBuild_ListOfListOfLoop {
 	public:
@@ -2261,6 +2381,11 @@ class TopOpeBRepBuild_ListOfListOfLoop {
 };
 
 
+%extend TopOpeBRepBuild_ListOfListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListOfLoop;
 class TopOpeBRepBuild_ListOfLoop {
 	public:
@@ -2391,6 +2516,11 @@ class TopOpeBRepBuild_ListOfLoop {
 };
 
 
+%extend TopOpeBRepBuild_ListOfLoop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListOfPave;
 class TopOpeBRepBuild_ListOfPave {
 	public:
@@ -2521,6 +2651,11 @@ class TopOpeBRepBuild_ListOfPave {
 };
 
 
+%extend TopOpeBRepBuild_ListOfPave {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ListOfShapeListOfShape;
 class TopOpeBRepBuild_ListOfShapeListOfShape {
 	public:
@@ -2651,6 +2786,11 @@ class TopOpeBRepBuild_ListOfShapeListOfShape {
 };
 
 
+%extend TopOpeBRepBuild_ListOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Loop;
 class TopOpeBRepBuild_Loop : public MMgt_TShared {
 	public:
@@ -2731,6 +2871,11 @@ class Handle_TopOpeBRepBuild_Loop : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepBuild_Loop {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_LoopClassifier;
 class TopOpeBRepBuild_LoopClassifier {
 	public:
@@ -2751,6 +2896,11 @@ class TopOpeBRepBuild_LoopClassifier {
 };
 
 
+%extend TopOpeBRepBuild_LoopClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_LoopSet;
 class TopOpeBRepBuild_LoopSet {
 	public:
@@ -2785,6 +2935,11 @@ class TopOpeBRepBuild_LoopSet {
 };
 
 
+%extend TopOpeBRepBuild_LoopSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ShapeListOfShape;
 class TopOpeBRepBuild_ShapeListOfShape {
 	public:
@@ -2825,6 +2980,11 @@ class TopOpeBRepBuild_ShapeListOfShape {
 };
 
 
+%extend TopOpeBRepBuild_ShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ShapeSet;
 class TopOpeBRepBuild_ShapeSet {
 	public:
@@ -3055,6 +3215,11 @@ class TopOpeBRepBuild_ShapeSet {
 };
 
 
+%extend TopOpeBRepBuild_ShapeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ShellToSolid;
 class TopOpeBRepBuild_ShellToSolid {
 	public:
@@ -3083,6 +3248,11 @@ class TopOpeBRepBuild_ShellToSolid {
 };
 
 
+%extend TopOpeBRepBuild_ShellToSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_SolidBuilder;
 class TopOpeBRepBuild_SolidBuilder {
 	public:
@@ -3163,6 +3333,11 @@ class TopOpeBRepBuild_SolidBuilder {
 };
 
 
+%extend TopOpeBRepBuild_SolidBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepBuild_Tools {
 	public:
 		%feature("compactdefaultargs") DumpMapOfShapeWithState;
@@ -3422,6 +3597,11 @@ class TopOpeBRepBuild_Tools {
 };
 
 
+%extend TopOpeBRepBuild_Tools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepBuild_Tools2d {
 	public:
 		%feature("compactdefaultargs") MakeMapOfShapeVertexInfo;
@@ -3449,6 +3629,11 @@ class TopOpeBRepBuild_Tools2d {
 };
 
 
+%extend TopOpeBRepBuild_Tools2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_VertexInfo;
 class TopOpeBRepBuild_VertexInfo {
 	public:
@@ -3545,6 +3730,11 @@ class TopOpeBRepBuild_VertexInfo {
 };
 
 
+%extend TopOpeBRepBuild_VertexInfo {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_WireToFace;
 class TopOpeBRepBuild_WireToFace {
 	public:
@@ -3573,6 +3763,11 @@ class TopOpeBRepBuild_WireToFace {
 };
 
 
+%extend TopOpeBRepBuild_WireToFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Area1dBuilder;
 class TopOpeBRepBuild_Area1dBuilder : public TopOpeBRepBuild_AreaBuilder {
 	public:
@@ -3647,6 +3842,11 @@ class TopOpeBRepBuild_Area1dBuilder : public TopOpeBRepBuild_AreaBuilder {
 };
 
 
+%extend TopOpeBRepBuild_Area1dBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Area2dBuilder;
 class TopOpeBRepBuild_Area2dBuilder : public TopOpeBRepBuild_AreaBuilder {
 	public:
@@ -3681,6 +3881,11 @@ class TopOpeBRepBuild_Area2dBuilder : public TopOpeBRepBuild_AreaBuilder {
 };
 
 
+%extend TopOpeBRepBuild_Area2dBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Area3dBuilder;
 class TopOpeBRepBuild_Area3dBuilder : public TopOpeBRepBuild_AreaBuilder {
 	public:
@@ -3715,6 +3920,11 @@ class TopOpeBRepBuild_Area3dBuilder : public TopOpeBRepBuild_AreaBuilder {
 };
 
 
+%extend TopOpeBRepBuild_Area3dBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Builder1;
 class TopOpeBRepBuild_Builder1 : public TopOpeBRepBuild_Builder {
 	public:
@@ -3957,6 +4167,11 @@ class TopOpeBRepBuild_Builder1 : public TopOpeBRepBuild_Builder {
 };
 
 
+%extend TopOpeBRepBuild_Builder1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_CompositeClassifier;
 class TopOpeBRepBuild_CompositeClassifier : public TopOpeBRepBuild_LoopClassifier {
 	public:
@@ -4021,6 +4236,11 @@ class TopOpeBRepBuild_CompositeClassifier : public TopOpeBRepBuild_LoopClassifie
 };
 
 
+%extend TopOpeBRepBuild_CompositeClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_Pave;
 class TopOpeBRepBuild_Pave : public TopOpeBRepBuild_Loop {
 	public:
@@ -4139,6 +4359,11 @@ class Handle_TopOpeBRepBuild_Pave : public Handle_TopOpeBRepBuild_Loop {
     }
 };
 
+%extend TopOpeBRepBuild_Pave {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_PaveClassifier;
 class TopOpeBRepBuild_PaveClassifier : public TopOpeBRepBuild_LoopClassifier {
 	public:
@@ -4191,6 +4416,11 @@ class TopOpeBRepBuild_PaveClassifier : public TopOpeBRepBuild_LoopClassifier {
 };
 
 
+%extend TopOpeBRepBuild_PaveClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_PaveSet;
 class TopOpeBRepBuild_PaveSet : public TopOpeBRepBuild_LoopSet {
 	public:
@@ -4259,6 +4489,11 @@ class TopOpeBRepBuild_PaveSet : public TopOpeBRepBuild_LoopSet {
 };
 
 
+%extend TopOpeBRepBuild_PaveSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ShellFaceSet;
 class TopOpeBRepBuild_ShellFaceSet : public TopOpeBRepBuild_ShapeSet {
 	public:
@@ -4347,6 +4582,11 @@ class TopOpeBRepBuild_ShellFaceSet : public TopOpeBRepBuild_ShapeSet {
 };
 
 
+%extend TopOpeBRepBuild_ShellFaceSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_WireEdgeSet;
 class TopOpeBRepBuild_WireEdgeSet : public TopOpeBRepBuild_ShapeSet {
 	public:
@@ -4463,6 +4703,11 @@ class TopOpeBRepBuild_WireEdgeSet : public TopOpeBRepBuild_ShapeSet {
 };
 
 
+%extend TopOpeBRepBuild_WireEdgeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_EdgeBuilder;
 class TopOpeBRepBuild_EdgeBuilder : public TopOpeBRepBuild_Area1dBuilder {
 	public:
@@ -4527,6 +4772,11 @@ class TopOpeBRepBuild_EdgeBuilder : public TopOpeBRepBuild_Area1dBuilder {
 };
 
 
+%extend TopOpeBRepBuild_EdgeBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_FaceAreaBuilder;
 class TopOpeBRepBuild_FaceAreaBuilder : public TopOpeBRepBuild_Area2dBuilder {
 	public:
@@ -4559,6 +4809,11 @@ class TopOpeBRepBuild_FaceAreaBuilder : public TopOpeBRepBuild_Area2dBuilder {
 };
 
 
+%extend TopOpeBRepBuild_FaceAreaBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_ShellFaceClassifier;
 class TopOpeBRepBuild_ShellFaceClassifier : public TopOpeBRepBuild_CompositeClassifier {
 	public:
@@ -4627,6 +4882,11 @@ class TopOpeBRepBuild_ShellFaceClassifier : public TopOpeBRepBuild_CompositeClas
 };
 
 
+%extend TopOpeBRepBuild_ShellFaceClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_SolidAreaBuilder;
 class TopOpeBRepBuild_SolidAreaBuilder : public TopOpeBRepBuild_Area3dBuilder {
 	public:
@@ -4659,6 +4919,11 @@ class TopOpeBRepBuild_SolidAreaBuilder : public TopOpeBRepBuild_Area3dBuilder {
 };
 
 
+%extend TopOpeBRepBuild_SolidAreaBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepBuild_WireEdgeClassifier;
 class TopOpeBRepBuild_WireEdgeClassifier : public TopOpeBRepBuild_CompositeClassifier {
 	public:
@@ -4739,3 +5004,8 @@ class TopOpeBRepBuild_WireEdgeClassifier : public TopOpeBRepBuild_CompositeClass
 };
 
 
+%extend TopOpeBRepBuild_WireEdgeClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopOpeBRepDS.i
+++ b/src/SWIG_files/wrapper/TopOpeBRepDS.i
@@ -219,6 +219,11 @@ class TopOpeBRepDS {
 };
 
 
+%extend TopOpeBRepDS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Array1OfDataMapOfIntegerListOfInterference;
 class TopOpeBRepDS_Array1OfDataMapOfIntegerListOfInterference {
 	public:
@@ -301,6 +306,11 @@ class TopOpeBRepDS_Array1OfDataMapOfIntegerListOfInterference {
 };
 
 
+%extend TopOpeBRepDS_Array1OfDataMapOfIntegerListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Association;
 class TopOpeBRepDS_Association : public MMgt_TShared {
 	public:
@@ -393,6 +403,11 @@ class Handle_TopOpeBRepDS_Association : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepDS_Association {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_BuildTool;
 class TopOpeBRepDS_BuildTool {
 	public:
@@ -799,6 +814,11 @@ class TopOpeBRepDS_BuildTool {
 };
 
 
+%extend TopOpeBRepDS_BuildTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Check;
 class TopOpeBRepDS_Check : public MMgt_TShared {
 	public:
@@ -951,6 +971,11 @@ class Handle_TopOpeBRepDS_Check : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepDS_Check {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Curve;
 class TopOpeBRepDS_Curve {
 	public:
@@ -1153,6 +1178,11 @@ class TopOpeBRepDS_Curve {
 };
 
 
+%extend TopOpeBRepDS_Curve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_CurveExplorer;
 class TopOpeBRepDS_CurveExplorer {
 	public:
@@ -1217,6 +1247,11 @@ class TopOpeBRepDS_CurveExplorer {
 };
 
 
+%extend TopOpeBRepDS_CurveExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfCheckStatus;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfCheckStatus : public TCollection_BasicMapIterator {
 	public:
@@ -1247,6 +1282,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfCheckStatus : public TCollection_Ba
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfCheckStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfIntegerListOfInterference;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfIntegerListOfInterference : public TCollection_BasicMapIterator {
 	public:
@@ -1277,6 +1317,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfIntegerListOfInterference : public 
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfIntegerListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceListOfInterference;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceListOfInterference : public TCollection_BasicMapIterator {
 	public:
@@ -1307,6 +1352,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceListOfInterference : pu
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceShape;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceShape : public TCollection_BasicMapIterator {
 	public:
@@ -1337,6 +1387,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceShape : public TCollect
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfInterferenceShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeListOfShapeOn1State;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeListOfShapeOn1State : public TCollection_BasicMapIterator {
 	public:
@@ -1367,6 +1422,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeListOfShapeOn1State : public T
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeListOfShapeOn1State {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeState;
 class TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeState : public TCollection_BasicMapIterator {
 	public:
@@ -1397,6 +1457,11 @@ class TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeState : public TCollection_Bas
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfDataMapOfShapeState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfMapOfCurve;
 class TopOpeBRepDS_DataMapIteratorOfMapOfCurve : public TCollection_BasicMapIterator {
 	public:
@@ -1427,6 +1492,11 @@ class TopOpeBRepDS_DataMapIteratorOfMapOfCurve : public TCollection_BasicMapIter
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfMapOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfMapOfIntegerShapeData;
 class TopOpeBRepDS_DataMapIteratorOfMapOfIntegerShapeData : public TCollection_BasicMapIterator {
 	public:
@@ -1457,6 +1527,11 @@ class TopOpeBRepDS_DataMapIteratorOfMapOfIntegerShapeData : public TCollection_B
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfMapOfIntegerShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfMapOfPoint;
 class TopOpeBRepDS_DataMapIteratorOfMapOfPoint : public TCollection_BasicMapIterator {
 	public:
@@ -1487,6 +1562,11 @@ class TopOpeBRepDS_DataMapIteratorOfMapOfPoint : public TCollection_BasicMapIter
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfMapOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfMapOfSurface;
 class TopOpeBRepDS_DataMapIteratorOfMapOfSurface : public TCollection_BasicMapIterator {
 	public:
@@ -1517,6 +1597,11 @@ class TopOpeBRepDS_DataMapIteratorOfMapOfSurface : public TCollection_BasicMapIt
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfMapOfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapIteratorOfShapeSurface;
 class TopOpeBRepDS_DataMapIteratorOfShapeSurface : public TCollection_BasicMapIterator {
 	public:
@@ -1547,6 +1632,11 @@ class TopOpeBRepDS_DataMapIteratorOfShapeSurface : public TCollection_BasicMapIt
 };
 
 
+%extend TopOpeBRepDS_DataMapIteratorOfShapeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfCheckStatus;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfCheckStatus : public TCollection_MapNode {
 	public:
@@ -1626,6 +1716,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfCheckStatus : public Handle_TCol
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfCheckStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfIntegerListOfInterference;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfIntegerListOfInterference : public TCollection_MapNode {
 	public:
@@ -1705,6 +1800,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfIntegerListOfInterference : publ
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfIntegerListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceListOfInterference;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceListOfInterference : public TCollection_MapNode {
 	public:
@@ -1775,6 +1875,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceListOfInterference :
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceShape;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceShape : public TCollection_MapNode {
 	public:
@@ -1845,6 +1950,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceShape : public Handl
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfInterferenceShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfShapeListOfShapeOn1State;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfShapeListOfShapeOn1State : public TCollection_MapNode {
 	public:
@@ -1915,6 +2025,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfShapeListOfShapeOn1State : publi
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfShapeListOfShapeOn1State {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfDataMapOfShapeState;
 class TopOpeBRepDS_DataMapNodeOfDataMapOfShapeState : public TCollection_MapNode {
 	public:
@@ -1985,6 +2100,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfDataMapOfShapeState : public Handle_TColl
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfDataMapOfShapeState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfMapOfCurve;
 class TopOpeBRepDS_DataMapNodeOfMapOfCurve : public TCollection_MapNode {
 	public:
@@ -2064,6 +2184,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfMapOfCurve : public Handle_TCollection_Ma
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfMapOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfMapOfIntegerShapeData;
 class TopOpeBRepDS_DataMapNodeOfMapOfIntegerShapeData : public TCollection_MapNode {
 	public:
@@ -2143,6 +2268,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfMapOfIntegerShapeData : public Handle_TCo
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfMapOfIntegerShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfMapOfPoint;
 class TopOpeBRepDS_DataMapNodeOfMapOfPoint : public TCollection_MapNode {
 	public:
@@ -2222,6 +2352,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfMapOfPoint : public Handle_TCollection_Ma
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfMapOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfMapOfSurface;
 class TopOpeBRepDS_DataMapNodeOfMapOfSurface : public TCollection_MapNode {
 	public:
@@ -2301,6 +2436,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfMapOfSurface : public Handle_TCollection_
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfMapOfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapNodeOfShapeSurface;
 class TopOpeBRepDS_DataMapNodeOfShapeSurface : public TCollection_MapNode {
 	public:
@@ -2371,6 +2511,11 @@ class Handle_TopOpeBRepDS_DataMapNodeOfShapeSurface : public Handle_TCollection_
     }
 };
 
+%extend TopOpeBRepDS_DataMapNodeOfShapeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfCheckStatus;
 class TopOpeBRepDS_DataMapOfCheckStatus : public TCollection_BasicMap {
 	public:
@@ -2449,6 +2594,11 @@ class TopOpeBRepDS_DataMapOfCheckStatus : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_DataMapOfCheckStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfIntegerListOfInterference;
 class TopOpeBRepDS_DataMapOfIntegerListOfInterference : public TCollection_BasicMap {
 	public:
@@ -2527,6 +2677,11 @@ class TopOpeBRepDS_DataMapOfIntegerListOfInterference : public TCollection_Basic
 };
 
 
+%extend TopOpeBRepDS_DataMapOfIntegerListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfInterferenceListOfInterference;
 class TopOpeBRepDS_DataMapOfInterferenceListOfInterference : public TCollection_BasicMap {
 	public:
@@ -2605,6 +2760,11 @@ class TopOpeBRepDS_DataMapOfInterferenceListOfInterference : public TCollection_
 };
 
 
+%extend TopOpeBRepDS_DataMapOfInterferenceListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfInterferenceShape;
 class TopOpeBRepDS_DataMapOfInterferenceShape : public TCollection_BasicMap {
 	public:
@@ -2683,6 +2843,11 @@ class TopOpeBRepDS_DataMapOfInterferenceShape : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_DataMapOfInterferenceShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfShapeListOfShapeOn1State;
 class TopOpeBRepDS_DataMapOfShapeListOfShapeOn1State : public TCollection_BasicMap {
 	public:
@@ -2761,6 +2926,11 @@ class TopOpeBRepDS_DataMapOfShapeListOfShapeOn1State : public TCollection_BasicM
 };
 
 
+%extend TopOpeBRepDS_DataMapOfShapeListOfShapeOn1State {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataMapOfShapeState;
 class TopOpeBRepDS_DataMapOfShapeState : public TCollection_BasicMap {
 	public:
@@ -2839,6 +3009,11 @@ class TopOpeBRepDS_DataMapOfShapeState : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_DataMapOfShapeState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DataStructure;
 class TopOpeBRepDS_DataStructure {
 	public:
@@ -3517,6 +3692,11 @@ class TopOpeBRepDS_DataStructure {
 };
 
 
+%extend TopOpeBRepDS_DataStructure {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DoubleMapIteratorOfDoubleMapOfIntegerShape;
 class TopOpeBRepDS_DoubleMapIteratorOfDoubleMapOfIntegerShape : public TCollection_BasicMapIterator {
 	public:
@@ -3547,6 +3727,11 @@ class TopOpeBRepDS_DoubleMapIteratorOfDoubleMapOfIntegerShape : public TCollecti
 };
 
 
+%extend TopOpeBRepDS_DoubleMapIteratorOfDoubleMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DoubleMapNodeOfDoubleMapOfIntegerShape;
 class TopOpeBRepDS_DoubleMapNodeOfDoubleMapOfIntegerShape : public TCollection_MapNode {
 	public:
@@ -3632,6 +3817,11 @@ class Handle_TopOpeBRepDS_DoubleMapNodeOfDoubleMapOfIntegerShape : public Handle
     }
 };
 
+%extend TopOpeBRepDS_DoubleMapNodeOfDoubleMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_DoubleMapOfIntegerShape;
 class TopOpeBRepDS_DoubleMapOfIntegerShape : public TCollection_BasicMap {
 	public:
@@ -3718,6 +3908,11 @@ class TopOpeBRepDS_DoubleMapOfIntegerShape : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_DoubleMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Dumper;
 class TopOpeBRepDS_Dumper {
 	public:
@@ -3936,6 +4131,11 @@ class TopOpeBRepDS_Dumper {
 };
 
 
+%extend TopOpeBRepDS_Dumper {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_EIR;
 class TopOpeBRepDS_EIR {
 	public:
@@ -3958,6 +4158,11 @@ class TopOpeBRepDS_EIR {
 };
 
 
+%extend TopOpeBRepDS_EIR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Edge3dInterferenceTool;
 class TopOpeBRepDS_Edge3dInterferenceTool {
 	public:
@@ -4006,6 +4211,11 @@ class TopOpeBRepDS_Edge3dInterferenceTool {
 };
 
 
+%extend TopOpeBRepDS_Edge3dInterferenceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_EdgeInterferenceTool;
 class TopOpeBRepDS_EdgeInterferenceTool {
 	public:
@@ -4050,6 +4260,11 @@ class TopOpeBRepDS_EdgeInterferenceTool {
 };
 
 
+%extend TopOpeBRepDS_EdgeInterferenceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Explorer;
 class TopOpeBRepDS_Explorer {
 	public:
@@ -4112,6 +4327,11 @@ class TopOpeBRepDS_Explorer {
 };
 
 
+%extend TopOpeBRepDS_Explorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_FIR;
 class TopOpeBRepDS_FIR {
 	public:
@@ -4138,6 +4358,11 @@ class TopOpeBRepDS_FIR {
 };
 
 
+%extend TopOpeBRepDS_FIR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_FaceInterferenceTool;
 class TopOpeBRepDS_FaceInterferenceTool {
 	public:
@@ -4216,6 +4441,11 @@ class TopOpeBRepDS_FaceInterferenceTool {
 };
 
 
+%extend TopOpeBRepDS_FaceInterferenceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Filter;
 class TopOpeBRepDS_Filter {
 	public:
@@ -4268,6 +4498,11 @@ class TopOpeBRepDS_Filter {
 };
 
 
+%extend TopOpeBRepDS_Filter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_GapFiller;
 class TopOpeBRepDS_GapFiller {
 	public:
@@ -4378,6 +4613,11 @@ class TopOpeBRepDS_GapFiller {
 };
 
 
+%extend TopOpeBRepDS_GapFiller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_GapTool;
 class TopOpeBRepDS_GapTool : public MMgt_TShared {
 	public:
@@ -4520,6 +4760,11 @@ class Handle_TopOpeBRepDS_GapTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepDS_GapTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_GeometryData;
 class TopOpeBRepDS_GeometryData {
 	public:
@@ -4562,6 +4807,11 @@ class TopOpeBRepDS_GeometryData {
 };
 
 
+%extend TopOpeBRepDS_GeometryData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_HArray1OfDataMapOfIntegerListOfInterference;
 class TopOpeBRepDS_HArray1OfDataMapOfIntegerListOfInterference : public MMgt_TShared {
 	public:
@@ -4678,6 +4928,11 @@ class Handle_TopOpeBRepDS_HArray1OfDataMapOfIntegerListOfInterference : public H
     }
 };
 
+%extend TopOpeBRepDS_HArray1OfDataMapOfIntegerListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfShapeWithState;
 class TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfShapeWithState : public TCollection_MapNode {
 	public:
@@ -4769,6 +5024,11 @@ class Handle_TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfShapeWithState : p
     }
 };
 
+%extend TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfShapeWithState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfVertexPoint;
 class TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfVertexPoint : public TCollection_MapNode {
 	public:
@@ -4860,6 +5120,11 @@ class Handle_TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfVertexPoint : publ
     }
 };
 
+%extend TopOpeBRepDS_IndexedDataMapNodeOfIndexedDataMapOfVertexPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_IndexedDataMapNodeOfMapOfShapeData;
 class TopOpeBRepDS_IndexedDataMapNodeOfMapOfShapeData : public TCollection_MapNode {
 	public:
@@ -4951,6 +5216,11 @@ class Handle_TopOpeBRepDS_IndexedDataMapNodeOfMapOfShapeData : public Handle_TCo
     }
 };
 
+%extend TopOpeBRepDS_IndexedDataMapNodeOfMapOfShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_IndexedDataMapOfShapeWithState;
 class TopOpeBRepDS_IndexedDataMapOfShapeWithState : public TCollection_BasicMap {
 	public:
@@ -5061,6 +5331,11 @@ class TopOpeBRepDS_IndexedDataMapOfShapeWithState : public TCollection_BasicMap 
 };
 
 
+%extend TopOpeBRepDS_IndexedDataMapOfShapeWithState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_IndexedDataMapOfVertexPoint;
 class TopOpeBRepDS_IndexedDataMapOfVertexPoint : public TCollection_BasicMap {
 	public:
@@ -5171,6 +5446,11 @@ class TopOpeBRepDS_IndexedDataMapOfVertexPoint : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_IndexedDataMapOfVertexPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Interference;
 class TopOpeBRepDS_Interference : public MMgt_TShared {
 	public:
@@ -5367,6 +5647,11 @@ class Handle_TopOpeBRepDS_Interference : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepDS_Interference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_InterferenceIterator;
 class TopOpeBRepDS_InterferenceIterator {
 	public:
@@ -5461,6 +5746,11 @@ class TopOpeBRepDS_InterferenceIterator {
 };
 
 
+%extend TopOpeBRepDS_InterferenceIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepDS_InterferenceTool {
 	public:
 		%feature("compactdefaultargs") MakeEdgeInterference;
@@ -5572,6 +5862,11 @@ class TopOpeBRepDS_InterferenceTool {
 };
 
 
+%extend TopOpeBRepDS_InterferenceTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ListIteratorOfListOfInterference;
 class TopOpeBRepDS_ListIteratorOfListOfInterference {
 	public:
@@ -5606,6 +5901,11 @@ class TopOpeBRepDS_ListIteratorOfListOfInterference {
 };
 
 
+%extend TopOpeBRepDS_ListIteratorOfListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ListNodeOfListOfInterference;
 class TopOpeBRepDS_ListNodeOfListOfInterference : public TCollection_MapNode {
 	public:
@@ -5670,6 +5970,11 @@ class Handle_TopOpeBRepDS_ListNodeOfListOfInterference : public Handle_TCollecti
     }
 };
 
+%extend TopOpeBRepDS_ListNodeOfListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ListOfInterference;
 class TopOpeBRepDS_ListOfInterference {
 	public:
@@ -5800,6 +6105,11 @@ class TopOpeBRepDS_ListOfInterference {
 };
 
 
+%extend TopOpeBRepDS_ListOfInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ListOfShapeOn1State;
 class TopOpeBRepDS_ListOfShapeOn1State {
 	public:
@@ -5832,6 +6142,11 @@ class TopOpeBRepDS_ListOfShapeOn1State {
 };
 
 
+%extend TopOpeBRepDS_ListOfShapeOn1State {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_MapOfCurve;
 class TopOpeBRepDS_MapOfCurve : public TCollection_BasicMap {
 	public:
@@ -5910,6 +6225,11 @@ class TopOpeBRepDS_MapOfCurve : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_MapOfCurve {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_MapOfIntegerShapeData;
 class TopOpeBRepDS_MapOfIntegerShapeData : public TCollection_BasicMap {
 	public:
@@ -5988,6 +6308,11 @@ class TopOpeBRepDS_MapOfIntegerShapeData : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_MapOfIntegerShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_MapOfPoint;
 class TopOpeBRepDS_MapOfPoint : public TCollection_BasicMap {
 	public:
@@ -6066,6 +6391,11 @@ class TopOpeBRepDS_MapOfPoint : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_MapOfPoint {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_MapOfShapeData;
 class TopOpeBRepDS_MapOfShapeData : public TCollection_BasicMap {
 	public:
@@ -6176,6 +6506,11 @@ class TopOpeBRepDS_MapOfShapeData : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_MapOfShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_MapOfSurface;
 class TopOpeBRepDS_MapOfSurface : public TCollection_BasicMap {
 	public:
@@ -6254,6 +6589,11 @@ class TopOpeBRepDS_MapOfSurface : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_MapOfSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Marker;
 class TopOpeBRepDS_Marker : public MMgt_TShared {
 	public:
@@ -6344,6 +6684,11 @@ class Handle_TopOpeBRepDS_Marker : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepDS_Marker {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Point;
 class TopOpeBRepDS_Point {
 	public:
@@ -6402,6 +6747,11 @@ class TopOpeBRepDS_Point {
 };
 
 
+%extend TopOpeBRepDS_Point {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_PointExplorer;
 class TopOpeBRepDS_PointExplorer {
 	public:
@@ -6466,6 +6816,11 @@ class TopOpeBRepDS_PointExplorer {
 };
 
 
+%extend TopOpeBRepDS_PointExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Reducer;
 class TopOpeBRepDS_Reducer {
 	public:
@@ -6488,6 +6843,11 @@ class TopOpeBRepDS_Reducer {
 };
 
 
+%extend TopOpeBRepDS_Reducer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ShapeData;
 class TopOpeBRepDS_ShapeData {
 	public:
@@ -6516,6 +6876,11 @@ class TopOpeBRepDS_ShapeData {
 };
 
 
+%extend TopOpeBRepDS_ShapeData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ShapeSurface;
 class TopOpeBRepDS_ShapeSurface : public TCollection_BasicMap {
 	public:
@@ -6594,6 +6959,11 @@ class TopOpeBRepDS_ShapeSurface : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepDS_ShapeSurface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ShapeWithState;
 class TopOpeBRepDS_ShapeWithState {
 	public:
@@ -6646,6 +7016,11 @@ class TopOpeBRepDS_ShapeWithState {
 };
 
 
+%extend TopOpeBRepDS_ShapeWithState {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Surface;
 class TopOpeBRepDS_Surface {
 	public:
@@ -6708,6 +7083,11 @@ class TopOpeBRepDS_Surface {
 };
 
 
+%extend TopOpeBRepDS_Surface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_SurfaceExplorer;
 class TopOpeBRepDS_SurfaceExplorer {
 	public:
@@ -6772,6 +7152,11 @@ class TopOpeBRepDS_SurfaceExplorer {
 };
 
 
+%extend TopOpeBRepDS_SurfaceExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_TKI;
 class TopOpeBRepDS_TKI {
 	public:
@@ -6928,6 +7313,11 @@ class TopOpeBRepDS_TKI {
 };
 
 
+%extend TopOpeBRepDS_TKI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepDS_TOOL {
 	public:
 		%feature("compactdefaultargs") EShareG;
@@ -6993,6 +7383,11 @@ class TopOpeBRepDS_TOOL {
 };
 
 
+%extend TopOpeBRepDS_TOOL {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_Transition;
 class TopOpeBRepDS_Transition {
 	public:
@@ -7179,6 +7574,11 @@ class TopOpeBRepDS_Transition {
         };
 
 
+%extend TopOpeBRepDS_Transition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_CurveData;
 class TopOpeBRepDS_CurveData : public TopOpeBRepDS_GeometryData {
 	public:
@@ -7195,6 +7595,11 @@ class TopOpeBRepDS_CurveData : public TopOpeBRepDS_GeometryData {
 };
 
 
+%extend TopOpeBRepDS_CurveData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_CurveIterator;
 class TopOpeBRepDS_CurveIterator : public TopOpeBRepDS_InterferenceIterator {
 	public:
@@ -7233,6 +7638,11 @@ class TopOpeBRepDS_CurveIterator : public TopOpeBRepDS_InterferenceIterator {
 };
 
 
+%extend TopOpeBRepDS_CurveIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_CurvePointInterference;
 class TopOpeBRepDS_CurvePointInterference : public TopOpeBRepDS_Interference {
 	public:
@@ -7319,6 +7729,11 @@ class Handle_TopOpeBRepDS_CurvePointInterference : public Handle_TopOpeBRepDS_In
     }
 };
 
+%extend TopOpeBRepDS_CurvePointInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_PointData;
 class TopOpeBRepDS_PointData : public TopOpeBRepDS_GeometryData {
 	public:
@@ -7361,6 +7776,11 @@ class TopOpeBRepDS_PointData : public TopOpeBRepDS_GeometryData {
 };
 
 
+%extend TopOpeBRepDS_PointData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_PointIterator;
 class TopOpeBRepDS_PointIterator : public TopOpeBRepDS_InterferenceIterator {
 	public:
@@ -7419,6 +7839,11 @@ class TopOpeBRepDS_PointIterator : public TopOpeBRepDS_InterferenceIterator {
 };
 
 
+%extend TopOpeBRepDS_PointIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_ShapeShapeInterference;
 class TopOpeBRepDS_ShapeShapeInterference : public TopOpeBRepDS_Interference {
 	public:
@@ -7513,6 +7938,11 @@ class Handle_TopOpeBRepDS_ShapeShapeInterference : public Handle_TopOpeBRepDS_In
     }
 };
 
+%extend TopOpeBRepDS_ShapeShapeInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_SolidSurfaceInterference;
 class TopOpeBRepDS_SolidSurfaceInterference : public TopOpeBRepDS_Interference {
 	public:
@@ -7587,6 +8017,11 @@ class Handle_TopOpeBRepDS_SolidSurfaceInterference : public Handle_TopOpeBRepDS_
     }
 };
 
+%extend TopOpeBRepDS_SolidSurfaceInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_SurfaceCurveInterference;
 class TopOpeBRepDS_SurfaceCurveInterference : public TopOpeBRepDS_Interference {
 	public:
@@ -7691,6 +8126,11 @@ class Handle_TopOpeBRepDS_SurfaceCurveInterference : public Handle_TopOpeBRepDS_
     }
 };
 
+%extend TopOpeBRepDS_SurfaceCurveInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_SurfaceData;
 class TopOpeBRepDS_SurfaceData : public TopOpeBRepDS_GeometryData {
 	public:
@@ -7707,6 +8147,11 @@ class TopOpeBRepDS_SurfaceData : public TopOpeBRepDS_GeometryData {
 };
 
 
+%extend TopOpeBRepDS_SurfaceData {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_SurfaceIterator;
 class TopOpeBRepDS_SurfaceIterator : public TopOpeBRepDS_InterferenceIterator {
 	public:
@@ -7733,6 +8178,11 @@ class TopOpeBRepDS_SurfaceIterator : public TopOpeBRepDS_InterferenceIterator {
 };
 
 
+%extend TopOpeBRepDS_SurfaceIterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_EdgeVertexInterference;
 class TopOpeBRepDS_EdgeVertexInterference : public TopOpeBRepDS_ShapeShapeInterference {
 	public:
@@ -7841,6 +8291,11 @@ class Handle_TopOpeBRepDS_EdgeVertexInterference : public Handle_TopOpeBRepDS_Sh
     }
 };
 
+%extend TopOpeBRepDS_EdgeVertexInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepDS_FaceEdgeInterference;
 class TopOpeBRepDS_FaceEdgeInterference : public TopOpeBRepDS_ShapeShapeInterference {
 	public:
@@ -7917,3 +8372,8 @@ class Handle_TopOpeBRepDS_FaceEdgeInterference : public Handle_TopOpeBRepDS_Shap
     }
 };
 
+%extend TopOpeBRepDS_FaceEdgeInterference {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopOpeBRepTool.i
+++ b/src/SWIG_files/wrapper/TopOpeBRepTool.i
@@ -177,6 +177,11 @@ class TopOpeBRepTool {
 };
 
 
+%extend TopOpeBRepTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepTool_AncestorsTool {
 	public:
 		%feature("compactdefaultargs") MakeAncestors;
@@ -196,6 +201,11 @@ class TopOpeBRepTool_AncestorsTool {
 };
 
 
+%extend TopOpeBRepTool_AncestorsTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_BoxSort;
 class TopOpeBRepTool_BoxSort {
 	public:
@@ -306,6 +316,11 @@ class TopOpeBRepTool_BoxSort {
 };
 
 
+%extend TopOpeBRepTool_BoxSort {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_C2DF;
 class TopOpeBRepTool_C2DF {
 	public:
@@ -374,6 +389,11 @@ class TopOpeBRepTool_C2DF {
 };
 
 
+%extend TopOpeBRepTool_C2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_CLASSI;
 class TopOpeBRepTool_CLASSI {
 	public:
@@ -446,6 +466,11 @@ class TopOpeBRepTool_CLASSI {
 };
 
 
+%extend TopOpeBRepTool_CLASSI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_CORRISO;
 class TopOpeBRepTool_CORRISO {
 	public:
@@ -630,6 +655,11 @@ class TopOpeBRepTool_CORRISO {
 };
 
 
+%extend TopOpeBRepTool_CORRISO {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_CurveTool;
 class TopOpeBRepTool_CurveTool {
 	public:
@@ -730,6 +760,11 @@ class TopOpeBRepTool_CurveTool {
 };
 
 
+%extend TopOpeBRepTool_CurveTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapIteratorOfDataMapOfOrientedShapeC2DF;
 class TopOpeBRepTool_DataMapIteratorOfDataMapOfOrientedShapeC2DF : public TCollection_BasicMapIterator {
 	public:
@@ -760,6 +795,11 @@ class TopOpeBRepTool_DataMapIteratorOfDataMapOfOrientedShapeC2DF : public TColle
 };
 
 
+%extend TopOpeBRepTool_DataMapIteratorOfDataMapOfOrientedShapeC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeListOfC2DF;
 class TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeListOfC2DF : public TCollection_BasicMapIterator {
 	public:
@@ -790,6 +830,11 @@ class TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeListOfC2DF : public TCollect
 };
 
 
+%extend TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeface;
 class TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeface : public TCollection_BasicMapIterator {
 	public:
@@ -820,6 +865,11 @@ class TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeface : public TCollection_Ba
 };
 
 
+%extend TopOpeBRepTool_DataMapIteratorOfDataMapOfShapeface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapNodeOfDataMapOfOrientedShapeC2DF;
 class TopOpeBRepTool_DataMapNodeOfDataMapOfOrientedShapeC2DF : public TCollection_MapNode {
 	public:
@@ -890,6 +940,11 @@ class Handle_TopOpeBRepTool_DataMapNodeOfDataMapOfOrientedShapeC2DF : public Han
     }
 };
 
+%extend TopOpeBRepTool_DataMapNodeOfDataMapOfOrientedShapeC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapNodeOfDataMapOfShapeListOfC2DF;
 class TopOpeBRepTool_DataMapNodeOfDataMapOfShapeListOfC2DF : public TCollection_MapNode {
 	public:
@@ -960,6 +1015,11 @@ class Handle_TopOpeBRepTool_DataMapNodeOfDataMapOfShapeListOfC2DF : public Handl
     }
 };
 
+%extend TopOpeBRepTool_DataMapNodeOfDataMapOfShapeListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapNodeOfDataMapOfShapeface;
 class TopOpeBRepTool_DataMapNodeOfDataMapOfShapeface : public TCollection_MapNode {
 	public:
@@ -1030,6 +1090,11 @@ class Handle_TopOpeBRepTool_DataMapNodeOfDataMapOfShapeface : public Handle_TCol
     }
 };
 
+%extend TopOpeBRepTool_DataMapNodeOfDataMapOfShapeface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapOfOrientedShapeC2DF;
 class TopOpeBRepTool_DataMapOfOrientedShapeC2DF : public TCollection_BasicMap {
 	public:
@@ -1108,6 +1173,11 @@ class TopOpeBRepTool_DataMapOfOrientedShapeC2DF : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepTool_DataMapOfOrientedShapeC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapOfShapeListOfC2DF;
 class TopOpeBRepTool_DataMapOfShapeListOfC2DF : public TCollection_BasicMap {
 	public:
@@ -1186,6 +1256,11 @@ class TopOpeBRepTool_DataMapOfShapeListOfC2DF : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepTool_DataMapOfShapeListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_DataMapOfShapeface;
 class TopOpeBRepTool_DataMapOfShapeface : public TCollection_BasicMap {
 	public:
@@ -1264,6 +1339,11 @@ class TopOpeBRepTool_DataMapOfShapeface : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepTool_DataMapOfShapeface {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_FuseEdges;
 class TopOpeBRepTool_FuseEdges {
 	public:
@@ -1330,6 +1410,11 @@ class TopOpeBRepTool_FuseEdges {
 };
 
 
+%extend TopOpeBRepTool_FuseEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_GeomTool;
 class TopOpeBRepTool_GeomTool {
 	public:
@@ -1454,6 +1539,11 @@ class TopOpeBRepTool_GeomTool {
 };
 
 
+%extend TopOpeBRepTool_GeomTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_HBoxTool;
 class TopOpeBRepTool_HBoxTool : public MMgt_TShared {
 	public:
@@ -1594,6 +1684,11 @@ class Handle_TopOpeBRepTool_HBoxTool : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopOpeBRepTool_HBoxTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox;
 class TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox : public TCollection_MapNode {
 	public:
@@ -1685,6 +1780,11 @@ class Handle_TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox : publi
     }
 };
 
+%extend TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox2d;
 class TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox2d : public TCollection_MapNode {
 	public:
@@ -1776,6 +1876,11 @@ class Handle_TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox2d : pub
     }
 };
 
+%extend TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeconnexity;
 class TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeconnexity : public TCollection_MapNode {
 	public:
@@ -1867,6 +1972,11 @@ class Handle_TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeconnexity :
     }
 };
 
+%extend TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfShapeconnexity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfSolidClassifier;
 class TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfSolidClassifier : public TCollection_MapNode {
 	public:
@@ -1958,6 +2068,11 @@ class Handle_TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfSolidClassifier 
     }
 };
 
+%extend TopOpeBRepTool_IndexedDataMapNodeOfIndexedDataMapOfSolidClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapOfShapeBox;
 class TopOpeBRepTool_IndexedDataMapOfShapeBox : public TCollection_BasicMap {
 	public:
@@ -2068,6 +2183,11 @@ class TopOpeBRepTool_IndexedDataMapOfShapeBox : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepTool_IndexedDataMapOfShapeBox {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapOfShapeBox2d;
 class TopOpeBRepTool_IndexedDataMapOfShapeBox2d : public TCollection_BasicMap {
 	public:
@@ -2178,6 +2298,11 @@ class TopOpeBRepTool_IndexedDataMapOfShapeBox2d : public TCollection_BasicMap {
 };
 
 
+%extend TopOpeBRepTool_IndexedDataMapOfShapeBox2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapOfShapeconnexity;
 class TopOpeBRepTool_IndexedDataMapOfShapeconnexity : public TCollection_BasicMap {
 	public:
@@ -2288,6 +2413,11 @@ class TopOpeBRepTool_IndexedDataMapOfShapeconnexity : public TCollection_BasicMa
 };
 
 
+%extend TopOpeBRepTool_IndexedDataMapOfShapeconnexity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_IndexedDataMapOfSolidClassifier;
 class TopOpeBRepTool_IndexedDataMapOfSolidClassifier : public TCollection_BasicMap {
 	public:
@@ -2398,6 +2528,11 @@ class TopOpeBRepTool_IndexedDataMapOfSolidClassifier : public TCollection_BasicM
 };
 
 
+%extend TopOpeBRepTool_IndexedDataMapOfSolidClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_ListIteratorOfListOfC2DF;
 class TopOpeBRepTool_ListIteratorOfListOfC2DF {
 	public:
@@ -2432,6 +2567,11 @@ class TopOpeBRepTool_ListIteratorOfListOfC2DF {
 };
 
 
+%extend TopOpeBRepTool_ListIteratorOfListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_ListNodeOfListOfC2DF;
 class TopOpeBRepTool_ListNodeOfListOfC2DF : public TCollection_MapNode {
 	public:
@@ -2496,6 +2636,11 @@ class Handle_TopOpeBRepTool_ListNodeOfListOfC2DF : public Handle_TCollection_Map
     }
 };
 
+%extend TopOpeBRepTool_ListNodeOfListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_ListOfC2DF;
 class TopOpeBRepTool_ListOfC2DF {
 	public:
@@ -2626,6 +2771,11 @@ class TopOpeBRepTool_ListOfC2DF {
 };
 
 
+%extend TopOpeBRepTool_ListOfC2DF {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_PurgeInternalEdges;
 class TopOpeBRepTool_PurgeInternalEdges {
 	public:
@@ -2674,6 +2824,11 @@ class TopOpeBRepTool_PurgeInternalEdges {
 };
 
 
+%extend TopOpeBRepTool_PurgeInternalEdges {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_REGUS;
 class TopOpeBRepTool_REGUS {
 	public:
@@ -2766,6 +2921,11 @@ class TopOpeBRepTool_REGUS {
 };
 
 
+%extend TopOpeBRepTool_REGUS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_REGUW;
 class TopOpeBRepTool_REGUW {
 	public:
@@ -2898,6 +3058,11 @@ class TopOpeBRepTool_REGUW {
 };
 
 
+%extend TopOpeBRepTool_REGUW {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_ShapeClassifier;
 class TopOpeBRepTool_ShapeClassifier {
 	public:
@@ -3038,6 +3203,11 @@ class TopOpeBRepTool_ShapeClassifier {
 };
 
 
+%extend TopOpeBRepTool_ShapeClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_ShapeExplorer;
 class TopOpeBRepTool_ShapeExplorer {
 	public:
@@ -3106,6 +3276,11 @@ class TopOpeBRepTool_ShapeExplorer {
         };
 
 
+%extend TopOpeBRepTool_ShapeExplorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepTool_ShapeTool {
 	public:
 		%feature("compactdefaultargs") Tolerance;
@@ -3323,6 +3498,11 @@ class TopOpeBRepTool_ShapeTool {
 };
 
 
+%extend TopOpeBRepTool_ShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_SolidClassifier;
 class TopOpeBRepTool_SolidClassifier {
 	public:
@@ -3381,6 +3561,11 @@ class TopOpeBRepTool_SolidClassifier {
 };
 
 
+%extend TopOpeBRepTool_SolidClassifier {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopOpeBRepTool_TOOL {
 	public:
 		%feature("compactdefaultargs") OriinSor;
@@ -3960,6 +4145,11 @@ class TopOpeBRepTool_TOOL {
 };
 
 
+%extend TopOpeBRepTool_TOOL {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_connexity;
 class TopOpeBRepTool_connexity {
 	public:
@@ -4050,6 +4240,11 @@ class TopOpeBRepTool_connexity {
 };
 
 
+%extend TopOpeBRepTool_connexity {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_face;
 class TopOpeBRepTool_face {
 	public:
@@ -4088,6 +4283,11 @@ class TopOpeBRepTool_face {
 };
 
 
+%extend TopOpeBRepTool_face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopOpeBRepTool_makeTransition;
 class TopOpeBRepTool_makeTransition {
 	public:
@@ -4174,3 +4374,8 @@ class TopOpeBRepTool_makeTransition {
 };
 
 
+%extend TopOpeBRepTool_makeTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopTools.i
+++ b/src/SWIG_files/wrapper/TopTools.i
@@ -81,6 +81,11 @@ class TopTools {
 };
 
 
+%extend TopTools {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_Array1OfListOfShape;
 class TopTools_Array1OfListOfShape {
 	public:
@@ -163,6 +168,11 @@ class TopTools_Array1OfListOfShape {
 };
 
 
+%extend TopTools_Array1OfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_Array1OfShape;
 class TopTools_Array1OfShape {
 	public:
@@ -245,6 +255,11 @@ class TopTools_Array1OfShape {
 };
 
 
+%extend TopTools_Array1OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_Array2OfShape;
 class TopTools_Array2OfShape {
 	public:
@@ -349,6 +364,11 @@ class TopTools_Array2OfShape {
 };
 
 
+%extend TopTools_Array2OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfIntegerListOfShape;
 class TopTools_DataMapIteratorOfDataMapOfIntegerListOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -379,6 +399,11 @@ class TopTools_DataMapIteratorOfDataMapOfIntegerListOfShape : public TCollection
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfIntegerListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfIntegerShape;
 class TopTools_DataMapIteratorOfDataMapOfIntegerShape : public TCollection_BasicMapIterator {
 	public:
@@ -409,6 +434,11 @@ class TopTools_DataMapIteratorOfDataMapOfIntegerShape : public TCollection_Basic
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfOrientedShapeInteger;
 class TopTools_DataMapIteratorOfDataMapOfOrientedShapeInteger : public TCollection_BasicMapIterator {
 	public:
@@ -439,6 +469,11 @@ class TopTools_DataMapIteratorOfDataMapOfOrientedShapeInteger : public TCollecti
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfOrientedShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfOrientedShapeShape;
 class TopTools_DataMapIteratorOfDataMapOfOrientedShapeShape : public TCollection_BasicMapIterator {
 	public:
@@ -469,6 +504,11 @@ class TopTools_DataMapIteratorOfDataMapOfOrientedShapeShape : public TCollection
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfOrientedShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeInteger;
 class TopTools_DataMapIteratorOfDataMapOfShapeInteger : public TCollection_BasicMapIterator {
 	public:
@@ -499,6 +539,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeInteger : public TCollection_Basic
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeListOfInteger;
 class TopTools_DataMapIteratorOfDataMapOfShapeListOfInteger : public TCollection_BasicMapIterator {
 	public:
@@ -529,6 +574,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeListOfInteger : public TCollection
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeListOfShape;
 class TopTools_DataMapIteratorOfDataMapOfShapeListOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -559,6 +609,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeListOfShape : public TCollection_B
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeReal;
 class TopTools_DataMapIteratorOfDataMapOfShapeReal : public TCollection_BasicMapIterator {
 	public:
@@ -589,6 +644,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeReal : public TCollection_BasicMap
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeSequenceOfShape;
 class TopTools_DataMapIteratorOfDataMapOfShapeSequenceOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -619,6 +679,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeSequenceOfShape : public TCollecti
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapIteratorOfDataMapOfShapeShape;
 class TopTools_DataMapIteratorOfDataMapOfShapeShape : public TCollection_BasicMapIterator {
 	public:
@@ -649,6 +714,11 @@ class TopTools_DataMapIteratorOfDataMapOfShapeShape : public TCollection_BasicMa
 };
 
 
+%extend TopTools_DataMapIteratorOfDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfIntegerListOfShape;
 class TopTools_DataMapNodeOfDataMapOfIntegerListOfShape : public TCollection_MapNode {
 	public:
@@ -728,6 +798,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfIntegerListOfShape : public Handle_T
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfIntegerListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfIntegerShape;
 class TopTools_DataMapNodeOfDataMapOfIntegerShape : public TCollection_MapNode {
 	public:
@@ -807,6 +882,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfIntegerShape : public Handle_TCollec
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfOrientedShapeInteger;
 class TopTools_DataMapNodeOfDataMapOfOrientedShapeInteger : public TCollection_MapNode {
 	public:
@@ -886,6 +966,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfOrientedShapeInteger : public Handle
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfOrientedShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfOrientedShapeShape;
 class TopTools_DataMapNodeOfDataMapOfOrientedShapeShape : public TCollection_MapNode {
 	public:
@@ -956,6 +1041,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfOrientedShapeShape : public Handle_T
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfOrientedShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeInteger;
 class TopTools_DataMapNodeOfDataMapOfShapeInteger : public TCollection_MapNode {
 	public:
@@ -1035,6 +1125,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeInteger : public Handle_TCollec
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeListOfInteger;
 class TopTools_DataMapNodeOfDataMapOfShapeListOfInteger : public TCollection_MapNode {
 	public:
@@ -1105,6 +1200,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeListOfInteger : public Handle_T
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeListOfShape;
 class TopTools_DataMapNodeOfDataMapOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -1175,6 +1275,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeListOfShape : public Handle_TCo
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeReal;
 class TopTools_DataMapNodeOfDataMapOfShapeReal : public TCollection_MapNode {
 	public:
@@ -1254,6 +1359,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeReal : public Handle_TCollectio
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeSequenceOfShape;
 class TopTools_DataMapNodeOfDataMapOfShapeSequenceOfShape : public TCollection_MapNode {
 	public:
@@ -1324,6 +1434,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeSequenceOfShape : public Handle
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapNodeOfDataMapOfShapeShape;
 class TopTools_DataMapNodeOfDataMapOfShapeShape : public TCollection_MapNode {
 	public:
@@ -1394,6 +1509,11 @@ class Handle_TopTools_DataMapNodeOfDataMapOfShapeShape : public Handle_TCollecti
     }
 };
 
+%extend TopTools_DataMapNodeOfDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfIntegerListOfShape;
 class TopTools_DataMapOfIntegerListOfShape : public TCollection_BasicMap {
 	public:
@@ -1472,6 +1592,11 @@ class TopTools_DataMapOfIntegerListOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfIntegerListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfIntegerShape;
 class TopTools_DataMapOfIntegerShape : public TCollection_BasicMap {
 	public:
@@ -1550,6 +1675,11 @@ class TopTools_DataMapOfIntegerShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfIntegerShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfOrientedShapeInteger;
 class TopTools_DataMapOfOrientedShapeInteger : public TCollection_BasicMap {
 	public:
@@ -1628,6 +1758,11 @@ class TopTools_DataMapOfOrientedShapeInteger : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfOrientedShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfOrientedShapeShape;
 class TopTools_DataMapOfOrientedShapeShape : public TCollection_BasicMap {
 	public:
@@ -1706,6 +1841,11 @@ class TopTools_DataMapOfOrientedShapeShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfOrientedShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeInteger;
 class TopTools_DataMapOfShapeInteger : public TCollection_BasicMap {
 	public:
@@ -1784,6 +1924,11 @@ class TopTools_DataMapOfShapeInteger : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeListOfInteger;
 class TopTools_DataMapOfShapeListOfInteger : public TCollection_BasicMap {
 	public:
@@ -1862,6 +2007,11 @@ class TopTools_DataMapOfShapeListOfInteger : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeListOfInteger {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeListOfShape;
 class TopTools_DataMapOfShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -1940,6 +2090,11 @@ class TopTools_DataMapOfShapeListOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeReal;
 class TopTools_DataMapOfShapeReal : public TCollection_BasicMap {
 	public:
@@ -2018,6 +2173,11 @@ class TopTools_DataMapOfShapeReal : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeReal {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeSequenceOfShape;
 class TopTools_DataMapOfShapeSequenceOfShape : public TCollection_BasicMap {
 	public:
@@ -2096,6 +2256,11 @@ class TopTools_DataMapOfShapeSequenceOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_DataMapOfShapeShape;
 class TopTools_DataMapOfShapeShape : public TCollection_BasicMap {
 	public:
@@ -2174,6 +2339,11 @@ class TopTools_DataMapOfShapeShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_DataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_HArray1OfListOfShape;
 class TopTools_HArray1OfListOfShape : public MMgt_TShared {
 	public:
@@ -2290,6 +2460,11 @@ class Handle_TopTools_HArray1OfListOfShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopTools_HArray1OfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_HArray1OfShape;
 class TopTools_HArray1OfShape : public MMgt_TShared {
 	public:
@@ -2406,6 +2581,11 @@ class Handle_TopTools_HArray1OfShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopTools_HArray1OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_HArray2OfShape;
 class TopTools_HArray2OfShape : public MMgt_TShared {
 	public:
@@ -2548,6 +2728,11 @@ class Handle_TopTools_HArray2OfShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopTools_HArray2OfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_HSequenceOfShape;
 class TopTools_HSequenceOfShape : public MMgt_TShared {
 	public:
@@ -2732,6 +2917,11 @@ class Handle_TopTools_HSequenceOfShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopTools_HSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeAddress;
 class TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeAddress : public TCollection_MapNode {
 	public:
@@ -2823,6 +3013,11 @@ class Handle_TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeAddress : public 
     }
 };
 
+%extend TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeListOfShape;
 class TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeListOfShape : public TCollection_MapNode {
 	public:
@@ -2914,6 +3109,11 @@ class Handle_TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeListOfShape : pub
     }
 };
 
+%extend TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeShape;
 class TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeShape : public TCollection_MapNode {
 	public:
@@ -3005,6 +3205,11 @@ class Handle_TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeShape : public Ha
     }
 };
 
+%extend TopTools_IndexedDataMapNodeOfIndexedDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapOfShapeAddress;
 class TopTools_IndexedDataMapOfShapeAddress : public TCollection_BasicMap {
 	public:
@@ -3115,6 +3320,11 @@ class TopTools_IndexedDataMapOfShapeAddress : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_IndexedDataMapOfShapeAddress {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapOfShapeListOfShape;
 class TopTools_IndexedDataMapOfShapeListOfShape : public TCollection_BasicMap {
 	public:
@@ -3225,6 +3435,11 @@ class TopTools_IndexedDataMapOfShapeListOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_IndexedDataMapOfShapeListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedDataMapOfShapeShape;
 class TopTools_IndexedDataMapOfShapeShape : public TCollection_BasicMap {
 	public:
@@ -3335,6 +3550,11 @@ class TopTools_IndexedDataMapOfShapeShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_IndexedDataMapOfShapeShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedMapNodeOfIndexedMapOfOrientedShape;
 class TopTools_IndexedMapNodeOfIndexedMapOfOrientedShape : public TCollection_MapNode {
 	public:
@@ -3420,6 +3640,11 @@ class Handle_TopTools_IndexedMapNodeOfIndexedMapOfOrientedShape : public Handle_
     }
 };
 
+%extend TopTools_IndexedMapNodeOfIndexedMapOfOrientedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedMapNodeOfIndexedMapOfShape;
 class TopTools_IndexedMapNodeOfIndexedMapOfShape : public TCollection_MapNode {
 	public:
@@ -3505,6 +3730,11 @@ class Handle_TopTools_IndexedMapNodeOfIndexedMapOfShape : public Handle_TCollect
     }
 };
 
+%extend TopTools_IndexedMapNodeOfIndexedMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedMapOfOrientedShape;
 class TopTools_IndexedMapOfOrientedShape : public TCollection_BasicMap {
 	public:
@@ -3581,6 +3811,11 @@ class TopTools_IndexedMapOfOrientedShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_IndexedMapOfOrientedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_IndexedMapOfShape;
 class TopTools_IndexedMapOfShape : public TCollection_BasicMap {
 	public:
@@ -3657,6 +3892,11 @@ class TopTools_IndexedMapOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_IndexedMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_ListIteratorOfListOfShape;
 class TopTools_ListIteratorOfListOfShape {
 	public:
@@ -3691,6 +3931,11 @@ class TopTools_ListIteratorOfListOfShape {
 };
 
 
+%extend TopTools_ListIteratorOfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_ListNodeOfListOfShape;
 class TopTools_ListNodeOfListOfShape : public TCollection_MapNode {
 	public:
@@ -3755,6 +4000,11 @@ class Handle_TopTools_ListNodeOfListOfShape : public Handle_TCollection_MapNode 
     }
 };
 
+%extend TopTools_ListNodeOfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_ListOfShape;
 class TopTools_ListOfShape {
 	public:
@@ -3885,6 +4135,11 @@ class TopTools_ListOfShape {
 };
 
 
+%extend TopTools_ListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_LocationSet;
 class TopTools_LocationSet {
 	public:
@@ -3960,6 +4215,11 @@ class TopTools_LocationSet {
 };
 
 
+%extend TopTools_LocationSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_MapIteratorOfMapOfOrientedShape;
 class TopTools_MapIteratorOfMapOfOrientedShape : public TCollection_BasicMapIterator {
 	public:
@@ -3986,6 +4246,11 @@ class TopTools_MapIteratorOfMapOfOrientedShape : public TCollection_BasicMapIter
 };
 
 
+%extend TopTools_MapIteratorOfMapOfOrientedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_MapIteratorOfMapOfShape;
 class TopTools_MapIteratorOfMapOfShape : public TCollection_BasicMapIterator {
 	public:
@@ -4012,6 +4277,11 @@ class TopTools_MapIteratorOfMapOfShape : public TCollection_BasicMapIterator {
 };
 
 
+%extend TopTools_MapIteratorOfMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_MapOfOrientedShape;
 class TopTools_MapOfOrientedShape : public TCollection_BasicMap {
 	public:
@@ -4070,6 +4340,11 @@ class TopTools_MapOfOrientedShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_MapOfOrientedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_MapOfShape;
 class TopTools_MapOfShape : public TCollection_BasicMap {
 	public:
@@ -4128,6 +4403,11 @@ class TopTools_MapOfShape : public TCollection_BasicMap {
 };
 
 
+%extend TopTools_MapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_MutexForShapeProvider;
 class TopTools_MutexForShapeProvider {
 	public:
@@ -4172,6 +4452,11 @@ class TopTools_MutexForShapeProvider {
 };
 
 
+%extend TopTools_MutexForShapeProvider {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopTools_OrientedShapeMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -4197,6 +4482,11 @@ class TopTools_OrientedShapeMapHasher {
 };
 
 
+%extend TopTools_OrientedShapeMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_SequenceNodeOfSequenceOfShape;
 class TopTools_SequenceNodeOfSequenceOfShape : public TCollection_SeqNode {
 	public:
@@ -4263,6 +4553,11 @@ class Handle_TopTools_SequenceNodeOfSequenceOfShape : public Handle_TCollection_
     }
 };
 
+%extend TopTools_SequenceNodeOfSequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_SequenceOfShape;
 class TopTools_SequenceOfShape : public TCollection_BaseSequence {
 	public:
@@ -4401,6 +4696,11 @@ class TopTools_SequenceOfShape : public TCollection_BaseSequence {
 };
 
 
+%extend TopTools_SequenceOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopTools_ShapeMapHasher {
 	public:
 		%feature("compactdefaultargs") HashCode;
@@ -4426,6 +4726,11 @@ class TopTools_ShapeMapHasher {
 };
 
 
+%extend TopTools_ShapeMapHasher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_ShapeSet;
 class TopTools_ShapeSet {
 	public:
@@ -4660,6 +4965,11 @@ class TopTools_ShapeSet {
 };
 
 
+%extend TopTools_ShapeSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_StdMapNodeOfMapOfOrientedShape;
 class TopTools_StdMapNodeOfMapOfOrientedShape : public TCollection_MapNode {
 	public:
@@ -4724,6 +5034,11 @@ class Handle_TopTools_StdMapNodeOfMapOfOrientedShape : public Handle_TCollection
     }
 };
 
+%extend TopTools_StdMapNodeOfMapOfOrientedShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTools_StdMapNodeOfMapOfShape;
 class TopTools_StdMapNodeOfMapOfShape : public TCollection_MapNode {
 	public:
@@ -4788,3 +5103,8 @@ class Handle_TopTools_StdMapNodeOfMapOfShape : public Handle_TCollection_MapNode
     }
 };
 
+%extend TopTools_StdMapNodeOfMapOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopTrans.i
+++ b/src/SWIG_files/wrapper/TopTrans.i
@@ -160,6 +160,11 @@ class TopTrans_Array2OfOrientation {
 };
 
 
+%extend TopTrans_Array2OfOrientation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTrans_CurveTransition;
 class TopTrans_CurveTransition {
 	public:
@@ -222,6 +227,11 @@ class TopTrans_CurveTransition {
 };
 
 
+%extend TopTrans_CurveTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopTrans_SurfaceTransition;
 class TopTrans_SurfaceTransition {
 	public:
@@ -322,3 +332,8 @@ class TopTrans_SurfaceTransition {
 };
 
 
+%extend TopTrans_SurfaceTransition {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -174,6 +174,11 @@ class TopoDS {
 };
 
 
+%extend TopoDS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopoDS_Builder {
 	public:
 		%feature("compactdefaultargs") MakeWire;
@@ -239,6 +244,11 @@ class TopoDS_Builder {
 };
 
 
+%extend TopoDS_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_HShape;
 class TopoDS_HShape : public MMgt_TShared {
 	public:
@@ -325,6 +335,11 @@ class Handle_TopoDS_HShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopoDS_HShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Iterator;
 class TopoDS_Iterator {
 	public:
@@ -379,6 +394,11 @@ class TopoDS_Iterator {
 };
 
 
+%extend TopoDS_Iterator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_ListIteratorOfListOfShape;
 class TopoDS_ListIteratorOfListOfShape {
 	public:
@@ -413,6 +433,11 @@ class TopoDS_ListIteratorOfListOfShape {
 };
 
 
+%extend TopoDS_ListIteratorOfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_ListNodeOfListOfShape;
 class TopoDS_ListNodeOfListOfShape : public TCollection_MapNode {
 	public:
@@ -477,6 +502,11 @@ class Handle_TopoDS_ListNodeOfListOfShape : public Handle_TCollection_MapNode {
     }
 };
 
+%extend TopoDS_ListNodeOfListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_ListOfShape;
 class TopoDS_ListOfShape {
 	public:
@@ -607,6 +637,11 @@ class TopoDS_ListOfShape {
 };
 
 
+%extend TopoDS_ListOfShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Shape;
 class TopoDS_Shape {
 	public:
@@ -967,6 +1002,11 @@ class TopoDS_Shape {
 		self.this = the_shape.this
 	}
 };
+%extend TopoDS_Shape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TShape;
 class TopoDS_TShape : public MMgt_TShared {
 	public:
@@ -1143,6 +1183,11 @@ class Handle_TopoDS_TShape : public Handle_MMgt_TShared {
     }
 };
 
+%extend TopoDS_TShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_CompSolid;
 class TopoDS_CompSolid : public TopoDS_Shape {
 	public:
@@ -1155,6 +1200,11 @@ class TopoDS_CompSolid : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_CompSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Compound;
 class TopoDS_Compound : public TopoDS_Shape {
 	public:
@@ -1167,6 +1217,11 @@ class TopoDS_Compound : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Compound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Edge;
 class TopoDS_Edge : public TopoDS_Shape {
 	public:
@@ -1179,6 +1234,11 @@ class TopoDS_Edge : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Edge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Face;
 class TopoDS_Face : public TopoDS_Shape {
 	public:
@@ -1191,6 +1251,11 @@ class TopoDS_Face : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Face {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Shell;
 class TopoDS_Shell : public TopoDS_Shape {
 	public:
@@ -1203,6 +1268,11 @@ class TopoDS_Shell : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Shell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Solid;
 class TopoDS_Solid : public TopoDS_Shape {
 	public:
@@ -1215,6 +1285,11 @@ class TopoDS_Solid : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Solid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TCompSolid;
 class TopoDS_TCompSolid : public TopoDS_TShape {
 	public:
@@ -1285,6 +1360,11 @@ class Handle_TopoDS_TCompSolid : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TCompSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TCompound;
 class TopoDS_TCompound : public TopoDS_TShape {
 	public:
@@ -1355,6 +1435,11 @@ class Handle_TopoDS_TCompound : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TCompound {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TEdge;
 class TopoDS_TEdge : public TopoDS_TShape {
 	public:
@@ -1413,6 +1498,11 @@ class Handle_TopoDS_TEdge : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TFace;
 class TopoDS_TFace : public TopoDS_TShape {
 	public:
@@ -1483,6 +1573,11 @@ class Handle_TopoDS_TFace : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TShell;
 class TopoDS_TShell : public TopoDS_TShape {
 	public:
@@ -1553,6 +1648,11 @@ class Handle_TopoDS_TShell : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TShell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TSolid;
 class TopoDS_TSolid : public TopoDS_TShape {
 	public:
@@ -1623,6 +1723,11 @@ class Handle_TopoDS_TSolid : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TSolid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TVertex;
 class TopoDS_TVertex : public TopoDS_TShape {
 	public:
@@ -1681,6 +1786,11 @@ class Handle_TopoDS_TVertex : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_TWire;
 class TopoDS_TWire : public TopoDS_TShape {
 	public:
@@ -1751,6 +1861,11 @@ class Handle_TopoDS_TWire : public Handle_TopoDS_TShape {
     }
 };
 
+%extend TopoDS_TWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Vertex;
 class TopoDS_Vertex : public TopoDS_Shape {
 	public:
@@ -1765,6 +1880,11 @@ class TopoDS_Vertex : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Vertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDS_Wire;
 class TopoDS_Wire : public TopoDS_Shape {
 	public:
@@ -1777,3 +1897,8 @@ class TopoDS_Wire : public TopoDS_Shape {
 };
 
 
+%extend TopoDS_Wire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/TopoDSToStep.i
+++ b/src/SWIG_files/wrapper/TopoDSToStep.i
@@ -153,6 +153,11 @@ class TopoDSToStep {
 };
 
 
+%extend TopoDSToStep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class TopoDSToStep_FacetedTool {
 	public:
 		%feature("compactdefaultargs") CheckTopoDSShape;
@@ -164,6 +169,11 @@ class TopoDSToStep_FacetedTool {
 };
 
 
+%extend TopoDSToStep_FacetedTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_Root;
 class TopoDSToStep_Root {
 	public:
@@ -187,6 +197,11 @@ class TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_Tool;
 class TopoDSToStep_Tool {
 	public:
@@ -311,6 +326,11 @@ class TopoDSToStep_Tool {
 };
 
 
+%extend TopoDSToStep_Tool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_Builder;
 class TopoDSToStep_Builder : public TopoDSToStep_Root {
 	public:
@@ -349,6 +369,11 @@ class TopoDSToStep_Builder : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_Builder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeBrepWithVoids;
 class TopoDSToStep_MakeBrepWithVoids : public TopoDSToStep_Root {
 	public:
@@ -367,6 +392,11 @@ class TopoDSToStep_MakeBrepWithVoids : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeBrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeFacetedBrep;
 class TopoDSToStep_MakeFacetedBrep : public TopoDSToStep_Root {
 	public:
@@ -393,6 +423,11 @@ class TopoDSToStep_MakeFacetedBrep : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeFacetedBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeFacetedBrepAndBrepWithVoids;
 class TopoDSToStep_MakeFacetedBrepAndBrepWithVoids : public TopoDSToStep_Root {
 	public:
@@ -411,6 +446,11 @@ class TopoDSToStep_MakeFacetedBrepAndBrepWithVoids : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeFacetedBrepAndBrepWithVoids {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeGeometricCurveSet;
 class TopoDSToStep_MakeGeometricCurveSet : public TopoDSToStep_Root {
 	public:
@@ -429,6 +469,11 @@ class TopoDSToStep_MakeGeometricCurveSet : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeGeometricCurveSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeManifoldSolidBrep;
 class TopoDSToStep_MakeManifoldSolidBrep : public TopoDSToStep_Root {
 	public:
@@ -455,6 +500,11 @@ class TopoDSToStep_MakeManifoldSolidBrep : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeManifoldSolidBrep {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeShellBasedSurfaceModel;
 class TopoDSToStep_MakeShellBasedSurfaceModel : public TopoDSToStep_Root {
 	public:
@@ -489,6 +539,11 @@ class TopoDSToStep_MakeShellBasedSurfaceModel : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeShellBasedSurfaceModel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeStepEdge;
 class TopoDSToStep_MakeStepEdge : public TopoDSToStep_Root {
 	public:
@@ -527,6 +582,11 @@ class TopoDSToStep_MakeStepEdge : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeStepEdge {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeStepFace;
 class TopoDSToStep_MakeStepFace : public TopoDSToStep_Root {
 	public:
@@ -565,6 +625,11 @@ class TopoDSToStep_MakeStepFace : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeStepFace {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeStepVertex;
 class TopoDSToStep_MakeStepVertex : public TopoDSToStep_Root {
 	public:
@@ -603,6 +668,11 @@ class TopoDSToStep_MakeStepVertex : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeStepVertex {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_MakeStepWire;
 class TopoDSToStep_MakeStepWire : public TopoDSToStep_Root {
 	public:
@@ -641,6 +711,11 @@ class TopoDSToStep_MakeStepWire : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_MakeStepWire {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor TopoDSToStep_WireframeBuilder;
 class TopoDSToStep_WireframeBuilder : public TopoDSToStep_Root {
 	public:
@@ -717,3 +792,8 @@ class TopoDSToStep_WireframeBuilder : public TopoDSToStep_Root {
 };
 
 
+%extend TopoDSToStep_WireframeBuilder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Units.i
+++ b/src/SWIG_files/wrapper/Units.i
@@ -178,6 +178,11 @@ class Units {
 };
 
 
+%extend Units {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Explorer;
 class Units_Explorer {
 	public:
@@ -304,6 +309,11 @@ class Units_Explorer {
 };
 
 
+%extend Units_Explorer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Lexicon;
 class Units_Lexicon : public MMgt_TShared {
 	public:
@@ -406,6 +416,11 @@ class Handle_Units_Lexicon : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_Lexicon {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Measurement;
 class Units_Measurement {
 	public:
@@ -572,6 +587,11 @@ class Units_Measurement {
 };
 
 
+%extend Units_Measurement {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_QtsSequence;
 class Units_QtsSequence : public TCollection_BaseSequence {
 	public:
@@ -710,6 +730,11 @@ class Units_QtsSequence : public TCollection_BaseSequence {
 };
 
 
+%extend Units_QtsSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_QuantitiesSequence;
 class Units_QuantitiesSequence : public MMgt_TShared {
 	public:
@@ -894,6 +919,11 @@ class Handle_Units_QuantitiesSequence : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_QuantitiesSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Sentence;
 class Units_Sentence {
 	public:
@@ -948,6 +978,11 @@ class Units_Sentence {
 };
 
 
+%extend Units_Sentence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_SequenceNodeOfQtsSequence;
 class Units_SequenceNodeOfQtsSequence : public TCollection_SeqNode {
 	public:
@@ -1014,6 +1049,11 @@ class Handle_Units_SequenceNodeOfQtsSequence : public Handle_TCollection_SeqNode
     }
 };
 
+%extend Units_SequenceNodeOfQtsSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_SequenceNodeOfTksSequence;
 class Units_SequenceNodeOfTksSequence : public TCollection_SeqNode {
 	public:
@@ -1080,6 +1120,11 @@ class Handle_Units_SequenceNodeOfTksSequence : public Handle_TCollection_SeqNode
     }
 };
 
+%extend Units_SequenceNodeOfTksSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_SequenceNodeOfUtsSequence;
 class Units_SequenceNodeOfUtsSequence : public TCollection_SeqNode {
 	public:
@@ -1146,6 +1191,11 @@ class Handle_Units_SequenceNodeOfUtsSequence : public Handle_TCollection_SeqNode
     }
 };
 
+%extend Units_SequenceNodeOfUtsSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_TksSequence;
 class Units_TksSequence : public TCollection_BaseSequence {
 	public:
@@ -1284,6 +1334,11 @@ class Units_TksSequence : public TCollection_BaseSequence {
 };
 
 
+%extend Units_TksSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Token;
 class Units_Token : public MMgt_TShared {
 	public:
@@ -1620,6 +1675,11 @@ class Handle_Units_Token : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_Token {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_TokensSequence;
 class Units_TokensSequence : public MMgt_TShared {
 	public:
@@ -1804,6 +1864,11 @@ class Handle_Units_TokensSequence : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_TokensSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_Unit;
 class Units_Unit : public MMgt_TShared {
 	public:
@@ -1960,6 +2025,11 @@ class Handle_Units_Unit : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_Unit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UnitsDictionary;
 class Units_UnitsDictionary : public MMgt_TShared {
 	public:
@@ -2062,6 +2132,11 @@ class Handle_Units_UnitsDictionary : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_UnitsDictionary {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UnitsSequence;
 class Units_UnitsSequence : public MMgt_TShared {
 	public:
@@ -2246,6 +2321,11 @@ class Handle_Units_UnitsSequence : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_UnitsSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UnitsSystem;
 class Units_UnitsSystem : public MMgt_TShared {
 	public:
@@ -2412,6 +2492,11 @@ class Handle_Units_UnitsSystem : public Handle_MMgt_TShared {
     }
 };
 
+%extend Units_UnitsSystem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UtsSequence;
 class Units_UtsSequence : public TCollection_BaseSequence {
 	public:
@@ -2550,6 +2635,11 @@ class Units_UtsSequence : public TCollection_BaseSequence {
 };
 
 
+%extend Units_UtsSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_MathSentence;
 class Units_MathSentence : public Units_Sentence {
 	public:
@@ -2564,6 +2654,11 @@ class Units_MathSentence : public Units_Sentence {
 };
 
 
+%extend Units_MathSentence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_ShiftedToken;
 class Units_ShiftedToken : public Units_Token {
 	public:
@@ -2674,6 +2769,11 @@ class Handle_Units_ShiftedToken : public Handle_Units_Token {
     }
 };
 
+%extend Units_ShiftedToken {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_ShiftedUnit;
 class Units_ShiftedUnit : public Units_Unit {
 	public:
@@ -2788,6 +2888,11 @@ class Handle_Units_ShiftedUnit : public Handle_Units_Unit {
     }
 };
 
+%extend Units_ShiftedUnit {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UnitSentence;
 class Units_UnitSentence : public Units_Sentence {
 	public:
@@ -2826,6 +2931,11 @@ class Units_UnitSentence : public Units_Sentence {
 };
 
 
+%extend Units_UnitSentence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Units_UnitsLexicon;
 class Units_UnitsLexicon : public Units_Lexicon {
 	public:
@@ -2914,3 +3024,8 @@ class Handle_Units_UnitsLexicon : public Handle_Units_Lexicon {
     }
 };
 
+%extend Units_UnitsLexicon {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/UnitsAPI.i
+++ b/src/SWIG_files/wrapper/UnitsAPI.i
@@ -330,3 +330,8 @@ class UnitsAPI {
 };
 
 
+%extend UnitsAPI {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/V3d.i
+++ b/src/SWIG_files/wrapper/V3d.i
@@ -283,6 +283,11 @@ class V3d {
 };
 
 
+%extend V3d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_CircularGrid;
 class V3d_CircularGrid : public Aspect_CircularGrid {
 	public:
@@ -381,6 +386,11 @@ class Handle_V3d_CircularGrid : public Handle_Aspect_CircularGrid {
     }
 };
 
+%extend V3d_CircularGrid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_ColorScale;
 class V3d_ColorScale : public Aspect_ColorScale {
 	public:
@@ -511,6 +521,11 @@ class Handle_V3d_ColorScale : public Handle_Aspect_ColorScale {
     }
 };
 
+%extend V3d_ColorScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_ColorScaleLayerItem;
 class V3d_ColorScaleLayerItem : public Visual3d_LayerItem {
 	public:
@@ -583,6 +598,11 @@ class Handle_V3d_ColorScaleLayerItem : public Handle_Visual3d_LayerItem {
     }
 };
 
+%extend V3d_ColorScaleLayerItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_LayerMgr;
 class V3d_LayerMgr : public MMgt_TShared {
 	public:
@@ -675,6 +695,11 @@ class Handle_V3d_LayerMgr : public Handle_MMgt_TShared {
     }
 };
 
+%extend V3d_LayerMgr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_Light;
 class V3d_Light : public MMgt_TShared {
 	public:
@@ -811,6 +836,11 @@ class Handle_V3d_Light : public Handle_MMgt_TShared {
     }
 };
 
+%extend V3d_Light {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_ListOfTransient;
 class V3d_ListOfTransient : public TColStd_ListOfTransient {
 	public:
@@ -833,6 +863,11 @@ class V3d_ListOfTransient : public TColStd_ListOfTransient {
 };
 
 
+%extend V3d_ListOfTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_Plane;
 class V3d_Plane : public MMgt_TShared {
 	public:
@@ -955,6 +990,11 @@ class Handle_V3d_Plane : public Handle_MMgt_TShared {
     }
 };
 
+%extend V3d_Plane {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_RectangularGrid;
 class V3d_RectangularGrid : public Aspect_RectangularGrid {
 	public:
@@ -1057,6 +1097,11 @@ class Handle_V3d_RectangularGrid : public Handle_Aspect_RectangularGrid {
     }
 };
 
+%extend V3d_RectangularGrid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_View;
 class V3d_View : public MMgt_TShared {
 	public:
@@ -2893,6 +2938,11 @@ class Handle_V3d_View : public Handle_MMgt_TShared {
     }
 };
 
+%extend V3d_View {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_Viewer;
 class V3d_Viewer : public MMgt_TShared {
 	public:
@@ -3707,6 +3757,11 @@ class Handle_V3d_Viewer : public Handle_MMgt_TShared {
     }
 };
 
+%extend V3d_Viewer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_AmbientLight;
 class V3d_AmbientLight : public V3d_Light {
 	public:
@@ -3769,6 +3824,11 @@ class Handle_V3d_AmbientLight : public Handle_V3d_Light {
     }
 };
 
+%extend V3d_AmbientLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_PositionLight;
 class V3d_PositionLight : public V3d_Light {
 	public:
@@ -3937,6 +3997,11 @@ class Handle_V3d_PositionLight : public Handle_V3d_Light {
     }
 };
 
+%extend V3d_PositionLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_DirectionalLight;
 class V3d_DirectionalLight : public V3d_PositionLight {
 	public:
@@ -4117,6 +4182,11 @@ class Handle_V3d_DirectionalLight : public Handle_V3d_PositionLight {
     }
 };
 
+%extend V3d_DirectionalLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_PositionalLight;
 class V3d_PositionalLight : public V3d_PositionLight {
 	public:
@@ -4269,6 +4339,11 @@ class Handle_V3d_PositionalLight : public Handle_V3d_PositionLight {
     }
 };
 
+%extend V3d_PositionalLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor V3d_SpotLight;
 class V3d_SpotLight : public V3d_PositionLight {
 	public:
@@ -4489,3 +4564,8 @@ class Handle_V3d_SpotLight : public Handle_V3d_PositionLight {
     }
 };
 
+%extend V3d_SpotLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/Visual3d.i
+++ b/src/SWIG_files/wrapper/Visual3d.i
@@ -173,6 +173,11 @@ class Visual3d_ContextPick {
 };
 
 
+%extend Visual3d_ContextPick {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_ContextView;
 class Visual3d_ContextView {
 	public:
@@ -423,6 +428,11 @@ class Visual3d_ContextView {
 };
 
 
+%extend Visual3d_ContextView {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_HSequenceOfLight;
 class Visual3d_HSequenceOfLight : public MMgt_TShared {
 	public:
@@ -607,6 +617,11 @@ class Handle_Visual3d_HSequenceOfLight : public Handle_MMgt_TShared {
     }
 };
 
+%extend Visual3d_HSequenceOfLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_HSequenceOfView;
 class Visual3d_HSequenceOfView : public MMgt_TShared {
 	public:
@@ -791,6 +806,11 @@ class Handle_Visual3d_HSequenceOfView : public Handle_MMgt_TShared {
     }
 };
 
+%extend Visual3d_HSequenceOfView {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_Layer;
 class Visual3d_Layer : public MMgt_TShared {
 	public:
@@ -1045,6 +1065,11 @@ class Handle_Visual3d_Layer : public Handle_MMgt_TShared {
     }
 };
 
+%extend Visual3d_Layer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_LayerItem;
 class Visual3d_LayerItem : public MMgt_TShared {
 	public:
@@ -1125,6 +1150,11 @@ class Handle_Visual3d_LayerItem : public Handle_MMgt_TShared {
     }
 };
 
+%extend Visual3d_LayerItem {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_Light;
 class Visual3d_Light : public MMgt_TShared {
 	public:
@@ -1377,6 +1407,11 @@ class Handle_Visual3d_Light : public Handle_MMgt_TShared {
     }
 };
 
+%extend Visual3d_Light {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_SequenceNodeOfSequenceOfLight;
 class Visual3d_SequenceNodeOfSequenceOfLight : public TCollection_SeqNode {
 	public:
@@ -1443,6 +1478,11 @@ class Handle_Visual3d_SequenceNodeOfSequenceOfLight : public Handle_TCollection_
     }
 };
 
+%extend Visual3d_SequenceNodeOfSequenceOfLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_SequenceNodeOfSequenceOfView;
 class Visual3d_SequenceNodeOfSequenceOfView : public TCollection_SeqNode {
 	public:
@@ -1509,6 +1549,11 @@ class Handle_Visual3d_SequenceNodeOfSequenceOfView : public Handle_TCollection_S
     }
 };
 
+%extend Visual3d_SequenceNodeOfSequenceOfView {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_SequenceOfLight;
 class Visual3d_SequenceOfLight : public TCollection_BaseSequence {
 	public:
@@ -1647,6 +1692,11 @@ class Visual3d_SequenceOfLight : public TCollection_BaseSequence {
 };
 
 
+%extend Visual3d_SequenceOfLight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_SequenceOfView;
 class Visual3d_SequenceOfView : public TCollection_BaseSequence {
 	public:
@@ -1785,6 +1835,11 @@ class Visual3d_SequenceOfView : public TCollection_BaseSequence {
 };
 
 
+%extend Visual3d_SequenceOfView {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_View;
 class Visual3d_View : public Graphic3d_DataStructureManager {
 	public:
@@ -2697,6 +2752,11 @@ class Handle_Visual3d_View : public Handle_Graphic3d_DataStructureManager {
     }
 };
 
+%extend Visual3d_View {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor Visual3d_ViewManager;
 class Visual3d_ViewManager : public Graphic3d_StructureManager {
 	public:
@@ -3077,3 +3137,8 @@ class Handle_Visual3d_ViewManager : public Handle_Graphic3d_StructureManager {
     }
 };
 
+%extend Visual3d_ViewManager {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/XBRepMesh.i
+++ b/src/SWIG_files/wrapper/XBRepMesh.i
@@ -74,3 +74,8 @@ class XBRepMesh {
 };
 
 
+%extend XBRepMesh {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/XCAFApp.i
+++ b/src/SWIG_files/wrapper/XCAFApp.i
@@ -134,3 +134,8 @@ class Handle_XCAFApp_Application : public Handle_TDocStd_Application {
     }
 };
 
+%extend XCAFApp_Application {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/XCAFDoc.i
+++ b/src/SWIG_files/wrapper/XCAFDoc.i
@@ -130,6 +130,11 @@ class XCAFDoc {
 };
 
 
+%extend XCAFDoc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Area;
 class XCAFDoc_Area : public TDF_Attribute {
 	public:
@@ -254,6 +259,11 @@ class Handle_XCAFDoc_Area : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Area {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Centroid;
 class XCAFDoc_Centroid : public TDF_Attribute {
 	public:
@@ -376,6 +386,11 @@ class Handle_XCAFDoc_Centroid : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Centroid {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Color;
 class XCAFDoc_Color : public TDF_Attribute {
 	public:
@@ -530,6 +545,11 @@ class Handle_XCAFDoc_Color : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Color {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_ColorTool;
 class XCAFDoc_ColorTool : public TDF_Attribute {
 	public:
@@ -886,6 +906,11 @@ class Handle_XCAFDoc_ColorTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_ColorTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DataMapIteratorOfDataMapOfShapeLabel;
 class XCAFDoc_DataMapIteratorOfDataMapOfShapeLabel : public TCollection_BasicMapIterator {
 	public:
@@ -916,6 +941,11 @@ class XCAFDoc_DataMapIteratorOfDataMapOfShapeLabel : public TCollection_BasicMap
 };
 
 
+%extend XCAFDoc_DataMapIteratorOfDataMapOfShapeLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DataMapNodeOfDataMapOfShapeLabel;
 class XCAFDoc_DataMapNodeOfDataMapOfShapeLabel : public TCollection_MapNode {
 	public:
@@ -986,6 +1016,11 @@ class Handle_XCAFDoc_DataMapNodeOfDataMapOfShapeLabel : public Handle_TCollectio
     }
 };
 
+%extend XCAFDoc_DataMapNodeOfDataMapOfShapeLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DataMapOfShapeLabel;
 class XCAFDoc_DataMapOfShapeLabel : public TCollection_BasicMap {
 	public:
@@ -1064,6 +1099,11 @@ class XCAFDoc_DataMapOfShapeLabel : public TCollection_BasicMap {
 };
 
 
+%extend XCAFDoc_DataMapOfShapeLabel {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Datum;
 class XCAFDoc_Datum : public TDF_Attribute {
 	public:
@@ -1180,6 +1220,11 @@ class Handle_XCAFDoc_Datum : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Datum {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DimTol;
 class XCAFDoc_DimTol : public TDF_Attribute {
 	public:
@@ -1304,6 +1349,11 @@ class Handle_XCAFDoc_DimTol : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_DimTol {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DimTolTool;
 class XCAFDoc_DimTolTool : public TDF_Attribute {
 	public:
@@ -1620,6 +1670,11 @@ class Handle_XCAFDoc_DimTolTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_DimTolTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_DocumentTool;
 class XCAFDoc_DocumentTool : public TDF_Attribute {
 	public:
@@ -1818,6 +1873,11 @@ class Handle_XCAFDoc_DocumentTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_DocumentTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_GraphNode;
 class XCAFDoc_GraphNode : public TDF_Attribute {
 	public:
@@ -2064,6 +2124,11 @@ class Handle_XCAFDoc_GraphNode : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_GraphNode {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_GraphNodeSequence;
 class XCAFDoc_GraphNodeSequence : public TCollection_BaseSequence {
 	public:
@@ -2202,6 +2267,11 @@ class XCAFDoc_GraphNodeSequence : public TCollection_BaseSequence {
 };
 
 
+%extend XCAFDoc_GraphNodeSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_LayerTool;
 class XCAFDoc_LayerTool : public TDF_Attribute {
 	public:
@@ -2592,6 +2662,11 @@ class Handle_XCAFDoc_LayerTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_LayerTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Location;
 class XCAFDoc_Location : public TDF_Attribute {
 	public:
@@ -2698,6 +2773,11 @@ class Handle_XCAFDoc_Location : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Location {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Material;
 class XCAFDoc_Material : public TDF_Attribute {
 	public:
@@ -2830,6 +2910,11 @@ class Handle_XCAFDoc_Material : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Material {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_MaterialTool;
 class XCAFDoc_MaterialTool : public TDF_Attribute {
 	public:
@@ -3018,6 +3103,11 @@ class Handle_XCAFDoc_MaterialTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_MaterialTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_SequenceNodeOfGraphNodeSequence;
 class XCAFDoc_SequenceNodeOfGraphNodeSequence : public TCollection_SeqNode {
 	public:
@@ -3084,6 +3174,11 @@ class Handle_XCAFDoc_SequenceNodeOfGraphNodeSequence : public Handle_TCollection
     }
 };
 
+%extend XCAFDoc_SequenceNodeOfGraphNodeSequence {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_ShapeMapTool;
 class XCAFDoc_ShapeMapTool : public TDF_Attribute {
 	public:
@@ -3196,6 +3291,11 @@ class Handle_XCAFDoc_ShapeMapTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_ShapeMapTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_ShapeTool;
 class XCAFDoc_ShapeTool : public TDF_Attribute {
 	public:
@@ -3832,6 +3932,11 @@ class Handle_XCAFDoc_ShapeTool : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_ShapeTool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFDoc_Volume;
 class XCAFDoc_Volume : public TDF_Attribute {
 	public:
@@ -3956,3 +4061,8 @@ class Handle_XCAFDoc_Volume : public Handle_TDF_Attribute {
     }
 };
 
+%extend XCAFDoc_Volume {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/XCAFPrs.i
+++ b/src/SWIG_files/wrapper/XCAFPrs.i
@@ -104,6 +104,11 @@ class XCAFPrs {
 };
 
 
+%extend XCAFPrs {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_AISObject;
 class XCAFPrs_AISObject : public AIS_ColoredShape {
 	public:
@@ -164,6 +169,11 @@ class Handle_XCAFPrs_AISObject : public Handle_AIS_ColoredShape {
     }
 };
 
+%extend XCAFPrs_AISObject {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapIteratorOfDataMapOfShapeStyle;
 class XCAFPrs_DataMapIteratorOfDataMapOfShapeStyle : public TCollection_BasicMapIterator {
 	public:
@@ -194,6 +204,11 @@ class XCAFPrs_DataMapIteratorOfDataMapOfShapeStyle : public TCollection_BasicMap
 };
 
 
+%extend XCAFPrs_DataMapIteratorOfDataMapOfShapeStyle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapIteratorOfDataMapOfStyleShape;
 class XCAFPrs_DataMapIteratorOfDataMapOfStyleShape : public TCollection_BasicMapIterator {
 	public:
@@ -224,6 +239,11 @@ class XCAFPrs_DataMapIteratorOfDataMapOfStyleShape : public TCollection_BasicMap
 };
 
 
+%extend XCAFPrs_DataMapIteratorOfDataMapOfStyleShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapIteratorOfDataMapOfStyleTransient;
 class XCAFPrs_DataMapIteratorOfDataMapOfStyleTransient : public TCollection_BasicMapIterator {
 	public:
@@ -254,6 +274,11 @@ class XCAFPrs_DataMapIteratorOfDataMapOfStyleTransient : public TCollection_Basi
 };
 
 
+%extend XCAFPrs_DataMapIteratorOfDataMapOfStyleTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapNodeOfDataMapOfShapeStyle;
 class XCAFPrs_DataMapNodeOfDataMapOfShapeStyle : public TCollection_MapNode {
 	public:
@@ -324,6 +349,11 @@ class Handle_XCAFPrs_DataMapNodeOfDataMapOfShapeStyle : public Handle_TCollectio
     }
 };
 
+%extend XCAFPrs_DataMapNodeOfDataMapOfShapeStyle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapNodeOfDataMapOfStyleShape;
 class XCAFPrs_DataMapNodeOfDataMapOfStyleShape : public TCollection_MapNode {
 	public:
@@ -394,6 +424,11 @@ class Handle_XCAFPrs_DataMapNodeOfDataMapOfStyleShape : public Handle_TCollectio
     }
 };
 
+%extend XCAFPrs_DataMapNodeOfDataMapOfStyleShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapNodeOfDataMapOfStyleTransient;
 class XCAFPrs_DataMapNodeOfDataMapOfStyleTransient : public TCollection_MapNode {
 	public:
@@ -464,6 +499,11 @@ class Handle_XCAFPrs_DataMapNodeOfDataMapOfStyleTransient : public Handle_TColle
     }
 };
 
+%extend XCAFPrs_DataMapNodeOfDataMapOfStyleTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapOfShapeStyle;
 class XCAFPrs_DataMapOfShapeStyle : public TCollection_BasicMap {
 	public:
@@ -542,6 +582,11 @@ class XCAFPrs_DataMapOfShapeStyle : public TCollection_BasicMap {
 };
 
 
+%extend XCAFPrs_DataMapOfShapeStyle {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapOfStyleShape;
 class XCAFPrs_DataMapOfStyleShape : public TCollection_BasicMap {
 	public:
@@ -620,6 +665,11 @@ class XCAFPrs_DataMapOfStyleShape : public TCollection_BasicMap {
 };
 
 
+%extend XCAFPrs_DataMapOfStyleShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_DataMapOfStyleTransient;
 class XCAFPrs_DataMapOfStyleTransient : public TCollection_BasicMap {
 	public:
@@ -698,6 +748,11 @@ class XCAFPrs_DataMapOfStyleTransient : public TCollection_BasicMap {
 };
 
 
+%extend XCAFPrs_DataMapOfStyleTransient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_Driver;
 class XCAFPrs_Driver : public TPrsStd_Driver {
 	public:
@@ -764,6 +819,11 @@ class Handle_XCAFPrs_Driver : public Handle_TPrsStd_Driver {
     }
 };
 
+%extend XCAFPrs_Driver {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XCAFPrs_Style;
 class XCAFPrs_Style {
 	public:
@@ -868,3 +928,8 @@ class XCAFPrs_Style {
 };
 
 
+%extend XCAFPrs_Style {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/XSControl.i
+++ b/src/SWIG_files/wrapper/XSControl.i
@@ -78,6 +78,11 @@ class XSControl {
 };
 
 
+%extend XSControl {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_ConnectedShapes;
 class XSControl_ConnectedShapes : public IFSelect_SelectExplore {
 	public:
@@ -184,6 +189,11 @@ class Handle_XSControl_ConnectedShapes : public Handle_IFSelect_SelectExplore {
     }
 };
 
+%extend XSControl_ConnectedShapes {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_Controller;
 class XSControl_Controller : public MMgt_TShared {
 	public:
@@ -580,6 +590,11 @@ class Handle_XSControl_Controller : public Handle_MMgt_TShared {
     }
 };
 
+%extend XSControl_Controller {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class XSControl_FuncShape {
 	public:
 		%feature("compactdefaultargs") Init;
@@ -621,6 +636,11 @@ class XSControl_FuncShape {
 };
 
 
+%extend XSControl_FuncShape {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class XSControl_Functions {
 	public:
 		%feature("compactdefaultargs") Init;
@@ -632,6 +652,11 @@ class XSControl_Functions {
 };
 
 
+%extend XSControl_Functions {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_Reader;
 class XSControl_Reader {
 	public:
@@ -842,6 +867,11 @@ class XSControl_Reader {
 };
 
 
+%extend XSControl_Reader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_SelectForTransfer;
 class XSControl_SelectForTransfer : public IFSelect_SelectExtract {
 	public:
@@ -954,6 +984,11 @@ class Handle_XSControl_SelectForTransfer : public Handle_IFSelect_SelectExtract 
     }
 };
 
+%extend XSControl_SelectForTransfer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_SignTransferStatus;
 class XSControl_SignTransferStatus : public IFSelect_Signature {
 	public:
@@ -1058,6 +1093,11 @@ class Handle_XSControl_SignTransferStatus : public Handle_IFSelect_Signature {
     }
 };
 
+%extend XSControl_SignTransferStatus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_TransferReader;
 class XSControl_TransferReader : public MMgt_TShared {
 	public:
@@ -1508,6 +1548,11 @@ class Handle_XSControl_TransferReader : public Handle_MMgt_TShared {
     }
 };
 
+%extend XSControl_TransferReader {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_TransferWriter;
 class XSControl_TransferWriter : public MMgt_TShared {
 	public:
@@ -1688,6 +1733,11 @@ class Handle_XSControl_TransferWriter : public Handle_MMgt_TShared {
     }
 };
 
+%extend XSControl_TransferWriter {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_Utils;
 class XSControl_Utils {
 	public:
@@ -2026,6 +2076,11 @@ class XSControl_Utils {
 };
 
 
+%extend XSControl_Utils {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_WorkSession;
 class XSControl_WorkSession : public IFSelect_WorkSession {
 	public:
@@ -2304,6 +2359,11 @@ class Handle_XSControl_WorkSession : public Handle_IFSelect_WorkSession {
     }
 };
 
+%extend XSControl_WorkSession {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor XSControl_Writer;
 class XSControl_Writer {
 	public:
@@ -2394,3 +2454,8 @@ class XSControl_Writer {
 };
 
 
+%extend XSControl_Writer {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/gce.i
+++ b/src/SWIG_files/wrapper/gce.i
@@ -137,6 +137,11 @@ class gce_MakeMirror {
 };
 
 
+%extend gce_MakeMirror {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeMirror2d;
 class gce_MakeMirror2d {
 	public:
@@ -185,6 +190,11 @@ class gce_MakeMirror2d {
 };
 
 
+%extend gce_MakeMirror2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeRotation;
 class gce_MakeRotation {
 	public:
@@ -237,6 +247,11 @@ class gce_MakeRotation {
 };
 
 
+%extend gce_MakeRotation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeRotation2d;
 class gce_MakeRotation2d {
 	public:
@@ -267,6 +282,11 @@ class gce_MakeRotation2d {
 };
 
 
+%extend gce_MakeRotation2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeScale;
 class gce_MakeScale {
 	public:
@@ -297,6 +317,11 @@ class gce_MakeScale {
 };
 
 
+%extend gce_MakeScale {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeScale2d;
 class gce_MakeScale2d {
 	public:
@@ -327,6 +352,11 @@ class gce_MakeScale2d {
 };
 
 
+%extend gce_MakeScale2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeTranslation;
 class gce_MakeTranslation {
 	public:
@@ -365,6 +395,11 @@ class gce_MakeTranslation {
 };
 
 
+%extend gce_MakeTranslation {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeTranslation2d;
 class gce_MakeTranslation2d {
 	public:
@@ -403,6 +438,11 @@ class gce_MakeTranslation2d {
 };
 
 
+%extend gce_MakeTranslation2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class gce_Root {
 	public:
 		%feature("compactdefaultargs") IsDone;
@@ -420,6 +460,11 @@ class gce_Root {
 };
 
 
+%extend gce_Root {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeCirc;
 class gce_MakeCirc : public gce_Root {
 	public:
@@ -528,6 +573,11 @@ class gce_MakeCirc : public gce_Root {
 };
 
 
+%extend gce_MakeCirc {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeCirc2d;
 class gce_MakeCirc2d : public gce_Root {
 	public:
@@ -626,6 +676,11 @@ class gce_MakeCirc2d : public gce_Root {
 };
 
 
+%extend gce_MakeCirc2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeCone;
 class gce_MakeCone : public gce_Root {
 	public:
@@ -730,6 +785,11 @@ class gce_MakeCone : public gce_Root {
 };
 
 
+%extend gce_MakeCone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeCylinder;
 class gce_MakeCylinder : public gce_Root {
 	public:
@@ -810,6 +870,11 @@ class gce_MakeCylinder : public gce_Root {
 };
 
 
+%extend gce_MakeCylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeDir;
 class gce_MakeDir : public gce_Root {
 	public:
@@ -868,6 +933,11 @@ class gce_MakeDir : public gce_Root {
 };
 
 
+%extend gce_MakeDir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeDir2d;
 class gce_MakeDir2d : public gce_Root {
 	public:
@@ -924,6 +994,11 @@ class gce_MakeDir2d : public gce_Root {
 };
 
 
+%extend gce_MakeDir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeElips;
 class gce_MakeElips : public gce_Root {
 	public:
@@ -968,6 +1043,11 @@ class gce_MakeElips : public gce_Root {
 };
 
 
+%extend gce_MakeElips {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeElips2d;
 class gce_MakeElips2d : public gce_Root {
 	public:
@@ -1026,6 +1106,11 @@ class gce_MakeElips2d : public gce_Root {
 };
 
 
+%extend gce_MakeElips2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeHypr;
 class gce_MakeHypr : public gce_Root {
 	public:
@@ -1070,6 +1155,11 @@ class gce_MakeHypr : public gce_Root {
 };
 
 
+%extend gce_MakeHypr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeHypr2d;
 class gce_MakeHypr2d : public gce_Root {
 	public:
@@ -1128,6 +1218,11 @@ class gce_MakeHypr2d : public gce_Root {
 };
 
 
+%extend gce_MakeHypr2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeLin;
 class gce_MakeLin : public gce_Root {
 	public:
@@ -1186,6 +1281,11 @@ class gce_MakeLin : public gce_Root {
 };
 
 
+%extend gce_MakeLin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeLin2d;
 class gce_MakeLin2d : public gce_Root {
 	public:
@@ -1266,6 +1366,11 @@ class gce_MakeLin2d : public gce_Root {
 };
 
 
+%extend gce_MakeLin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeParab;
 class gce_MakeParab : public gce_Root {
 	public:
@@ -1306,6 +1411,11 @@ class gce_MakeParab : public gce_Root {
 };
 
 
+%extend gce_MakeParab {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakeParab2d;
 class gce_MakeParab2d : public gce_Root {
 	public:
@@ -1382,6 +1492,11 @@ class gce_MakeParab2d : public gce_Root {
 };
 
 
+%extend gce_MakeParab2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gce_MakePln;
 class gce_MakePln : public gce_Root {
 	public:
@@ -1484,3 +1599,8 @@ class gce_MakePln : public gce_Root {
 };
 
 
+%extend gce_MakePln {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/gp.i
+++ b/src/SWIG_files/wrapper/gp.i
@@ -199,6 +199,11 @@ class gp {
 };
 
 
+%extend gp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Ax1;
 class gp_Ax1 {
 	public:
@@ -459,6 +464,11 @@ class gp_Ax1 {
 };
 
 
+%extend gp_Ax1 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Ax2;
 class gp_Ax2 {
 	public:
@@ -735,6 +745,11 @@ class gp_Ax2 {
 };
 
 
+%extend gp_Ax2 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Ax22d;
 class gp_Ax22d {
 	public:
@@ -981,6 +996,11 @@ class gp_Ax22d {
 };
 
 
+%extend gp_Ax22d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Ax2d;
 class gp_Ax2d {
 	public:
@@ -1211,6 +1231,11 @@ class gp_Ax2d {
 };
 
 
+%extend gp_Ax2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Ax3;
 class gp_Ax3 {
 	public:
@@ -1521,6 +1546,11 @@ class gp_Ax3 {
 };
 
 
+%extend gp_Ax3 {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Circ;
 class gp_Circ {
 	public:
@@ -1787,6 +1817,11 @@ class gp_Circ {
 };
 
 
+%extend gp_Circ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Circ2d;
 class gp_Circ2d {
 	public:
@@ -2095,6 +2130,11 @@ class gp_Circ2d {
 };
 
 
+%extend gp_Circ2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Cone;
 class gp_Cone {
 	public:
@@ -2399,6 +2439,11 @@ class gp_Cone {
 };
 
 
+%extend gp_Cone {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Cylinder;
 class gp_Cylinder {
 	public:
@@ -2671,6 +2716,11 @@ class gp_Cylinder {
 };
 
 
+%extend gp_Cylinder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Dir;
 class gp_Dir {
 	public:
@@ -3029,6 +3079,11 @@ class gp_Dir {
 };
 
 
+%extend gp_Dir {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Dir2d;
 class gp_Dir2d {
 	public:
@@ -3297,6 +3352,11 @@ class gp_Dir2d {
 };
 
 
+%extend gp_Dir2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Elips;
 class gp_Elips {
 	public:
@@ -3599,6 +3659,11 @@ class gp_Elips {
 };
 
 
+%extend gp_Elips {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Elips2d;
 class gp_Elips2d {
 	public:
@@ -3933,6 +3998,11 @@ class gp_Elips2d {
 };
 
 
+%extend gp_Elips2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_GTrsf;
 class gp_GTrsf {
 	public:
@@ -4163,6 +4233,11 @@ class gp_GTrsf {
 };
 
 
+%extend gp_GTrsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_GTrsf2d;
 class gp_GTrsf2d {
 	public:
@@ -4393,6 +4468,11 @@ class gp_GTrsf2d {
 };
 
 
+%extend gp_GTrsf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Hypr;
 class gp_Hypr {
 	public:
@@ -4719,6 +4799,11 @@ class gp_Hypr {
 };
 
 
+%extend gp_Hypr {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Hypr2d;
 class gp_Hypr2d {
 	public:
@@ -5081,6 +5166,11 @@ class gp_Hypr2d {
 };
 
 
+%extend gp_Hypr2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Lin;
 class gp_Lin {
 	public:
@@ -5349,6 +5439,11 @@ class gp_Lin {
 };
 
 
+%extend gp_Lin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Lin2d;
 class gp_Lin2d {
 	public:
@@ -5627,6 +5722,11 @@ class gp_Lin2d {
 };
 
 
+%extend gp_Lin2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Mat;
 class gp_Mat {
 	public:
@@ -6015,6 +6115,11 @@ class gp_Mat {
 };
 
 
+%extend gp_Mat {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Mat2d;
 class gp_Mat2d {
 	public:
@@ -6349,6 +6454,11 @@ class gp_Mat2d {
 };
 
 
+%extend gp_Mat2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Parab;
 class gp_Parab {
 	public:
@@ -6605,6 +6715,11 @@ class gp_Parab {
 };
 
 
+%extend gp_Parab {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Parab2d;
 class gp_Parab2d {
 	public:
@@ -6893,6 +7008,11 @@ class gp_Parab2d {
 };
 
 
+%extend gp_Parab2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Pln;
 class gp_Pln {
 	public:
@@ -7221,6 +7341,11 @@ class gp_Pln {
 };
 
 
+%extend gp_Pln {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Pnt;
 class gp_Pnt {
 	public:
@@ -7529,6 +7654,11 @@ class gp_Pnt {
 };
 
 
+%extend gp_Pnt {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Pnt2d;
 class gp_Pnt2d {
 	public:
@@ -7791,6 +7921,11 @@ class gp_Pnt2d {
 };
 
 
+%extend gp_Pnt2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Quaternion;
 class gp_Quaternion {
 	public:
@@ -8201,6 +8336,11 @@ class gp_Quaternion {
 };
 
 
+%extend gp_Quaternion {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_QuaternionNLerp;
 class gp_QuaternionNLerp {
 	public:
@@ -8255,6 +8395,11 @@ class gp_QuaternionNLerp {
 };
 
 
+%extend gp_QuaternionNLerp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_QuaternionSLerp;
 class gp_QuaternionSLerp {
 	public:
@@ -8299,6 +8444,11 @@ class gp_QuaternionSLerp {
 };
 
 
+%extend gp_QuaternionSLerp {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Sphere;
 class gp_Sphere {
 	public:
@@ -8569,6 +8719,11 @@ class gp_Sphere {
 };
 
 
+%extend gp_Sphere {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Torus;
 class gp_Torus {
 	public:
@@ -8853,6 +9008,11 @@ class gp_Torus {
 };
 
 
+%extend gp_Torus {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Trsf;
 class gp_Trsf {
 	public:
@@ -9193,6 +9353,11 @@ class gp_Trsf {
 };
 
 
+%extend gp_Trsf {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Trsf2d;
 class gp_Trsf2d {
 	public:
@@ -9473,6 +9638,11 @@ class gp_Trsf2d {
 };
 
 
+%extend gp_Trsf2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Vec;
 class gp_Vec {
 	public:
@@ -10087,6 +10257,11 @@ class gp_Vec {
 };
 
 
+%extend gp_Vec {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_Vec2d;
 class gp_Vec2d {
 	public:
@@ -10579,6 +10754,11 @@ class gp_Vec2d {
 };
 
 
+%extend gp_Vec2d {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_XY;
 class gp_XY {
 	public:
@@ -11001,6 +11181,11 @@ class gp_XY {
 };
 
 
+%extend gp_XY {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor gp_XYZ;
 class gp_XYZ {
 	public:
@@ -11529,3 +11714,8 @@ class gp_XYZ {
 };
 
 
+%extend gp_XYZ {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/src/SWIG_files/wrapper/math.i
+++ b/src/SWIG_files/wrapper/math.i
@@ -120,6 +120,11 @@ class math {
 };
 
 
+%extend math {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Array1OfValueAndWeight;
 class math_Array1OfValueAndWeight {
 	public:
@@ -202,6 +207,11 @@ class math_Array1OfValueAndWeight {
 };
 
 
+%extend math_Array1OfValueAndWeight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BFGS;
 class math_BFGS {
 	public:
@@ -314,6 +324,11 @@ class math_BFGS {
         };
 
 
+%extend math_BFGS {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BissecNewton;
 class math_BissecNewton {
 	public:
@@ -376,6 +391,11 @@ class math_BissecNewton {
         };
 
 
+%extend math_BissecNewton {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BracketMinimum;
 class math_BracketMinimum {
 	public:
@@ -462,6 +482,11 @@ class math_BracketMinimum {
         };
 
 
+%extend math_BracketMinimum {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BracketedRoot;
 class math_BracketedRoot {
 	public:
@@ -518,6 +543,11 @@ class math_BracketedRoot {
         };
 
 
+%extend math_BracketedRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BrentMinimum;
 class math_BrentMinimum {
 	public:
@@ -624,6 +654,11 @@ class math_BrentMinimum {
         };
 
 
+%extend math_BrentMinimum {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_BullardGenerator;
 class math_BullardGenerator {
 	public:
@@ -650,6 +685,11 @@ class math_BullardGenerator {
 };
 
 
+%extend math_BullardGenerator {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_CompareOfValueAndWeight;
 class math_CompareOfValueAndWeight {
 	public:
@@ -690,6 +730,11 @@ class math_CompareOfValueAndWeight {
 };
 
 
+%extend math_CompareOfValueAndWeight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_ComputeGaussPointsAndWeights;
 class math_ComputeGaussPointsAndWeights {
 	public:
@@ -714,6 +759,11 @@ class math_ComputeGaussPointsAndWeights {
 };
 
 
+%extend math_ComputeGaussPointsAndWeights {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_ComputeKronrodPointsAndWeights;
 class math_ComputeKronrodPointsAndWeights {
 	public:
@@ -738,6 +788,11 @@ class math_ComputeKronrodPointsAndWeights {
 };
 
 
+%extend math_ComputeKronrodPointsAndWeights {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Crout;
 class math_Crout {
 	public:
@@ -798,6 +853,11 @@ class math_Crout {
         };
 
 
+%extend math_Crout {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_DirectPolynomialRoots;
 class math_DirectPolynomialRoots {
 	public:
@@ -890,6 +950,11 @@ class math_DirectPolynomialRoots {
         };
 
 
+%extend math_DirectPolynomialRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_DoubleTab;
 class math_DoubleTab {
 	public:
@@ -964,6 +1029,11 @@ class math_DoubleTab {
 };
 
 
+%extend math_DoubleTab {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_EigenValuesSearcher;
 class math_EigenValuesSearcher {
 	public:
@@ -1006,6 +1076,11 @@ class math_EigenValuesSearcher {
 };
 
 
+%extend math_EigenValuesSearcher {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FRPR;
 class math_FRPR {
 	public:
@@ -1118,6 +1193,11 @@ class math_FRPR {
         };
 
 
+%extend math_FRPR {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Function;
 class math_Function {
 	public:
@@ -1140,6 +1220,11 @@ class math_Function {
 };
 
 
+%extend math_Function {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionAllRoots;
 class math_FunctionAllRoots {
 	public:
@@ -1228,6 +1313,11 @@ class math_FunctionAllRoots {
         };
 
 
+%extend math_FunctionAllRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionRoot;
 class math_FunctionRoot {
 	public:
@@ -1304,6 +1394,11 @@ class math_FunctionRoot {
         };
 
 
+%extend math_FunctionRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionRoots;
 class math_FunctionRoots {
 	public:
@@ -1374,6 +1469,11 @@ class math_FunctionRoots {
         };
 
 
+%extend math_FunctionRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionSample;
 class math_FunctionSample {
 	public:
@@ -1414,6 +1514,11 @@ class math_FunctionSample {
 };
 
 
+%extend math_FunctionSample {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionSet;
 class math_FunctionSet {
 	public:
@@ -1452,6 +1557,11 @@ class math_FunctionSet {
 };
 
 
+%extend math_FunctionSet {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionSetRoot;
 class math_FunctionSetRoot {
 	public:
@@ -1622,6 +1732,11 @@ class math_FunctionSetRoot {
 };
 
 
+%extend math_FunctionSetRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Gauss;
 class math_Gauss {
 	public:
@@ -1684,6 +1799,11 @@ class math_Gauss {
         };
 
 
+%extend math_Gauss {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_GaussLeastSquare;
 class math_GaussLeastSquare {
 	public:
@@ -1724,6 +1844,11 @@ class math_GaussLeastSquare {
         };
 
 
+%extend math_GaussLeastSquare {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_GaussMultipleIntegration;
 class math_GaussMultipleIntegration {
 	public:
@@ -1764,6 +1889,11 @@ class math_GaussMultipleIntegration {
         };
 
 
+%extend math_GaussMultipleIntegration {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_GaussSetIntegration;
 class math_GaussSetIntegration {
 	public:
@@ -1804,6 +1934,11 @@ class math_GaussSetIntegration {
         };
 
 
+%extend math_GaussSetIntegration {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_GaussSingleIntegration;
 class math_GaussSingleIntegration {
 	public:
@@ -1864,6 +1999,11 @@ class math_GaussSingleIntegration {
         };
 
 
+%extend math_GaussSingleIntegration {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_GlobOptMin;
 class math_GlobOptMin {
 	public:
@@ -1952,6 +2092,11 @@ class math_GlobOptMin {
 };
 
 
+%extend math_GlobOptMin {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Householder;
 class math_Householder {
 	public:
@@ -2032,6 +2177,11 @@ class math_Householder {
         };
 
 
+%extend math_Householder {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_IntegerRandom;
 class math_IntegerRandom {
 	public:
@@ -2060,6 +2210,11 @@ class math_IntegerRandom {
 };
 
 
+%extend math_IntegerRandom {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_IntegerVector;
 class math_IntegerVector {
 	public:
@@ -2368,6 +2523,11 @@ class math_IntegerVector {
         };
 
 
+%extend math_IntegerVector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Jacobi;
 class math_Jacobi {
 	public:
@@ -2426,6 +2586,11 @@ class math_Jacobi {
         };
 
 
+%extend math_Jacobi {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_KronrodSingleIntegration;
 class math_KronrodSingleIntegration {
 	public:
@@ -2560,6 +2725,11 @@ class math_KronrodSingleIntegration {
 };
 
 
+%extend math_KronrodSingleIntegration {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Matrix;
 class math_Matrix {
 	public:
@@ -3036,6 +3206,11 @@ class math_Matrix {
         };
 
 
+%extend math_Matrix {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_MultipleVarFunction;
 class math_MultipleVarFunction {
 	public:
@@ -3068,6 +3243,11 @@ class math_MultipleVarFunction {
 };
 
 
+%extend math_MultipleVarFunction {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_NewtonFunctionRoot;
 class math_NewtonFunctionRoot {
 	public:
@@ -3174,6 +3354,11 @@ class math_NewtonFunctionRoot {
         };
 
 
+%extend math_NewtonFunctionRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_NewtonFunctionSetRoot;
 class math_NewtonFunctionSetRoot {
 	public:
@@ -3338,6 +3523,11 @@ class math_NewtonFunctionSetRoot {
         };
 
 
+%extend math_NewtonFunctionSetRoot {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_NewtonMinimum;
 class math_NewtonMinimum {
 	public:
@@ -3452,6 +3642,11 @@ class math_NewtonMinimum {
         };
 
 
+%extend math_NewtonMinimum {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_PSO;
 class math_PSO {
 	public:
@@ -3506,6 +3701,11 @@ class math_PSO {
 };
 
 
+%extend math_PSO {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_PSOParticlesPool;
 class math_PSOParticlesPool {
 	public:
@@ -3534,6 +3734,11 @@ class math_PSOParticlesPool {
 };
 
 
+%extend math_PSOParticlesPool {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Powell;
 class math_Powell {
 	public:
@@ -3636,6 +3841,11 @@ class math_Powell {
         };
 
 
+%extend math_Powell {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 class math_QuickSortOfValueAndWeight {
 	public:
 		%feature("compactdefaultargs") Sort;
@@ -3649,6 +3859,11 @@ class math_QuickSortOfValueAndWeight {
 };
 
 
+%extend math_QuickSortOfValueAndWeight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_RealRandom;
 class math_RealRandom {
 	public:
@@ -3677,6 +3892,11 @@ class math_RealRandom {
 };
 
 
+%extend math_RealRandom {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_SVD;
 class math_SVD {
 	public:
@@ -3727,6 +3947,11 @@ class math_SVD {
         };
 
 
+%extend math_SVD {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_TrigonometricFunctionRoots;
 class math_TrigonometricFunctionRoots {
 	public:
@@ -3817,6 +4042,11 @@ class math_TrigonometricFunctionRoots {
         };
 
 
+%extend math_TrigonometricFunctionRoots {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Uzawa;
 class math_Uzawa {
 	public:
@@ -3915,6 +4145,11 @@ class math_Uzawa {
         };
 
 
+%extend math_Uzawa {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_ValueAndWeight;
 class math_ValueAndWeight {
 	public:
@@ -3941,6 +4176,11 @@ class math_ValueAndWeight {
 };
 
 
+%extend math_ValueAndWeight {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_Vector;
 class math_Vector {
 	public:
@@ -4343,6 +4583,11 @@ class math_Vector {
         };
 
 
+%extend math_Vector {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionSetWithDerivatives;
 class math_FunctionSetWithDerivatives : public math_FunctionSet {
 	public:
@@ -4393,6 +4638,11 @@ class math_FunctionSetWithDerivatives : public math_FunctionSet {
 };
 
 
+%extend math_FunctionSetWithDerivatives {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_FunctionWithDerivative;
 class math_FunctionWithDerivative : public math_Function {
 	public:
@@ -4435,6 +4685,11 @@ class math_FunctionWithDerivative : public math_Function {
 };
 
 
+%extend math_FunctionWithDerivative {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_MultipleVarFunctionWithGradient;
 class math_MultipleVarFunctionWithGradient : public math_MultipleVarFunction {
 	public:
@@ -4483,6 +4738,11 @@ class math_MultipleVarFunctionWithGradient : public math_MultipleVarFunction {
 };
 
 
+%extend math_MultipleVarFunctionWithGradient {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};
 %nodefaultctor math_MultipleVarFunctionWithHessian;
 class math_MultipleVarFunctionWithHessian : public math_MultipleVarFunctionWithGradient {
 	public:
@@ -4545,3 +4805,8 @@ class math_MultipleVarFunctionWithHessian : public math_MultipleVarFunctionWithG
 };
 
 
+%extend math_MultipleVarFunctionWithHessian {
+	%pythoncode {
+	__repr__ = _dumps_object
+	}
+};

--- a/test/core_wrapper_features_unittest.py
+++ b/test/core_wrapper_features_unittest.py
@@ -486,6 +486,14 @@ class TestWrapperFeatures(unittest.TestCase):
         graphic_params.RaytracingDepth = 5
         assert graphic_params.RaytracingDepth == 5
 
+    def test_repr_overload(self):
+        """ Test if repr string is properly returned
+        """
+        p = gp_Pnt(1,2,3)
+        assert str(p) == "class<'gp_Pnt'>"
+        shp = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+        assert "class<'TopoDS_Shape'; Type:Solid; id:" in str(shp)
+
 def suite():
     test_suite = unittest.TestSuite()
     test_suite.addTest(unittest.makeSuite(TestWrapperFeatures))


### PR DESCRIPTION
This branch alllows a less verbose and more explicit __repr__ method for each pythonocc object:

```
>>> from OCC.gp import gp_Pnt
>>> print(gp_Pnt(1,2,3))
class<'gp_Pnt'>
>>> from OCC.BRepPrimAPI import BRepPrimAPI_MakeSphere
>>> print(BRepPrimAPI_MakeSphere(5.).Shape())
class<'TopoDS_Shape'; Type:Solid; id:53941297>

```
