### PR TITLE
Fixed global change of log level

### DIFF
--- a/src/Display/backend.py
+++ b/src/Display/backend.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 # backend constants
 WX = "wx"

--- a/src/Display/backend.py
+++ b/src/Display/backend.py
@@ -14,8 +14,8 @@ HAVE_PYQT5, HAVE_PYQT4, HAVE_PYSIDE, HAVE_WX = False, False, False, False
 HAVE_BACKEND = False
 BACKEND_MODULE = "No backend loaded"
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 log = logging.getLogger(__name__)
+log.set_level(logging.DEBUG)
 
 
 def load_pyqt5():


### PR DESCRIPTION
Importing the init_display function e.g. using from `OCC.Display.SimpleGui import init_display` will globally change the log level to DEBUG. Aside from this being an undesirable side effect during import, it also causes cluttered output when running larger test suites involving pythonocc. Therefore I propose the attached change, which causes the log level to be set only for the local logger instead of globally.