### PR TITLE
Fix installation instructions after 83687c4

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ mkdir cmake-build && cd cmake-build
 RUN cmake \
  -DOCCT_INCLUDE_DIR=/opt/occt781/include/opencascade \
  -DOCCT_LIBRARY_DIR=/opt/occt781/lib \
- -DPYTHONOCC_BUILD_TYPE=Release \
+ -DCMAKE_BUILD_TYPE=Release \
  -DPYTHONOCC_INSTALL_DIRECTORY=<PATH-TO-INSTALL> \
   ..
 


### PR DESCRIPTION
Since `PYTHONOCC_BUILD_TYPE` is deprecated.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the installation documentation to replace the deprecated `PYTHONOCC_BUILD_TYPE` with `CMAKE_BUILD_TYPE` in the build configuration instructions.

- **Documentation**:
    - Updated installation instructions to replace deprecated `PYTHONOCC_BUILD_TYPE` with `CMAKE_BUILD_TYPE`.

<!-- Generated by sourcery-ai[bot]: end summary -->