### PR TITLE
fix transparent shape rendering in jupyter_renderer.py

### DIFF
--- a/src/Display/WebGl/jupyter_renderer.py
+++ b/src/Display/WebGl/jupyter_renderer.py
@@ -429,7 +429,8 @@ class JupyterRenderer(object):
                                          polygonOffsetFactor=1,
                                          polygonOffsetUnits=1,
                                          shininess=0.9,
-                                         transparent=transparency)
+                                         transparent=transparency,
+                                         opacity=opacity)
 
         # create a mesh unique id
         mesh_id = uuid.uuid4().hex


### PR DESCRIPTION
add missed parameter 'opacity' when initializing MeshPhongMaterial