### PR TITLE
lower timeout value, for Windows

### DIFF
--- a/test/run_examples_as_tests.py
+++ b/test/run_examples_as_tests.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     failed = mp.Value('i', 0)
 
     pool = mp.Pool(initializer = init, initargs = (failed, ))
-    pool.map_async(worker, all_examples_file_names).get(99999999)
+    pool.map_async(worker, all_examples_file_names).get(4233600)
     pool.close()
     pool.join()
 

--- a/test/run_examples_as_tests.py
+++ b/test/run_examples_as_tests.py
@@ -25,6 +25,10 @@ import sys
 import subprocess
 import multiprocessing as mp
 import time
+try:
+    from threading import TIMEOUT_MAX
+except ImportError:
+    TIMEOUT_MAX = 60 * 60 * 24 * 49
 
 def init(args):
     ''' store the counter for later use '''
@@ -80,7 +84,7 @@ if __name__ == "__main__":
     failed = mp.Value('i', 0)
 
     pool = mp.Pool(initializer = init, initargs = (failed, ))
-    pool.map_async(worker, all_examples_file_names).get(4233600)
+    pool.map_async(worker, all_examples_file_names).get(TIMEOUT_MAX)
     pool.close()
     pool.join()
 


### PR DESCRIPTION
49 days or 60 * 60 * 24 * 49 = 4233600 seconds.
With Python 3.2 and above, one can also use `threading.TIMEOUT_MAX`
https://docs.python.org/3/library/threading.html#threading.TIMEOUT_MAX
`print(TIMEOUT_MAX)` gives 4294967.0 seconds.

this closes #523