### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ pythonocc provides precompiled [conda packages](https://anaconda.org/pythonocc/p
 This will get you up and running in minutes whether you run win32/win64/linux64/osx64:
 
 ```bash
-conda install -c pythonocc -c dlr-sc pythonocc-core
+# install pythonocc in an environment named `pythonocc` with python 3.5; use python=2 for legacy python 2.7.12
+conda create -n pythonocc -c pythonocc -c dlr-sc pythonocc-core==0.17.1 python=3
 ```
 
 How to compile ?


### PR DESCRIPTION
Currently, the conda install command on the README.md has two issues:

1. by default legacy python is installed ( 2.7, rather than 3.5 )
2. it would make sense to create an environment rather than install in conda's root environment, which is best practice