### PR TITLE
Add hash eq and neq operations to TShape

### DIFF
--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -1980,10 +1980,43 @@ Returns the type as a term of the shapeenum enum: vertex, edge, wire, face, ....
 ") ShapeType;
 		virtual TopAbs_ShapeEnum ShapeType();
 
+
+%extend{
+    bool __ne_wrapper__(const opencascade::handle<TopoDS_TShape> & other) {
+    if (self!=other) return true;
+    else return false;
+    }
+}
+%pythoncode {
+def __ne__(self, right):
+    try:
+        return self.__ne_wrapper__(right)
+    except:
+        return True
+}
+
+%extend{
+    bool __eq_wrapper__(const opencascade::handle<TopoDS_TShape> & other) {
+    if (self==other) return true;
+    else return false;
+    }
+}
+%pythoncode {
+def __eq__(self, right):
+    try:
+        return self.__eq_wrapper__(right)
+    except:
+        return False
+}
 };
 
 
 %make_alias(TopoDS_TShape)
+
+%extend TopoDS_TShape {
+    size_t __hash__() {
+    return opencascade::hash(self);}
+};
 
 %extend TopoDS_TShape {
 	%pythoncode {

--- a/test/test_core_wrapper_features.py
+++ b/test/test_core_wrapper_features.py
@@ -539,6 +539,38 @@ def test_neq_operator() -> None:
     assert shape_1 != "some_string"
 
 
+def test_tshape_hash_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert hash(shape_1.TShape()) == hash(shape_1.TShape())
+    assert not hash(shape_1.TShape()) == hash(shape_2.TShape())
+    assert hash(shape_2.TShape()) == hash(shape_3.TShape())
+
+
+def test_tshape_eq_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert shape_1.TShape() == shape_1.TShape()
+    assert not shape_1.TShape() == shape_2.TShape()
+    assert shape_2.TShape() == shape_3.TShape()
+    assert not shape_1.TShape() == "some_string"
+
+
+def test_tshape_neq_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert not shape_1.TShape() != shape_1.TShape()
+    assert shape_1.TShape() != shape_2.TShape()
+    assert not shape_2.TShape() != shape_3.TShape()
+    assert shape_1.TShape() != "some_string"
+
+
 def test_inherit_topods_shape() -> None:
     class InheritEdge(TopoDS_Edge):
         def __init__(self, edge: TopoDS_Edge) -> None:


### PR DESCRIPTION
Fixes the issue where the `__hash__`, `__eq__` and `__neq__` operators of TopoDS_TShape are not implemented, giving unexpected results like: 
```
from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox

shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()

shape_1.TShape() == shape_1.TShape()    # Expected: True, but is False
hash(shape_1.TShape()) == hash(shape_1.TShape())    # Expected: True, but is False
```

This fix allows properly comparing TopoDS_TShapes and using them in sets/dictionaries.

## Summary by Sourcery

Implement hash, equality, and inequality operators for TopoDS_TShape to fix comparison issues and enable usage in sets and dictionaries, and add corresponding tests.

New Features:
- Implement `__hash__`, `__eq__`, and `__neq__` operators for TopoDS_TShape to enable proper comparison and usage in sets and dictionaries.

Tests:
- Add tests for the `__hash__`, `__eq__`, and `__neq__` operators of TopoDS_TShape to ensure correct functionality.