### PR TITLE
Fix trying to center using floating point numbers

### DIFF
--- a/src/Display/SimpleGui.py
+++ b/src/Display/SimpleGui.py
@@ -179,8 +179,8 @@ def init_display(
             def centerOnScreen(self) -> None:
                 """Centers the window on the screen."""
                 resolution = QtWidgets.QApplication.desktop().screenGeometry()
-                x = (resolution.width() - self.frameSize().width()) / 2
-                y = (resolution.height() - self.frameSize().height()) / 2
+                x = (resolution.width() - self.frameSize().width()) // 2
+                y = (resolution.height() - self.frameSize().height()) // 2
                 self.move(x, y)
 
             def add_menu(self, menu_name: str) -> None:


### PR DESCRIPTION
Fixes the following error for me:
```
Traceback (most recent call last):
    init_display()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 208, in init_display
    win = MainWindow()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 177, in __init__
    self.centerOnScreen()
  File "/usr/lib/python3.10/site-packages/OCC/Display/SimpleGui.py", line 184, in centerOnScreen
    self.move(x, y)
TypeError: arguments did not match any overloaded call:
  move(self, QPoint): argument 1 has unexpected type 'float'
  move(self, int, int): argument 1 has unexpected type 'float'
```
Might be some edge case, that `self.frameSize().width()/.height()` results in an odd number for me. Flooring the result fixes it.  