### PR TITLE
OCCT 7.4.0: Fixed handle issues and tests on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ endmacro(option_with_default OPTION_NAME OPTION_STRING OPTION_DEFAULT)
 ############
 # Python 3 #
 ############
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-message(STATUS "Python3 interpreter:" ${Python3_EXECUTABLE})
-message(STATUS "Python include directory: ${Python3_INCLUDE_DIR}")
-message(STATUS "Python library release: ${Python3_LIBRARY_RELEASE}")
-message(STATUS "Python library debug: ${Python3_LIBRARY_DEBUG}")
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+message(STATUS "Python3 interpreter:" ${Python_EXECUTABLE})
+message(STATUS "Python include directory: ${Python_INCLUDE_DIR}")
+message(STATUS "Python library release: ${Python_LIBRARY_RELEASE}")
+message(STATUS "Python library debug: ${Python_LIBRARY_DEBUG}")
 
 ##############################################
 # Installation directory                     #
@@ -244,7 +244,7 @@ foreach(OCE_MODULE ${OCE_TOOLKIT_MODEL})
     set(FILE ${SWIG_FILES_PATH}/${OCE_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library (${OCE_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCE_MODULE} ${OCE_MODEL_LIBRARIES} Python3::Module)
+    swig_link_libraries(${OCE_MODULE} ${OCE_MODEL_LIBRARIES} Python::Module)
 endforeach(OCE_MODULE)
 
 #################
@@ -258,7 +258,7 @@ if(PYTHONOCC_WRAP_VISU)
       set(FILE ${SWIG_FILES_PATH}/${OCE_MODULE}.i)
       set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
       swig_add_library (${OCE_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-      swig_link_libraries(${OCE_MODULE} ${OCE_VISUALIZATION_LIBRARIES} Python3::Module)
+      swig_link_libraries(${OCE_MODULE} ${OCE_VISUALIZATION_LIBRARIES} Python::Module)
     endforeach(OCE_MODULE)
 
   # Build third part modules
@@ -272,7 +272,7 @@ if(PYTHONOCC_WRAP_VISU)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/Visualization/Tesselator.cpp)
 
     swig_add_library(Visualization LANGUAGE python SOURCES ${VISUALIZATION_SOURCE_FILES} TYPE MODULE)
-    swig_link_libraries(Visualization  ${OCE_MODEL_LIBRARIES} ${OCE_VISUALIZATION_LIBRARIES} Python3::Module)
+    swig_link_libraries(Visualization  ${OCE_MODEL_LIBRARIES} ${OCE_VISUALIZATION_LIBRARIES} Python::Module)
 
   if(APPLE)
     # on OSX, always add /System/Library/Frameworks/Cocoa.framework, even
@@ -290,7 +290,7 @@ if(PYTHONOCC_WRAP_DATAEXCHANGE)
     set(FILE ${SWIG_FILES_PATH}/${OCE_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library(${OCE_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCE_MODULE} ${OCE_DATAEXCHANGE_LIBRARIES} Python3::Module)
+    swig_link_libraries(${OCE_MODULE} ${OCE_DATAEXCHANGE_LIBRARIES} Python::Module)
   endforeach(OCE_MODULE)
 endif(PYTHONOCC_WRAP_DATAEXCHANGE)
 
@@ -302,7 +302,7 @@ if(PYTHONOCC_WRAP_OCAF)
     set(FILE ${SWIG_FILES_PATH}/${OCE_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library(${OCE_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCE_MODULE}  ${OCE_OCAF_LIBRARIES} Python3::Module)
+    swig_link_libraries(${OCE_MODULE}  ${OCE_OCAF_LIBRARIES} Python::Module)
   endforeach(OCE_MODULE)
 endif(PYTHONOCC_WRAP_OCAF)
 
@@ -314,7 +314,7 @@ if(PYTHONOCC_WRAP_SMESH)
     set(FILE ${SWIG_FILES_PATH}/${SMESH_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library(${SMESH_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${SMESH_MODULE} ${OCE_MODEL_LIBRARIES} ${OCE_VISUALIZATION_LIBRARIES} ${OCE_OCAF_LIBRARIES} ${SMESH_LIBRARIES} Python3::Module)
+    swig_link_libraries(${SMESH_MODULE} ${OCE_MODEL_LIBRARIES} ${OCE_VISUALIZATION_LIBRARIES} ${OCE_OCAF_LIBRARIES} ${SMESH_LIBRARIES} Python::Module)
   endforeach(SMESH_MODULE)
 endif(PYTHONOCC_WRAP_SMESH)
 


### PR DESCRIPTION
Fixed almost all problems (just checked with unit tests).

Main issue was missing import of Geom and Geom2d. If Handle(Geom_XXX) is used somewhere, it cannot wrap it correctly, when Geom was not imported. Hence, you'll get some strange behavior.

Other changes:
 - Force C++ 11
 - Reenabled and changed TopoDS_Shape conversion in FunctionTransformers
 - Adapted one test to API change

Remaining issues:
 - Edge count 6 != 3 (as before)
 - Cannot create empty TopoDS_Shape (Null Shape), i.e. without argument. This comes from the new handle implementation. Do we really need this?
 - One surface distance check is different. I suppose this is due to new numerics.
 - BRepCheck_Status issue (as before)

Here are the test results:
```
(base) sigg_ma@sc-030117l:/localdata1/sigg_ma/src/pythonocc-core/test> python run_tests.py 

testAutoImportOfDependentModules (core_wrapper_features_unittest.TestWrapperFeatures)
Test: automatic import of dependent modules ... ok
testProtectedConstructor (core_wrapper_features_unittest.TestWrapperFeatures)
Test: protected constructor ... ok
testStandardBooleanByRefPassedReturned (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
testTopoDS_byref_arguments (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_array_iterator (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_const_Standard_Integer_byref (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_const_Standard_Real_byref (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_default_constructor_DEFINE_STANDARD_ALLOC (core_wrapper_features_unittest.TestWrapperFeatures)
OCE classes the defines standard alllocator can be instanciated ... ok
test_deprecation_downcasts (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_deprecation_get_handle (core_wrapper_features_unittest.TestWrapperFeatures)
Handles are now completely transparent. The GetHandle method is ... ok
test_deprecation_get_object (core_wrapper_features_unittest.TestWrapperFeatures)
Handles are now completely transparent. The GetObject method is ... ok
test_deprecation_handle_class (core_wrapper_features_unittest.TestWrapperFeatures)
Handles are now completely transparent. The Handle_* constructor is ... ok
test_deprecation_warning (core_wrapper_features_unittest.TestWrapperFeatures)
since pythonocc-0.18.2. import OCC.* changed to import OCC.Core.* ... ok
test_dict (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_downcast_curve (core_wrapper_features_unittest.TestWrapperFeatures)
Test if a GeomCurve can be DownCasted to a GeomLine ... class<'Geom_Line'>
ok
test_dump_to_string (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_eq_operator (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_ft1 (core_wrapper_features_unittest.TestWrapperFeatures)
Test: Standard_Integer & by reference transformator ... ok
test_gp_Quaternion (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_gp_Vec_operators (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_handle_standard_transient_copy (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_handling_exceptions (core_wrapper_features_unittest.TestWrapperFeatures)
asserts that handling of OCC exceptions is handled correctly in pythonocc ... ok
test_hash (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_hash_eq_operator (core_wrapper_features_unittest.TestWrapperFeatures)
test that the == wrapper is ok ... ok
test_in_place_operators (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_inherit_topods_shape (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_list (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_local_properties (core_wrapper_features_unittest.TestWrapperFeatures)
Get and modify class local properties ... ok
test_memory_handle_getobject (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_neq_operator (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_pickle_from_file (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_repr_for_null_topods_shapes (core_wrapper_features_unittest.TestWrapperFeatures) ... ERROR
test_repr_overload (core_wrapper_features_unittest.TestWrapperFeatures)
Test if repr string is properly returned ... ok
test_return_enum (core_wrapper_features_unittest.TestWrapperFeatures)
Check that returned enums are properly handled, wether they're returned ... FAIL
test_shape_conversion_as_py_none (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_standard_boolean_byref (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_standard_integer_by_ref_passed_returned (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_static_method (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_sub_class (core_wrapper_features_unittest.TestWrapperFeatures)
Test: subclass ... ok
test_topology (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_traverse_box_topology (core_wrapper_features_unittest.TestWrapperFeatures) ... ok
test_axis (core_geometry_unittest.TestGeometry)
Test: axis ... ok
test_bezier_surfaces (core_geometry_unittest.TestGeometry)
Test: Bezier surfaces ... ok
test_bspline (core_geometry_unittest.TestGeometry)
Test: bspline ... ok
test_circles2d_from_curves (core_geometry_unittest.TestGeometry)
Test: circles2d from curves ... ok
test_curves2d_from_curves (core_geometry_unittest.TestGeometry)
Test: curves 2d from curves ... ok
test_curves2d_from_offset (core_geometry_unittest.TestGeometry)
Test: curves 2d from offset ... ok
test_distances (core_geometry_unittest.TestGeometry)
Test: distances ... FAIL
test_parabola (core_geometry_unittest.TestGeometry)
Test: parabola ... /localdata1/sigg_ma/src/pythonocc-core/test/core_geometry_unittest.py:228: DeprecationWarning: IsNull is a deprecated function. Use is None instead
  self.assertFalse(aTrimmedCurve.IsNull())
ok
test_pipes (core_geometry_unittest.TestGeometry)
Test: pipes ... ok
test_point_from_curve (core_geometry_unittest.TestGeometry)
Test: point from curve ... ok
test_point_from_projections (core_geometry_unittest.TestGeometry)
Test: point from projections ... ok
test_points_from_intersection (core_geometry_unittest.TestGeometry)
Test: points from intersection ... /localdata1/sigg_ma/src/pythonocc-core/test/core_geometry_unittest.py:203: DeprecationWarning: IsNull is a deprecated function. Use is None instead
  self.assertFalse(aSurface.IsNull())
ok
test_project_point_on_curve (core_geometry_unittest.TestGeometry)
Test: project point on curve ... Q1: at Distance :4.079132288244904
Q2: at Distance :7.833305801192616
ok
test_surface_from_curves (core_geometry_unittest.TestGeometry)
Test: surfaces from curves ... ok
test_surfaces_from_offsets (core_geometry_unittest.TestGeometry)
Test: surfaces from offsets ... ok
test_surfaces_from_revolution (core_geometry_unittest.TestGeometry)
Test: surfaces from revolution ... ok
test_export_to_3js_JSON (core_visualization_unittest.TestTesselator) ... ok
test_export_to_x3d (core_visualization_unittest.TestTesselator)
3rd test : export a sphere to X3D file format ... ok
test_export_to_x3d_TriangleSet (core_visualization_unittest.TestTesselator)
3rd test : export a sphere to an X3D TriangleSet triangle mesh ... ok
test_tesselate_box (core_visualization_unittest.TestTesselator)
1st test : tesselation of a box ... ok
test_tesselate_torus (core_visualization_unittest.TestTesselator)
2st test : tesselation of a torus ... ok
test_tesselate_torus_with_bad_quality (core_visualization_unittest.TestTesselator)
2st test : tesselation of a torus ... ok
test_tesselate_torus_with_edges (core_visualization_unittest.TestTesselator)
2st test : tesselation of a torus ... ok
test_create_doc (core_ocaf_unittest.TestOCAF)
Creates an OCAF app and an empty document ... /localdata1/sigg_ma/src/pythonocc-core/test/core_ocaf_unittest.py:58: DeprecationWarning: IsNull is a deprecated function. Use is None instead
  self.assertFalse(doc.IsNull())
ok
test_read_step_file (core_ocaf_unittest.TestOCAF)
Reads the previous step file ... ok
test_write_step_file (core_ocaf_unittest.TestOCAF)
Exports a colored box into a STEP file ... 
*******************************************************************
******        Statistics on Transfer (Write)                 ******

*******************************************************************
******        Transfer Mode = 0  I.E.  As Is       ******
******        Transferring Shape, ShapeType = 2                      ******
** WorkSession : Sending all data
 Step File Name : ./test_io/test_ocaf_generated.stp(391 ents)  Write  Done
ok
test_threejs_edge (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## threejs r106 webgl renderer
discretize an edge
discretize an edge
ok
test_threejs_random_boxes (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## threejs r106 webgl renderer
/ mesh shape shp6d11a738f22049a5be83a28409171bde, 12 triangles     ok
test_threejs_render_torus (core_webgl_unittest.TestWebGL)
Render a simple torus in threejs ... ## threejs r106 webgl renderer
| mesh shape shp78f89d160ef44945b1812bfd75c8af5e, 1352 triangles     ok
test_threejs_wire (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## threejs r106 webgl renderer
discretize a wire
ok
test_x3d_edge (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## x3dom webgl renderer - render axes/planes : True - axes/plane zoom factor : 1
X3D exporter, discretize an edge
X3D exporter, discretize an edge
ok
test_x3d_wire (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## x3dom webgl renderer - render axes/planes : True - axes/plane zoom factor : 1
X3D exporter, discretize a wire
ok
test_x3dom_random_mesh_quality (core_webgl_unittest.TestWebGL)
Test: threejs 10 random boxes ... ## threejs r106 webgl renderer
- mesh shape shp3b8833fa47ef42ef89eb19947f5c51ad, 2048 triangles     ok
test_x3dom_render_torus (core_webgl_unittest.TestWebGL)
Render a simple torus using x3dom ... ## x3dom webgl renderer - render axes/planes : True - axes/plane zoom factor : 1
ok
test_discretize_edge (core_extend_topology_unittest.TestExtendTopology) ... ok
test_discretize_wire (core_extend_topology_unittest.TestExtendTopology) ... ok
test_edge_face (core_extend_topology_unittest.TestExtendTopology) ... ok
test_edge_wire (core_extend_topology_unittest.TestExtendTopology) ... ok
test_edges_out_of_scope (core_extend_topology_unittest.TestExtendTopology) ... ok
test_face_solid (core_extend_topology_unittest.TestExtendTopology) ... ok
test_kept_reference (core_extend_topology_unittest.TestExtendTopology)
did we keep a reference after looping several time through a list ... ok
test_loop_edges (core_extend_topology_unittest.TestExtendTopology) ... ok
test_loop_faces (core_extend_topology_unittest.TestExtendTopology) ... ok
test_nested_iteration (core_extend_topology_unittest.TestExtendTopology)
check nested looping ... ok
test_number_of_topological_entities (core_extend_topology_unittest.TestExtendTopology) ... ok
test_vertex_edge (core_extend_topology_unittest.TestExtendTopology) ... FAIL
test_vertex_face (core_extend_topology_unittest.TestExtendTopology) ... ok
test_wire_face (core_extend_topology_unittest.TestExtendTopology) ... ok
test_wires_out_of_scope (core_extend_topology_unittest.TestExtendTopology) ... ok

======================================================================
ERROR: test_repr_for_null_topods_shapes (core_wrapper_features_unittest.TestWrapperFeatures)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/localdata1/sigg_ma/src/pythonocc-core/test/core_wrapper_features_unittest.py", line 621, in test_repr_for_null_topods_shapes
    s = TopoDS_Shape()
TypeError: __init__() missing 1 required positional argument: 'arg0'

======================================================================
FAIL: test_return_enum (core_wrapper_features_unittest.TestWrapperFeatures)
Check that returned enums are properly handled, wether they're returned
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/localdata1/sigg_ma/src/pythonocc-core/test/core_wrapper_features_unittest.py", line 542, in test_return_enum
    self.assertEqual(los1.First(), BRepCheck_Multiple3DCurve)
AssertionError: <Swig Object of type 'BRepCheck_Status *' at 0x7f3921d44690> != 5

======================================================================
FAIL: test_distances (core_geometry_unittest.TestGeometry)
Test: distances
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/localdata1/sigg_ma/src/pythonocc-core/test/core_geometry_unittest.py", line 648, in test_distances
    self.assertGreater(dist, 1.25)
AssertionError: 1.224153673728948 not greater than 1.25

======================================================================
FAIL: test_vertex_edge (core_extend_topology_unittest.TestExtendTopology)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/localdata1/sigg_ma/src/pythonocc-core/test/core_extend_topology_unittest.py", line 126, in test_vertex_edge
    self.assertEqual(len(edges_from_vert), topo.number_of_edges_from_vertex(vert))
AssertionError: 3 != 6

----------------------------------------------------------------------
Ran 90 tests in 0.339s

FAILED (failures=3, errors=1)
```