### PR TITLE
Remove `calling_script` from image filename

### DIFF
--- a/src/Display/OCCViewer.py
+++ b/src/Display/OCCViewer.py
@@ -696,9 +696,8 @@ class OffscreenRenderer(Viewer3d):
             import __main__ as main
             calling_script = main.__file__.split(".")[0]  # only the fie without extension
             self.capture_number += 1
-            image_filename = "capture-%s-%i-%s.jpeg" % (calling_script,
-                                                        self.capture_number,
-                                                        timestamp.replace(" ", "-"))
+            image_filename = "capture-%i-%s.jpeg" % (self.capture_number,
+                                                     timestamp.replace(" ", "-"))
             if os.getenv("PYTHONOCC_OFFSCREEN_RENDERER_DUMP_IMAGE_PATH"):
                 path = os.getenv("PYTHONOCC_OFFSCREEN_RENDERER_DUMP_IMAGE_PATH")
                 assert os.path.isdir(path)


### PR DESCRIPTION
# Before

Without this patch, the generated image filenames can be pretty weird. For example:

```
/local/home/aang/Code/hello/hello/test/capture-/local/home/aang/Applications/pycharm-2018-1-1542064678.jpeg
``` 

> Note: This happens when using PyCharm.

# After

With this patch, the generated image filenames will look like:

```
/local/home/aang/Code/hello/hello/test/capture-1-1542064946.jpeg
```
