### PR TITLE
Makes current version of pythonocc-core compilable with occt 7.5.2

### DIFF
--- a/src/SWIG_files/wrapper/ShapeUpgrade.i
+++ b/src/SWIG_files/wrapper/ShapeUpgrade.i
@@ -37,6 +37,7 @@ https://www.opencascade.com/doc/occt-7.4.0/refman/html/package_shapeupgrade.html
 
 %{
 #include<Precision.hxx>
+#include<TopoDS_Edge.hxx>
 #include<ShapeUpgrade_UnifySameDomain.hxx>
 #include<ShapeUpgrade_module.hxx>
 


### PR DESCRIPTION
Fixes problem mentioned in #995 and https://forum.freecadweb.org/viewtopic.php?f=4&t=58090. Without fix, you end up with a compiler error

```
In file included from /home/mainuser/software/freecad_source/build_2021-04-25/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPy.h:8,
                 from /home/mainuser/software/freecad_source/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp:30:
/home/mainuser/software/occt-0dc2c37/include/opencascade/ShapeUpgrade_UnifySameDomain.hxx:72:15: error: field ‘UnionEdges’ has incomplete type ‘TopoDS_Edge’
   TopoDS_Edge UnionEdges;
               ^~~~~~~~~~
In file included from /home/mainuser/software/occt-0dc2c37/include/opencascade/BRepTools_History.hxx:20,
                 from /home/mainuser/software/occt-0dc2c37/include/opencascade/ShapeUpgrade_UnifySameDomain.hxx:20,
                 from /home/mainuser/software/freecad_source/build_2021-04-25/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPy.h:8,
                 from /home/mainuser/software/freecad_source/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp:30:
/home/mainuser/software/occt-0dc2c37/include/opencascade/TopExp.hxx:31:7: note: forward declaration of ‘class TopoDS_Edge’
 class TopoDS_Edge;
       ^~~~~~~~~~~
```