### PR TITLE
Fix TopTools_ListIteratorOfListOfShape import

### DIFF
--- a/src/Extend/TopologyUtils.py
+++ b/src/Extend/TopologyUtils.py
@@ -38,7 +38,7 @@ from OCC.Core.TopAbs import (
 )
 from OCC.Core.TopExp import TopExp_Explorer, topexp
 from OCC.Core.TopTools import (
-    TopTools_ListIteratorOfListOfShape,
+    TopTools_ListOfListOfShape,
     TopTools_IndexedDataMapOfShapeListOfShape,
 )
 from OCC.Core.TopoDS import (
@@ -332,7 +332,7 @@ class TopologyExplorer:
         if results.Size() == 0:
             yield None
 
-        topology_iterator = TopTools_ListIteratorOfListOfShape(results)
+        topology_iterator = TopTools_ListOfListOfShape(results)
         while topology_iterator.More():
             topo_entity = self.topology_factory[topology_type_2](
                 topology_iterator.Value()
@@ -380,7 +380,7 @@ class TopologyExplorer:
         results = _map.FindFromKey(topological_entity)
         if results.Size() == 0:
             return None
-        topology_iterator = TopTools_ListIteratorOfListOfShape(results)
+        topology_iterator = TopTools_ListOfListOfShape(results)
         while topology_iterator.More():
             topo_set.add(topology_iterator.Value())
             topology_iterator.Next()


### PR DESCRIPTION
TopTools_ListIteratorOfListOfShape must be replaced by TopTools_ListOfListOfShape

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the import issue in TopologyUtils.py by replacing TopTools_ListIteratorOfListOfShape with the correct TopTools_ListOfListOfShape.

- **Bug Fixes**:
    - Replaced incorrect usage of TopTools_ListIteratorOfListOfShape with TopTools_ListOfListOfShape in TopologyUtils.py.

<!-- Generated by sourcery-ai[bot]: end summary -->