### PR TITLE
Fixes problem where server would always open a web browser

### DIFF
--- a/src/Display/WebGl/simple_server.py
+++ b/src/Display/WebGl/simple_server.py
@@ -72,7 +72,8 @@ def start_server(port=8080, path='.', open_webbrowser=False):
         print("## Open your webbrowser at the URL: http://localhost:%i" % port)
         print("## CTRL-C to shutdown the server")
         # open webbrowser
-        webbrowser.open('http://localhost:%i' % port, new=2)
+        if open_webbrowser:
+            webbrowser.open('http://localhost:%i' % port, new=2)        
         # starts the web_server
         httpd.serve_forever()
 


### PR DESCRIPTION
Previously, the start_server method would ignore the open_webbrowser kwarg
and open a web browser regardless of whether or not open_webbrowser was set.