### PR TITLE
_build/ directory should be ignored generally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ coverage.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea/
+workspace.xml
 
 # Rope
 .ropeproject

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ coverage.xml
 *.pot
 
 # Sphinx documentation
-docs/_build/
+_build/
 

--- a/doc/getting_started/build_install.rst
+++ b/doc/getting_started/build_install.rst
@@ -37,37 +37,37 @@ The configuration steps uses cmake::
 
 By default, cmake looks for oce include headers in /usr/local/include/oce and
 libraries in /usr/local/include/lib. If these paths don't match your
-installation, you have to set OCE_INCLUDE_PATH and OCE_LIB_PATH
-::
+installation, you have to set OCE_INCLUDE_PATH and OCE_LIB_PATH::
+
     $ cmake -DOCE_INCLUDE_PATH=/your_oce_headers -DOCE_LIB_PATH=/your_lib_dir ..
 
-If you prefer, you can launche the cmake-gui using the following command
-::
+If you prefer, you can launche the cmake-gui using the following command::
+
     $ cmake-gui ..
 
-And launch the build process
-::
+And launch the build process::
+
     $ make
 
 If you have many cpus, you can increase the compilation speed with::
-::
+
     $ make -j$ncpus
 
 According to your machine/os/ncpus, the total compilation time shold be
 between 5 to 15 minutes.
 
-Then
-::
+Then::
+
     $ make install
 
-You may require admin privileges to install
-::
+You may require admin privileges to install::
+
     $ sudo make install
 
 test
 ^^^^
-In order to check that everything is ok, run the pythonocc unittest suite:
-::
+In order to check that everything is ok, run the pythonocc unittest suite::
+
     $ cd ../test
     $ python run_tests.py
 


### PR DESCRIPTION
_build/  for documentation can be in the sub folder (e.g. doc/examples/_build/ ).