### PR TITLE
Update INSTALL.md with respect to Open CASCADE version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,9 @@ can compile/use it :
 *   the python programming language (<http://www.python.org>). Python 3.x is required. Python 2
 is officially dropped since the release 7.5.0.
 
-*   OpenCascade 7.5.1 (<https://dev.opencascade.org>), direct source download at https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=94c00556ea33f3895196b30c45b1fa901ad4c377;sf=tgz
+*   OpenCascade 7.5.2 (<https://dev.opencascade.org>), direct source download at https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=0dc2c377fc5a2d8cf065f4ec005e356240cb484c;sf=tgz
+
+    IMPORTANT: OpenCASCADE has to be compiled using flag -D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
 
 *   SWIG 3.0.11 or higher (<http://www.swig.org>),
 


### PR DESCRIPTION
master version of pythonocc-core does not work with occt 7.5.1 since they added `Extrema_FuncExtCS::PointsOnCurve` only recently in 7.5.2
