### PR TITLE
Fixes for python 3.10

### DIFF
--- a/src/Display/SimpleGui.py
+++ b/src/Display/SimpleGui.py
@@ -179,8 +179,8 @@ def init_display(
             def centerOnScreen(self) -> None:
                 """Centers the window on the screen."""
                 resolution = QtWidgets.QApplication.desktop().screenGeometry()
-                x = (resolution.width() - self.frameSize().width()) / 2
-                y = (resolution.height() - self.frameSize().height()) / 2
+                x = (resolution.width() - self.frameSize().width()) // 2
+                y = (resolution.height() - self.frameSize().height()) // 2
                 self.move(x, y)
 
             def add_menu(self, menu_name: str) -> None:


### PR DESCRIPTION
After updating my system python to 3.10, pythonocc started crashing.

 Example:
```bash
14:08 $ ./core_classic_occ_bottle.py 
creating bottle
bottle finished
 ###### 3D rendering pipe initialisation #####
Display3d class initialization starting ...
Aspect_DisplayConnection created.
Graphic_Driver created.
V3d_Viewer created.
AIS_InteractiveContext created.
V3d_View created
Traceback (most recent call last):
  File "/home/nilsson/devel/pythonocc-demos/examples/./core_classic_occ_bottle.py", line 232, in <module>
    display, start_display, add_menu, add_function_to_menu = init_display()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 188, in init_display
    win = MainWindow()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 159, in __init__
    self.centerOnScreen()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 166, in centerOnScreen
    self.move(x, y)
TypeError: arguments did not match any overloaded call:
  move(self, QPoint): argument 1 has unexpected type 'float'
  move(self, int, int): argument 1 has unexpected type 'float'
```

Turns out, python 3.10 removes implicit conversions in some cases:
> Builtin and extension functions that take integer arguments no longer
> accept Decimals, Fractions and other objects ...

https://docs.python.org/3.10/whatsnew/3.10.html#other-language-changes

This patch fixes the crash on my system.