### PR TITLE
Add missing call of keyPressEvent in the super class

### DIFF
--- a/src/Display/qtDisplay.py
+++ b/src/Display/qtDisplay.py
@@ -138,6 +138,7 @@ class qtViewer3d(qtBaseViewer):
         self._current_cursor = "arrow"
 
     def keyPressEvent(self, event):
+        super(qtViewer3d, self).keyPressEvent(event)
         code = event.key()
         if code in self._key_map:
             self._key_map[code]()


### PR DESCRIPTION
I use the qtViewer3d as a QWidget in my application, keyPressEvents in the 3D Viewer don't get passed to my main_window.

Here is an easy fix that was probably just forgotten when implemented.