### PR TITLE
minor fix on qtdisplay

### DIFF
--- a/src/Display/qtDisplay.py
+++ b/src/Display/qtDisplay.py
@@ -341,7 +341,7 @@ class qtViewer3dWithManipulator(qtViewer3d):
         modifiers = evt.modifiers()
         # TRANSFORM via MANIPULATOR or ROTATE
         if (
-            buttons == QtCore.Qt.Button.LeftButton
+            buttons == QtCore.Qt.MouseButton.LeftButton
             and modifiers != QtCore.Qt.Modifier.SHIFT
         ):
             if self.manipulator.HasActiveMode():


### PR DESCRIPTION
It resolves the following error from PySide2 or PyQt5 :

```bash
 File "/usr/lib/python3/dist-packages/OCC/Display/qtDisplay.py", line 344, in mouseMoveEvent
    buttons == QtCore.Qt.Button.LeftButton
AttributeError: type object 'PySide2.QtCore.Qt' has no attribute 'Button' 

```

see issue https://github.com/tpaviot/pythonocc-core/issues/1280