### PR TITLE
Fixed numpy interface for surface derivative computation; added tests

### DIFF
--- a/src/SWIG_files/common/ArrayMacros.i
+++ b/src/SWIG_files/common/ArrayMacros.i
@@ -474,8 +474,8 @@
         def eval_numpy_array(self, u_arr):
             return self.evalNumpy(u_arr, len(u_arr) * 3, 3).reshape(-1, 3)
 
-        def eval_derivative_numpy_array(self, u_arr, n_u):
-            return self.evalDerivativeNumpy(u_arr, len(u_arr) * 3, 3, n_u).reshape(-1, 3)
+        def eval_derivative_numpy_array(self, u_arr, n_u, n_v):
+            return self.evalDerivativeNumpy(u_arr, len(u_arr) * 3, 3, n_u, n_v).reshape(-1, 3)
         }
 
     };


### PR DESCRIPTION
Hi, I was made aware of a bug in the python interfaces for the numpy surface derivative computation, which made me realize that there were no tests. This PR fixes the error and supplements the tests.

## Summary by Sourcery

Fix the numpy interface for surface derivative computation and add tests to validate curve and surface derivative evaluations.

Bug Fixes:
- Fix the numpy interface for surface derivative computation by correcting the function signature to include an additional parameter.

Tests:
- Add tests for curve and surface derivative evaluations to ensure correct functionality of the numpy interface.