### PR TITLE
Pickling does not round

### DIFF
--- a/src/SWIG_files/wrapper/BRepTools.i
+++ b/src/SWIG_files/wrapper/BRepTools.i
@@ -616,7 +616,24 @@ bool
 ") Write;
 		static Standard_Boolean Write(const TopoDS_Shape & Sh, const char * File, const Message_ProgressRange & theProgress = Message_ProgressRange());
 
-};
+                    
+                    %feature("autodoc", "Serializes TopoDS_Shape to string") WriteToString;
+                    %extend{
+                        static std::string WriteToString(const TopoDS_Shape & shape) {
+                        std::stringstream s;
+                        BRepTools::Write(shape, s);
+                        return s.str();}
+                    };
+                    %feature("autodoc", "Deserializes TopoDS_Shape from string") ReadFromString;
+                    %extend{
+                        static TopoDS_Shape ReadFromString(const std::string & src) {
+                        std::stringstream s(src);
+                        TopoDS_Shape shape;
+                        BRep_Builder b;
+                        BRepTools::Read(shape, s, b);
+                        return shape;}
+                    };
+            };
 
 
 %extend BRepTools {

--- a/src/SWIG_files/wrapper/BRepTools.i
+++ b/src/SWIG_files/wrapper/BRepTools.i
@@ -615,12 +615,16 @@ Returns
 bool
 ") Write;
 		static Standard_Boolean Write(const TopoDS_Shape & Sh, const char * File, const Message_ProgressRange & theProgress = Message_ProgressRange());
-
+		
                     
-                    %feature("autodoc", "Serializes TopoDS_Shape to string") WriteToString;
+                    %feature("autodoc", "Serializes TopoDS_Shape to string. If full_precision is False, the default precision of std::stringstream is used which regularly causes rounding.") WriteToString;
                     %extend{
-                        static std::string WriteToString(const TopoDS_Shape & shape) {
+                        static std::string WriteToString(const TopoDS_Shape & shape, bool full_precision = true) {
                         std::stringstream s;
+                        if(full_precision) {
+                            s.precision(17);
+                            s.setf(std::ios::scientific);
+                        }
                         BRepTools::Write(shape, s);
                         return s.str();}
                     };

--- a/src/SWIG_files/wrapper/BRepTools.pyi
+++ b/src/SWIG_files/wrapper/BRepTools.pyi
@@ -99,6 +99,10 @@ class breptools:
 	@overload
 	@staticmethod
 	def Write(Sh: TopoDS_Shape, File: str, theProgress: Optional[Message_ProgressRange] = Message_ProgressRange()) -> bool: ...
+	@staticmethod
+	def WriteToString(Sh: TopoDS_Shape) -> str: ...
+	@staticmethod
+	def ReadFromString(s: str) -> TopoDS_Shape: ...
 
 class BRepTools_History(Standard_Transient):
 	def AddGenerated(self, theInitial: TopoDS_Shape, theGenerated: TopoDS_Shape) -> None: ...
@@ -275,4 +279,6 @@ breptools_Update = breptools.Update
 breptools_UpdateFaceUVPoints = breptools.UpdateFaceUVPoints
 breptools_Write = breptools.Write
 breptools_Write = breptools.Write
+breptools_WriteToString = breptools.WriteToString
+breptools_ReadFromString = breptools.ReadFromString
 BRepTools_History_IsSupportedType = BRepTools_History.IsSupportedType

--- a/src/SWIG_files/wrapper/ShapeUpgrade.i
+++ b/src/SWIG_files/wrapper/ShapeUpgrade.i
@@ -37,6 +37,7 @@ https://www.opencascade.com/doc/occt-7.4.0/refman/html/package_shapeupgrade.html
 
 %{
 #include<Precision.hxx>
+#include<TopoDS_Edge.hxx>
 #include<ShapeUpgrade_UnifySameDomain.hxx>
 #include<ShapeUpgrade_module.hxx>
 

--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -1425,20 +1425,12 @@ None
 %extend TopoDS_Shape {
 %pythoncode {
 	def __getstate__(self):
-		from .BRepTools import BRepTools_ShapeSet
-		ss = BRepTools_ShapeSet()
-		ss.Add(self)
-		str_shape = ss.WriteToString()
-		indx = ss.Locations().Index(self.Location())
-		return str_shape, indx
+		from .BRepTools import breptools_WriteToString
+		str_shape = breptools_WriteToString(self)
+		return str_shape
 	def __setstate__(self, state):
-		from .BRepTools import BRepTools_ShapeSet
-		topods_str, indx = state
-		ss = BRepTools_ShapeSet()
-		ss.ReadFromString(topods_str)
-		the_shape = ss.Shape(ss.NbShapes())
-		location = ss.Locations().Location(indx)
-		the_shape.Location(location)
+		from .BRepTools import breptools_ReadFromString
+		the_shape = breptools_ReadFromString(state)
 		self.this = the_shape.this
 	}
 };

--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -1426,7 +1426,7 @@ None
 %pythoncode {
 	def __getstate__(self):
 		from .BRepTools import breptools_WriteToString
-		str_shape = breptools_WriteToString(self)
+		str_shape = breptools_WriteToString(self, True)
 		return str_shape
 	def __setstate__(self, state):
 		from .BRepTools import breptools_ReadFromString

--- a/test/core_wrapper_features_unittest.py
+++ b/test/core_wrapper_features_unittest.py
@@ -32,6 +32,7 @@ import OCC.Core
 from OCC.Core.AIS import AIS_Manipulator
 from OCC.Core.Standard import Standard_Transient
 from OCC.Core.Bnd import Bnd_Box
+from OCC.Core.TopAbs import TopAbs_REVERSED
 from OCC.Core.BRepExtrema import BRepExtrema_ShapeProximity
 from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_Sewing
 from OCC.Core.BRepBndLib import brepbndlib_Add
@@ -368,7 +369,11 @@ class TestWrapperFeatures(unittest.TestCase):
         '''
         # Create the shape
         box_shape = BRepPrimAPI_MakeBox(100, 200, 300).Shape()
-        shp_dump = pickle.dumps(box_shape)
+        # We reverse the orientation to check whether the orientation
+        # is conserved. Up until 2021-10-21 this was not the case!
+        box_shape.Reverse()
+        self.assertEqual(box_shape.Orientation(), TopAbs_REVERSED)
+        shp_dump = pickle.dumps(box_shape)        
         # file to dump to/from
         filename = os.path.join('.', 'test_io', 'box_shape_generated.brep')
         # write to file
@@ -377,7 +382,8 @@ class TestWrapperFeatures(unittest.TestCase):
         self.assertTrue(os.path.isfile(filename))
         # load from file
         with open(filename, "rb") as dump_from_file:
-            pickled_shape = pickle.load(dump_from_file)
+            pickled_shape = pickle.load(dump_from_file)        
+        self.assertEqual(pickled_shape.Orientation(), TopAbs_REVERSED)
         self.assertFalse(pickled_shape.IsNull())
 
     def test_sub_class(self) -> None:

--- a/test/core_wrapper_features_unittest.py
+++ b/test/core_wrapper_features_unittest.py
@@ -41,7 +41,6 @@ from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
 from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeVertex,
                                      BRepBuilderAPI_MakeEdge,
                                      BRepBuilderAPI_Sewing)
-from OCC.Core.BRepTools import breptools_WriteToString
 from OCC.Core.gp import (gp_Pnt, gp_Vec, gp_Pnt2d, gp_Lin, gp_Dir, gp_Ax1, gp_Ax2,
                          gp_Quaternion, gp_QuaternionSLerp, gp_XYZ, gp_Mat, gp_Trsf)
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_Transform
@@ -380,7 +379,8 @@ class TestWrapperFeatures(unittest.TestCase):
         # pickling+unpickling. Up until 2021/10/22 pickling+unpickling
         # deminished the precision of the shape's state
         trns = gp_Trsf()
-        trns.SetRotation(gp_Ax1(gp_Pnt(0.32352626, 0.25136247235, 0.357357324625), gp_Dir(1/sqrt(3), 1/sqrt(3), 1/sqrt(3))), 
+        trns.SetRotation(gp_Ax1(gp_Pnt(0.32352626, 0.25136247235, 0.357357324625),
+                                gp_Dir(1/sqrt(3), 1/sqrt(3), 1/sqrt(3))),
                          0.63572456358579834535746)
         rotator = BRepBuilderAPI_Transform(trns)
         rotator.Perform(box_shape)
@@ -398,10 +398,10 @@ class TestWrapperFeatures(unittest.TestCase):
         self.assertTrue(os.path.isfile(filename))
         # load from file
         with open(filename, "rb") as dump_from_file:
-            pickled_shape = pickle.load(dump_from_file)        
+            pickled_shape = pickle.load(dump_from_file)
         self.assertEqual(pickled_shape.Orientation(), TopAbs_REVERSED)
         self.assertFalse(pickled_shape.IsNull())
-        
+
         # compare value after unpickling with value before pickling. If no rounding
         # occured, this should work!
         state_after_pickling = pickled_shape.Location().Transformation().VectorialPart().Value(1, 3)


### PR DESCRIPTION
Up until now pickling rounded the shape. In our application this lead to slight differences between calculations done in the same process and calculations done in a subprocess (which was communicated with via pickle/unpickle). Building on top of PR #1042 I added an option to breptools_WriteToString to have full precision. In this case then the writing is done with a stringstream using 17 digits and a scientific floating point format. 

Perhaps - this would be a design decision up to you - it's more reasonable to always use full precision in breptools_WriteToString. I already made `full_precision = True` the default. My idea was that someone might still want to be able to exactly reproduce previously written brep files. 

Please note that 

- this PR is based upon previously commited PRs #1040 and #1042
- this PR contains the actual change in the generated code files and is logically connected to PR tpaviot/pythonocc-generator#83
