### PR TITLE
Add hash/eq/neq for Standard_Transient and its derivatives

### DIFF
--- a/src/SWIG_files/wrapper/BOPDS.i
+++ b/src/SWIG_files/wrapper/BOPDS.i
@@ -3152,8 +3152,8 @@ Sets the indices.
 
 %extend{
     bool __eq_wrapper__(const BOPDS_Pair other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3322,8 +3322,8 @@ Modifier sets the parameter of vertex <theparameter>.
 
 %extend{
     bool __eq_wrapper__(const BOPDS_Pave other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/BOPTools.i
+++ b/src/SWIG_files/wrapper/BOPTools.i
@@ -2466,8 +2466,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const BOPTools_Set other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/BRepMesh.i
+++ b/src/SWIG_files/wrapper/BRepMesh.i
@@ -3262,8 +3262,8 @@ Returns index of last node of the link.
 
 %extend{
     bool __eq_wrapper__(const BRepMesh_OrientedEdge other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -4232,8 +4232,8 @@ Sets movability of the triangle.
 
 %extend{
     bool __eq_wrapper__(const BRepMesh_Triangle other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -4510,8 +4510,8 @@ Sets movability of the vertex.
 
 %extend{
     bool __eq_wrapper__(const BRepMesh_Vertex other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -5254,8 +5254,8 @@ Sets movability flag of the link. @param themovability flag to be set.
 
 %extend{
     bool __eq_wrapper__(const BRepMesh_Edge other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/Bnd.i
+++ b/src/SWIG_files/wrapper/Bnd.i
@@ -4328,8 +4328,8 @@ Joins *this and theother to one interval. replaces *this to the result. returns 
 
 %extend{
     bool __eq_wrapper__(const Bnd_Range other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/Geom2dConvert.i
+++ b/src/SWIG_files/wrapper/Geom2dConvert.i
@@ -930,8 +930,8 @@ Change the value of the derivative at the point.
 
 %extend{
     bool __ne_wrapper__(const Geom2dConvert_PPoint other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -944,8 +944,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Geom2dConvert_PPoint other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/Graphic3d.i
+++ b/src/SWIG_files/wrapper/Graphic3d.i
@@ -5086,8 +5086,8 @@ Normalizes bsdf components.
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_BSDF other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -8369,8 +8369,8 @@ Return offset position from lower-left corner.
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_CameraTile other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -10283,8 +10283,8 @@ Returns serialized representation of fresnel factor.
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_Fresnel other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -13603,8 +13603,8 @@ Returns the transparency coefficient of the surface (1.0 - alpha); 0.0 means opa
 
 %extend{
     bool __ne_wrapper__(const Graphic3d_MaterialAspect other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -13617,8 +13617,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_MaterialAspect other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -14038,8 +14038,8 @@ Shows how much times less samples can be used in certain roughness value specula
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_PBRMaterial other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -14103,8 +14103,8 @@ Dump the object to JSON string.
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_PolygonOffset other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -19713,8 +19713,8 @@ Return world view state counter.
 
 %extend{
     bool __ne_wrapper__(const Graphic3d_WorldViewProjState other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -19727,8 +19727,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Graphic3d_WorldViewProjState other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/IGESData.i
+++ b/src/SWIG_files/wrapper/IGESData.i
@@ -5043,8 +5043,8 @@ Returns 'type' data.
 
 %extend{
     bool __eq_wrapper__(const IGESData_IGESType other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/IntPolyh.i
+++ b/src/SWIG_files/wrapper/IntPolyh.i
@@ -296,8 +296,8 @@ Sets the triangles.
 
 %extend{
     bool __eq_wrapper__(const IntPolyh_Couple other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/IntTools.i
+++ b/src/SWIG_files/wrapper/IntTools.i
@@ -5500,8 +5500,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const IntTools_SurfaceRangeSample other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -6389,8 +6389,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const IntTools_CurveRangeSample other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/Intf.i
+++ b/src/SWIG_files/wrapper/Intf.i
@@ -744,8 +744,8 @@ Reverses the order of the elements of the sectionline.
 
 %extend{
     bool __eq_wrapper__(const Intf_SectionLine other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1065,8 +1065,8 @@ Returns the type of the section point on the second element.
 
 %extend{
     bool __eq_wrapper__(const Intf_SectionPoint other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1413,8 +1413,8 @@ Returns true if <thepi> is in the parameter range of the tangentzone.
 
 %extend{
     bool __eq_wrapper__(const Intf_TangentZone other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/MAT2d.i
+++ b/src/SWIG_files/wrapper/MAT2d.i
@@ -305,8 +305,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const MAT2d_BiInt other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/MeshVS.i
+++ b/src/SWIG_files/wrapper/MeshVS.i
@@ -3539,8 +3539,8 @@ class MeshVS_TwoColors {
 
 %extend{
     bool __eq_wrapper__(const MeshVS_TwoColors other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3588,8 +3588,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const MeshVS_TwoNodes other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/NCollection.i
+++ b/src/SWIG_files/wrapper/NCollection.i
@@ -88,6 +88,10 @@ from OCC.Core.Exception import *
 %ignore NCollection_List::First();
 %ignore NCollection_List::Last();
 %ignore NCollection_TListIterator::Value();
+
+%ignore NCollection_Array2::Value();
+%ignore NCollection_Array2::ChangeValue();
+%ignore NCollection_Array2::operator();
 /* public enums */
 enum NCollection_CellFilter_Action {
 	CellFilter_Keep = 0,

--- a/src/SWIG_files/wrapper/Quantity.i
+++ b/src/SWIG_files/wrapper/Quantity.i
@@ -2641,8 +2641,8 @@ Returns in thec1, thec2 and thec3 the components of this color according to the 
 
 %extend{
     bool __ne_wrapper__(const Quantity_Color other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -2655,8 +2655,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Quantity_Color other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3058,8 +3058,8 @@ Assign new values to the color.
 
 %extend{
     bool __ne_wrapper__(const Quantity_ColorRGBA other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3072,8 +3072,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Quantity_ColorRGBA other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3496,8 +3496,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const Quantity_Date other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3834,8 +3834,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const Quantity_Period other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/RWPly.i
+++ b/src/SWIG_files/wrapper/RWPly.i
@@ -798,25 +798,6 @@ Return number of written vertices.
 ") NbWrittenVertices;
 		Standard_Integer NbWrittenVertices();
 
-		/****************** Open ******************/
-		/**** md5 signature: 8602e84f6acfb0cc325e9d67eb1ded24 ****/
-		%feature("compactdefaultargs") Open;
-		%feature("autodoc", "
-Parameters
-----------
-theName: str
-theStream: std::shared_ptr<std::ostream> (optional, default to std::shared_ptr<std::ostream>())
-
-Return
--------
-bool
-
-Description
------------
-Open file for writing.
-") Open;
-		bool Open(TCollection_AsciiString theName, const std::shared_ptr<std::ostream> & theStream = std::shared_ptr<std::ostream>());
-
 		/****************** SetColors ******************/
 		/**** md5 signature: ba154b7155d7a27211ce6b222d360537 ****/
 		%feature("compactdefaultargs") SetColors;
@@ -1052,6 +1033,10 @@ Write single point with all attributes. @param[in] thepoint 3d point coordinates
 %extend RWPly_PlyWriterContext {
 	%pythoncode {
 	__repr__ = _dumps_object
+
+	@methodnotwrapped
+	def Open(self):
+		pass
 	}
 };
 

--- a/src/SWIG_files/wrapper/Standard.i
+++ b/src/SWIG_files/wrapper/Standard.i
@@ -595,7 +595,7 @@ Removes handler from the handlers list.
 **********************/
 class Standard_GUID {
 	public:
-		friend struct std:: hash;
+		friend struct std::hash ;
 		/****************** Standard_GUID ******************/
 		/**** md5 signature: bd47278e877fa95d24363f9cfe93d187 ****/
 		%feature("compactdefaultargs") Standard_GUID;
@@ -867,8 +867,8 @@ No available documentation.
 
 %extend{
     bool __ne_wrapper__(const Standard_GUID other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -881,8 +881,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Standard_GUID other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1243,6 +1243,36 @@ No available documentation.
 
 %make_alias(Standard_Transient)
 
+
+%extend Standard_Transient {
+    %pythoncode {
+    __repr__ = _dumps_object
+
+    def __eq__(self, right):
+        if not isinstance(right, Standard_Transient):
+            return False
+        return self.__eq_wrapper__(right)
+
+    def __ne__(self, right):
+        if not isinstance(right, Standard_Transient):
+            return True
+        return self.__ne_wrapper__(right)
+    }
+};
+
+%extend Standard_Transient {
+    bool __eq_wrapper__(const opencascade::handle<Standard_Transient> & other) {
+        if (self==other) return true;
+        else return false;
+    }
+    bool __ne_wrapper__(const opencascade::handle<Standard_Transient> & other) {
+        if (self!=other) return true;
+        else return false;
+    }
+    size_t __hash__() {
+        return opencascade::hash(self);
+    }
+};
 %extend Standard_Transient {
 	%pythoncode {
 	__repr__ = _dumps_object

--- a/src/SWIG_files/wrapper/StepToTopoDS.i
+++ b/src/SWIG_files/wrapper/StepToTopoDS.i
@@ -857,8 +857,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const StepToTopoDS_PointPair other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/TColStd.i
+++ b/src/SWIG_files/wrapper/TColStd.i
@@ -1135,8 +1135,8 @@ def __isub__(self, right):
 
 %extend{
     bool __eq_wrapper__(const TColStd_PackedMapOfInteger other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/TCollection.i
+++ b/src/SWIG_files/wrapper/TCollection.i
@@ -1637,8 +1637,8 @@ Returns character at position <where> in <self>. if <where> is less than zero or
 
 %extend{
     bool __ne_wrapper__(const Standard_CString other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1651,8 +1651,8 @@ def __ne__(self, right):
 
 %extend{
     bool __ne_wrapper__(const TCollection_AsciiString other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1810,8 +1810,8 @@ def __iadd__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Standard_CString other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1824,8 +1824,8 @@ def __eq__(self, right):
 
 %extend{
     bool __eq_wrapper__(const TCollection_AsciiString other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -2726,8 +2726,8 @@ Returns character at position <where> in <self>. if <where> is less than zero or
 
 %extend{
     bool __ne_wrapper__(const Standard_ExtString other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -2740,8 +2740,8 @@ def __ne__(self, right):
 
 %extend{
     bool __ne_wrapper__(const TCollection_ExtendedString other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -2783,8 +2783,8 @@ def __iadd__(self, right):
 
 %extend{
     bool __eq_wrapper__(const Standard_ExtString other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -2797,8 +2797,8 @@ def __eq__(self, right):
 
 %extend{
     bool __eq_wrapper__(const TCollection_ExtendedString other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/TDF.i
+++ b/src/SWIG_files/wrapper/TDF.i
@@ -2919,7 +2919,7 @@ Attributes with id owned by <anidlist> are to be kept and the filter will answer
 ******************/
 class TDF_Label {
 	public:
-		friend struct std:: hash;
+		friend struct std::hash ;
 		/****************** TDF_Label ******************/
 		/**** md5 signature: 1a8e59ba046467c4e163db826620fcdb ****/
 		%feature("compactdefaultargs") TDF_Label;
@@ -3485,8 +3485,8 @@ Returns the current transaction index.
 
 %extend{
     bool __ne_wrapper__(const TDF_Label other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -3499,8 +3499,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const TDF_Label other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/TopLoc.i
+++ b/src/SWIG_files/wrapper/TopLoc.i
@@ -593,8 +593,8 @@ Returns the transformation associated to the coordinate system.
 
 %extend{
     bool __ne_wrapper__(const TopLoc_Location other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -643,8 +643,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const TopLoc_Location other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -1612,8 +1612,8 @@ No available documentation.
 
 %extend{
     bool __ne_wrapper__(const TopoDS_Shape other) {
-    if (*self!=other) return true;
-    else return false;
+        if (*self!=other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1626,8 +1626,8 @@ def __ne__(self, right):
 
 %extend{
     bool __eq_wrapper__(const TopoDS_Shape other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -1643,9 +1643,10 @@ def __eq__(self, right):
 
 %extend TopoDS_Shape {
     size_t __hash__() {
-    std::hash<TopoDS_Shape> shapeHasher;
-    size_t hashValue = shapeHasher(*self);
-    return hashValue;}
+        std::hash<TopoDS_Shape> shapeHasher;
+        size_t hashValue = shapeHasher(*self);
+        return hashValue;
+    }
 };
 
 %extend TopoDS_Shape {

--- a/src/SWIG_files/wrapper/XCAFDoc.i
+++ b/src/SWIG_files/wrapper/XCAFDoc.i
@@ -1174,8 +1174,8 @@ Returns the full pass as a formatted string.
 
 %extend{
     bool __eq_wrapper__(const XCAFDoc_AssemblyItemId other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/XCAFPrs.i
+++ b/src/SWIG_files/wrapper/XCAFPrs.i
@@ -713,8 +713,8 @@ No available documentation.
 
 %extend{
     bool __eq_wrapper__(const XCAFPrs_DocumentNode other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {
@@ -786,7 +786,7 @@ No available documentation.
 **********************/
 class XCAFPrs_Style {
 	public:
-		friend struct std:: hash;
+		friend struct std::hash ;
 		/****************** XCAFPrs_Style ******************/
 		/**** md5 signature: 9543f66d0ab16adfbffa6f1ff76c2dd5 ****/
 		%feature("compactdefaultargs") XCAFPrs_Style;
@@ -1075,8 +1075,8 @@ Manage surface color setting.
 
 %extend{
     bool __eq_wrapper__(const XCAFPrs_Style other) {
-    if (*self==other) return true;
-    else return false;
+        if (*self==other) return true;
+        else return false;
     }
 }
 %pythoncode {

--- a/src/SWIG_files/wrapper/generator.log
+++ b/src/SWIG_files/wrapper/generator.log
@@ -2,13 +2,13 @@
 ############################
 Running pythonocc-generator.
 ############################
-git revision : 0a2712e
+git revision : 020d4e8
 
-operating system : Linux 64bit 6.5.0-35-generic
+operating system : Linux 64bit 6.8.0-48-generic
 
 occt version targeted : 7.8.1
 
-date : 2024-05-22 13:48:56.569965
+date : 2024-11-08 14:20:50.686717
 ############################
 
 [INFO ]  Processing toolkit TKBO ===
@@ -280,11 +280,7 @@ date : 2024-05-22 13:48:56.569965
 [INFO ]  Class: BRepTools
 [INFO ]  Class: BRepTools_History
 [INFO ]  Enum: TRelationType
-[INFO ]      explicitly excluded method BRepTools_History::4a35f50a2b6bb1bb1303ad7d8374073c
-[INFO ]      explicitly excluded method BRepTools_History::7dfa827711ec2050a35ebaeda60fa3a6
-[INFO ]      explicitly excluded method BRepTools_History::fb045f600989a1f096e90b81d587d65a
-[INFO ]      explicitly excluded method BRepTools_History::bcea4b93e38784928b17c2d0cc2cf68c
-[INFO ]      explicitly excluded method BRepTools_History::1e361db725f2785773b933e1d47f0346
+[INFO ]      [TypeHint] More than 1 constructor, @overload decorator needed.
 [INFO ]  Class: BRepTools_Modification
 [INFO ]      Class BRepTools_Modification is abstract, using %nodefaultctor.
 [INFO ]  Class: BRepTools_Modifier
@@ -296,7 +292,6 @@ date : 2024-05-22 13:48:56.569965
 [INFO ]  Class: BRepTools_Quilt
 [INFO ]  Class: BRepTools_ReShape
 [INFO ]      Wrap nested class BRepTools_ReShape::TReplacement
-[INFO ]      explicitly excluded method BRepTools_ReShape::4a1e1cf3a68bb84f97ab6c753f9ff817
 [INFO ]  Class: BRepTools_ShapeSet
 [INFO ]      [TypeHint] More than 1 constructor, @overload decorator needed.
 [INFO ]  Class: BRepTools_Substitution
@@ -4635,7 +4630,7 @@ date : 2024-05-22 13:48:56.569965
 [INFO ]      Wrap nested class RWPly_ConfigurationNode::RWPly_InternalSection
 [INFO ]      [TypeHint] More than 1 constructor, @overload decorator needed.
 [INFO ]  Class: RWPly_PlyWriterContext
-[WARNI]      [TypeHint] Skip type std::shared_ptr<std::ostream>, because of trailing :
+[INFO ]      explicitly excluded method RWPly_PlyWriterContext::8602e84f6acfb0cc325e9d67eb1ded24
 [INFO ]  Class: RWPly_Provider
 [INFO ]      [TypeHint] More than 1 constructor, @overload decorator needed.
 [INFO ]  Processing toolkit TKSTEP ===
@@ -9559,8 +9554,8 @@ date : 2024-05-22 13:48:56.569965
 [INFO ]  Class: UnitsMethods
 [INFO ]  
 #################################################
-SWIG interface file generation completed in 17.47s
+SWIG interface file generation completed in 17.97s
 #################################################
 
 [INFO ]  Number of classes: 4743
-[INFO ]  Number of methods: 47534
+[INFO ]  Number of methods: 47536

--- a/test/test_core_wrapper_features.py
+++ b/test/test_core_wrapper_features.py
@@ -539,6 +539,38 @@ def test_neq_operator() -> None:
     assert shape_1 != "some_string"
 
 
+def test_tshape_hash_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert hash(shape_1.TShape()) == hash(shape_1.TShape())
+    assert not hash(shape_1.TShape()) == hash(shape_2.TShape())
+    assert hash(shape_2.TShape()) == hash(shape_3.TShape())
+
+
+def test_tshape_eq_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert shape_1.TShape() == shape_1.TShape()
+    assert not shape_1.TShape() == shape_2.TShape()
+    assert shape_2.TShape() == shape_3.TShape()
+    assert not shape_1.TShape() == "some_string"
+
+
+def test_tshape_neq_operator() -> None:
+    shape_1 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    shape_2 = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+    # Create a shape that differs from shape_2, but has the same TShape
+    shape_3 = shape_2.Reversed()
+    assert not shape_1.TShape() != shape_1.TShape()
+    assert shape_1.TShape() != shape_2.TShape()
+    assert not shape_2.TShape() != shape_3.TShape()
+    assert shape_1.TShape() != "some_string"
+
+
 def test_inherit_topods_shape() -> None:
     class InheritEdge(TopoDS_Edge):
         def __init__(self, edge: TopoDS_Edge) -> None:


### PR DESCRIPTION
and a couple other minor fixes

based on #1375

## Summary by Sourcery

Add hash, equality, and inequality operators for Standard_Transient and its derivatives, enhancing object comparison capabilities. Refactor existing operator implementations for improved readability. Include new tests to verify the functionality of these operators.

New Features:
- Introduce hash, equality, and inequality operators for Standard_Transient and its derivatives.

Enhancements:
- Refactor equality and inequality operator implementations for better readability across multiple classes.

Tests:
- Add tests for hash, equality, and inequality operators for TShape objects.