### PR TITLE
Fix opacity parameter

### DIFF
--- a/src/Display/WebGl/jupyter_renderer.py
+++ b/src/Display/WebGl/jupyter_renderer.py
@@ -763,6 +763,7 @@ class JupyterRenderer:
         material.polygonOffsetUnits = 1
         material.transparent = transparent
         material.opacity = opacity
+        material.alpha = opacity
         material.update("metalness", 0.3)
         material.update("roughness", 0.8)
         return material

--- a/src/Display/WebGl/jupyter_renderer.py
+++ b/src/Display/WebGl/jupyter_renderer.py
@@ -575,7 +575,7 @@ class JupyterRenderer:
                       mesh will be less precise, i.e. lower numer of triangles.
         transparency: optional, False by default (opaque).
         opacity: optional, float, by default to 1 (opaque). if transparency is set to True,
-                 0. is fully opaque, 1. is fully transparent.
+                 1. is fully opaque, 0. is fully transparent.
         topo_level: "default" by default. The value should be either "compound", "shape", "vertex".
         update: optional, False by default. If True, render all the shapes.
         selectable: if True, can be doubleclicked from the 3d window


### PR DESCRIPTION
Currently in JupyterViewer, with `DisplayShape`, `AddShapeToScene`, etc., if `transparency` is set to `True` then setting `opacity` has no effect - even if 0. or 1. The shape is semi-transparent with no control over the amount.

It seems the `alpha` needs to be set from this value on the material rather than `opacity`. Not sure if the `material.opacity = opacity` can be removed?

Also, the former docstring seems to be contradictory and the wrong way round.