### PR TITLE
Extended api documentation for the module Addons

### DIFF
--- a/src/Addons/Addons.i
+++ b/src/Addons/Addons.i
@@ -16,8 +16,8 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 */
-%module Addons;
 
+%module(package="OCC") Addons
 %{
 #include <Addons.h>
 #include <TextItem.h>
@@ -35,12 +35,67 @@ Font_FA_Italic = 3,
 Font_FA_BoldItalic = 4
 };
 
-TopoDS_Shape text_to_brep(char *text_to_render, char* aFontName, Font_FontAspect aFontAspect, float aSize, bool isCompositeCurve);
+
+
+%feature("compactdefaultargs") text_to_brep;
+%feature("autodoc", "	* Creates a shape of the given text. 
+	:param text_to_render: Text to render
+	:type text_to_render: char *
+	:param aFontName: Font name
+	:type aFontName: char *
+	:param aFontAspect:  Fontaspect, Font_FA_Regular, Font_FA_Bold, Font_FA_Italic or Font_FA_BoldItalic
+	:type aFontAspect: Font_FontAspect
+	:param aSize: Size of the font
+	:type aSize: float
+	:param isCompositeCurve:
+	:type isCompositeCurve: bool
+	:rtype: TopoDS_Shape
+") text_to_brep;
+TopoDS_Shape text_to_brep(char *text_to_render, char *aFontName, Font_FontAspect aFontAspect, float aSize, bool isCompositeCurve);
+
+%feature("compactdefaultargs") display_available_fonts;
+%feature("autodoc", "	* Prints a list of all available fonts.
+	:rtype: void
+") display_available_fonts;
 void display_available_fonts();
-void register_font(char* aFontPath);
+
+%feature("compactdefaultargs") register_font;
+%feature("autodoc", "	* Add a font to the available font list. 
+	:param aFontPath: Path to the font.
+	:type aFontPath: char *
+	:rtype: void
+") register_font;
+void register_font(char *aFontPath);
+
 
 class TextItem {
  public:
+ 
+	%feature("compactdefaultargs") TextItem;
+	%feature("autodoc", "	* Displays a text in the screen
+	:param theText: Text to display
+	:type theText: const TCollection_AsciiString&
+	:param theX1: X-Position on the display
+	:type theX1: float
+	:param theY1: Y-Position on the display
+	:type theY1: float
+	:param theHeight: Size of the font
+	:type theHeight: float
+	:param theFontName: Name of the font
+	:type theFontName: const TCollection_AsciiString&
+	:param theColor: Rgb color. E.g. Quantity_Color(0..1, 0..1, 0..1, 1)
+	:type theColor: const Quantity_Color&
+	:param theSubtitleColor: Rgb color of the sub title
+	:type theSubtitleColor: const Quantity_Color&
+	:param theTypeOfDisplay: Type of display, e.g. Aspect_TODT_NORMAL, Aspect_TODT_SUBTITLE, Aspect_TODT_DEKALE
+	:type theTypeOfDisplay: int
+	:param theLayer: 
+	:type: const Handle_Visual3d_Layer&
+	:param ScrollX: 
+	:type: const float
+	:param Scrolly: 
+	:type: const float
+") TextItem;
     TextItem(const TCollection_AsciiString& theText,
              float theX1,
              float theY1,
@@ -55,8 +110,32 @@ class TextItem {
     void RedrawLayerPrs();
 };
 
+
+
 class LineItem {
  public:
+	%feature("compactdefaultargs") LineItem;
+	%feature("autodoc", "	* Creates a shape of the given text
+	:param X1: X-Position of the first point 
+	:type X1: float
+	:param Y1: Y-Position of the first point   
+	:type Y1: float        
+    :param X2: X-Position of the second point    
+    :type X2: float 
+    :param Y2: Y-Position of the second point   
+    :type Y2: float 
+	:param theLayer: The Layer
+	:type theLayer: const Handle_Visual3d_Layer&
+	:param theType: Type of line: 0..10
+	:type theType: int
+	:param theWidth: Width of the line
+	:type theWidth: float	
+	:param theTransp: Transparency: 0..1
+	:type theTransp: float	
+	:param theColor: Rgb color
+	:type theColor: const Quantity_Color &	
+   
+") LineItem;
     LineItem(float X1, float Y1,
              float X2, float Y2,
              const Handle_Visual3d_Layer& theLayer,
@@ -67,8 +146,19 @@ class LineItem {
     void RedrawLayerPrs();
 };
 
+
 class TextureItem {
 public:
+	%feature("compactdefaultargs") TextureItem;
+	%feature("autodoc", "	* Creates a shape of the given text
+	:param theImageFilename: Path to the image
+	:type theImageFilename: const TCollection_AsciiString&
+	:param theView: The display view
+	:type theView: V3d_View *        
+    :param theLayer: Layer for the texture
+    :type theLayer: const Handle_Visual3d_Layer& 
+ 
+") TextureItem;
     TextureItem(const TCollection_AsciiString& theImageFilename,
                 V3d_View* theView,
                 const Handle_Visual3d_Layer& theLayer);


### PR DESCRIPTION
I added some rst code to the Addons.i file to extend the apidoc for this module. 
But some of the existing name definitions are seeming to be a little bit unclear. 
For example the Module name says not really something about the provided functionality. 
The parameters are starting partially with "the", for example theName, theX1 or theLayer without any obvious reference. 