### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,16 +31,16 @@ cd swig-4.2.1
 
 Build OpenCascade
 -----------------
-Download/extract version 7.8.1 https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=bd2a789f15235755ce4d1a3b07379a2e062fdc2e;sf=tgz
+Download/extract version 7.8.1 https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_8_1.tar.gz
 
 ```bash
-wget -O occt-7.8.1.tgz https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=bd2a789f15235755ce4d1a3b07379a2e062fdc2e;sf=tgz
-tar -zxvf occt-7.8.1.tgz
+wget https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_8_1.tar.gz
+tar -xvzf V7_8_1.tar.gz
 ```
 
 Prepare the build stage:
 ```bash
-cd occt-bd2a789
+cd OCCT-7.8.1
 mkdir cmake-build
 cd cmake-build
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,19 +68,22 @@ git clone https://github.com/tpaviot/pythonocc-core.git
 ```
 then
 ```bash
-cd xx/pythonocc-core
+cd pythonocc-core
 mkdir cmake-build && cd cmake-build
 
-RUN cmake \
+# Path to the installation folder
+INSTALL_DIR=<PATH-TO-INSTALL>
+
+cmake \
  -DOCCT_INCLUDE_DIR=/opt/occt781/include/opencascade \
  -DOCCT_LIBRARY_DIR=/opt/occt781/lib \
  -DCMAKE_BUILD_TYPE=Release \
- -DPYTHONOCC_INSTALL_DIRECTORY=<PATH-TO-INSTALL> \
+ -DPYTHONOCC_INSTALL_DIRECTORY=$INSTALL_DIR \
   ..
 
-RUN make -j4 && make install 
+make -j4 && make install 
 
-RUN  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/build/occt781/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/build/occt781/lib
 ```
 
 If `PYTHONOCC_INSTALL_DIRECTORY` is unset, it will be installed to `site-packages/OCC`. Also add your LD_LIBRARY_PATH in your .bashrc file.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,13 +72,13 @@ cd pythonocc-core
 mkdir cmake-build && cd cmake-build
 
 # Path to the installation folder
-INSTALL_DIR=<PATH-TO-INSTALL>
+PYTHONOCC_INSTALL_DIRECTORY=<PATH-TO-INSTALL>
 
 cmake \
  -DOCCT_INCLUDE_DIR=/opt/occt781/include/opencascade \
  -DOCCT_LIBRARY_DIR=/opt/occt781/lib \
  -DCMAKE_BUILD_TYPE=Release \
- -DPYTHONOCC_INSTALL_DIRECTORY=$INSTALL_DIR \
+ -DPYTHONOCC_INSTALL_DIRECTORY=$PYTHONOCC_INSTALL_DIRECTORY \
   ..
 
 make -j4 && make install 


### PR DESCRIPTION
The package located in OCCT gitolite is not well type defined. Better to use GitHub releases. They are up-to-date.
Right now with old guide there is a next issue:

```
gzip: stdin: not in gzip format tar: Child returned status 1 tar:
Error is not recoverable:
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the installation instructions in INSTALL.md to recommend downloading OpenCascade from GitHub releases, ensuring users access the most up-to-date and well-defined package.

Documentation:
- Update INSTALL.md to use GitHub releases for downloading OpenCascade version 7.8.1 instead of using the OCCT gitolite repository.

<!-- Generated by sourcery-ai[bot]: end summary -->