### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/Display/WebGl/jupyter_renderer.py
+++ b/src/Display/WebGl/jupyter_renderer.py
@@ -355,7 +355,7 @@ class JupyterRenderer:
         self._camera_distance_factor = 6
         self._camera_initial_zoom = 2.5
 
-        # a dictionnary of all the shapes belonging to the renderer
+        # a dictionary of all the shapes belonging to the renderer
         # each element is a key 'mesh_id:shape'
         self._shapes = {}
 
@@ -572,7 +572,7 @@ class JupyterRenderer:
         vertex_color: optional
         quality: optional, 1.0 by default. If set to something lower than 1.0,
                       mesh will be more precise. If set to something higher than 1.0,
-                      mesh will be less precise, i.e. lower numer of triangles.
+                      mesh will be less precise, i.e. lower number of triangles.
         transparency: optional, False by default (opaque).
         opacity: optional, float, by default to 1 (opaque). if transparency is set to True,
                  1. is fully opaque, 0. is fully transparent.

--- a/src/Display/WebGl/simple_server.py
+++ b/src/Display/WebGl/simple_server.py
@@ -30,7 +30,7 @@ def get_available_port(port):
     * takes a port number (an integer), above 1024
     * check if it is available
     * if not, take another one
-    * returns the port numer
+    * returns the port number
     """
     if not port > 1024:
         raise AssertionError("port number should be > 1024")

--- a/src/Display/WebGl/threejs_renderer.py
+++ b/src/Display/WebGl/threejs_renderer.py
@@ -57,7 +57,7 @@ def export_edgedata_to_json(edge_hash, point_set):
     for point in point_set:
         for coord in point:
             points_coordinates.append(coord)
-    # then build the dictionnary exported to json
+    # then build the dictionary exported to json
     edges_data = {"metadata": {"version": 4.4,
                                "type": "BufferGeometry",
                                "generator": "pythonocc"},

--- a/src/Display/WebGl/x3dom_renderer.py
+++ b/src/Display/WebGl/x3dom_renderer.py
@@ -434,7 +434,7 @@ class X3DomRenderer:
 
     def generate_html_file(self, axes_plane, axes_plane_zoom_factor):
         """ Generate the HTML file to be rendered wy the web browser
-        axes_plane: a boolean, telles wether or not display axes
+        axes_plane: a boolean, telles whether or not display axes
         """
         with open(self._html_filename, "w") as html_file:
             html_file.write("<!DOCTYPE HTML>\n")

--- a/src/Display/wxDisplay.py
+++ b/src/Display/wxDisplay.py
@@ -67,7 +67,7 @@ class wxBaseViewer(wx.Panel):
         win_id = self.GetHandle()
         init_time = time.time()
         delta_t = 0.  # elapsed time, initialized to 0 before the while loop
-        # if ever win_id is 0, enter the loop untill it gets a value
+        # if ever win_id is 0, enter the loop until it gets a value
         while win_id == 0 and delta_t < timeout:
             time.sleep(0.1)
             wx.SafeYield()

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -93,7 +93,7 @@ void ShapeTesselator::SetDeviation(Standard_Real aDeviation)
 void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool parallel)
 {
     TopExp_Explorer ExpFace;
-    // clean shape to remove any previous tringulation
+    // clean shape to remove any previous triangulation
     BRepTools::Clean(myShape);
     //Triangulate
     BRepMesh_IncrementalMesh(myShape, myDeviation*mesh_quality, false, 0.5*mesh_quality, parallel);


### PR DESCRIPTION
There are small typos in:
- src/Display/WebGl/jupyter_renderer.py
- src/Display/WebGl/simple_server.py
- src/Display/WebGl/threejs_renderer.py
- src/Display/WebGl/x3dom_renderer.py
- src/Display/wxDisplay.py
- src/Tesselator/ShapeTesselator.cpp

Fixes:
- Should read `number` rather than `numer`.
- Should read `dictionary` rather than `dictionnary`.
- Should read `whether` rather than `wether`.
- Should read `until` rather than `untill`.
- Should read `triangulation` rather than `tringulation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md