### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ can compile/use it :
 *   the python programming language (<http://www.python.org>). Python 3.x is required. Python 2
 is officially dropped since the release 7.5.0.
 
-*   OpenCascade 7.5.2 (<https://dev.opencascade.org>), direct source download at https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=0dc2c377fc5a2d8cf065f4ec005e356240cb484c;sf=tgz
+*   OpenCascade 7.5.3 (<https://dev.opencascade.org>), direct source download at https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=fecb042498514186bd37fa621cdcf09eb61899a3;sf=tgz
 
     IMPORTANT: OpenCASCADE has to be compiled using flag -D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
 


### PR DESCRIPTION
Changed OCC commit point to to 7.5.3 tag because following README.md in it's current state yields the following error.
```
CMake Error at CMakeLists.txt:151 (find_package):
  Could not find a configuration file for package "OpenCASCADE" that is
  compatible with requested version "7.5.3".

  The following configuration files were considered but not accepted:

    /usr/local/lib/cmake/opencascade/OpenCASCADEConfig.cmake, version: 7.5.2
    /home/thomas/Downloads/occt-0dc2c37/cmake-build/OpenCASCADEConfig.cmake, version: 7.5.2
```