### PR TITLE
Refactored exception catcher to avoid SWIG inlining thousands of time…

### DIFF
--- a/src/SWIG_files/common/ExceptionCatcher.i
+++ b/src/SWIG_files/common/ExceptionCatcher.i
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2008-2019 Thomas Paviot (tpaviot@gmail.com)
+Copyright 2008-2020 Thomas Paviot (tpaviot@gmail.com)
 
 This file is part of pythonOCC.
 
@@ -19,12 +19,19 @@ along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-/*
-Exception handling
-*/
 %{
 #include <Standard_Failure.hxx>
 #include <Standard_ErrorHandler.hxx>
+%}
+
+%inline %{
+void process_exception(Standard_Failure const& error, std::string method_name, std::string class_name) {
+    std::string error_name = error.DynamicType()->Name();
+	std::string error_message = error.GetMessageString();
+	std::string message = error_name + error_message +
+	                      " raised from method " + method_name + " of class " + class_name;
+	PyErr_SetString(PyExc_RuntimeError, message.c_str());
+}
 %}
 
 %exception
@@ -36,15 +43,7 @@ Exception handling
     } 
     catch(Standard_Failure const& error)
     {
-	    char *error_name = (char*) error.DynamicType()->Name();
-	    char *error_message = (char*) error.GetMessageString();
-	    std::string message;
-	    if (error_name) message += std::string(error_name) + "\n";
-	    if (error_message) message += std::string(error_message);
-	    // log SWIG specific debug information
-	    message += "\nwrapper details:\n  * symname: $symname\n  * wrapname: $wrapname\n  * fulldecl: $fulldecl";
-	    // raise the python exception
-	    PyErr_SetString(PyExc_RuntimeError, message.c_str());
+	    process_exception(error, "$name", "$parentclassname");
 	    SWIG_fail;
     }
 }


### PR DESCRIPTION
This small change saves around 10% of the total compilation time according to my first experiments