### PR TITLE
Tesselator minor coding fixes + Fix of a calculation error

### DIFF
--- a/src/Display/WebGl/x3dom_renderer.py
+++ b/src/Display/WebGl/x3dom_renderer.py
@@ -295,6 +295,10 @@ class X3DExporter:
 
     def compute(self):
         shape_tesselator = ShapeTesselator(self._shape)
+
+        if shape_tesselator.GetDeviation() <= 0:
+            raise ValueError("The deviation is <= 0.")
+
         shape_tesselator.Compute(
             compute_edges=self._export_edges,
             mesh_quality=self._mesh_quality,

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -42,9 +42,9 @@
 //---------------------------------------------------------------------------
 ShapeTesselator::ShapeTesselator(TopoDS_Shape aShape):
   myShape(aShape),
-  locVertexcoord(NULL),
-  locNormalcoord(NULL),
-  locTriIndices(NULL),
+  locVertexcoord(nullptr),
+  locNormalcoord(nullptr),
+  locTriIndices(nullptr),
   computed(false)
 {
     ComputeDefaultDeviation();
@@ -71,7 +71,7 @@ ShapeTesselator::~ShapeTesselator()
       if (edge) {
         delete[] edge->vertex_coord;
         delete edge;
-        *edgeit = NULL;
+        *edgeit = nullptr;
       }
     }
     edgelist.clear();
@@ -204,7 +204,7 @@ void ShapeTesselator::ComputeEdges()
     if (*it) {
       delete[] (*it)->vertex_coord;
       delete *it;
-      *it = NULL;
+      *it = nullptr;
     }
   }
   edgelist.clear();
@@ -694,16 +694,16 @@ void ShapeTesselator::JoinPrimitives()
     advance = obP;
 
     delete [] myface->vertex_coord;
-    myface->vertex_coord = NULL;
+    myface->vertex_coord = nullptr;
 
     delete [] myface->normal_coord;
-    myface->normal_coord = NULL;
+    myface->normal_coord = nullptr;
 
     delete [] myface->tri_indexes;
-    myface->tri_indexes = NULL;
+    myface->tri_indexes = nullptr;
 
     delete myface;
-    myface = NULL;
+    myface = nullptr;
 
     ++anIterator;
   }

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -42,12 +42,12 @@
 #include <utility>
 
 //---------------------------------------------------------------------------
-ShapeTesselator::ShapeTesselator(TopoDS_Shape  aShape):
+ShapeTesselator::ShapeTesselator(TopoDS_Shape& aShape):
   computed(false),
   locVertexcoord(nullptr),
   locNormalcoord(nullptr),
   locTriIndices(nullptr),
-  myShape(std::move(aShape))
+  myShape(aShape)
 {
     ComputeDefaultDeviation();
 }

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -38,10 +38,11 @@
 #include <BRep_Tool.hxx>
 #include <TopoDS_Face.hxx>
 #include <Precision.hxx>
+#include <utility>
 
 //---------------------------------------------------------------------------
-ShapeTesselator::ShapeTesselator(TopoDS_Shape aShape):
-  myShape(aShape),
+ShapeTesselator::ShapeTesselator(TopoDS_Shape  aShape):
+  myShape(std::move(aShape)),
   locVertexcoord(nullptr),
   locNormalcoord(nullptr),
   locTriIndices(nullptr),

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -438,7 +438,7 @@ void ShapeTesselator::ExportShapeToX3D(const char * filename, int diffR, int dif
     X3Dfile << "<!DOCTYPE X3D PUBLIC 'ISO//Web3D//DTD X3D 3.1//EN' 'https://www.web3d.org/specifications/x3d-3.1.dtd'>";
     X3Dfile << "<X3D>";
     X3Dfile << "<Head>";
-    X3Dfile << "<meta name='generator' content='pythonOCC, https://www.pythonocc.org'/>";
+    X3Dfile << "<meta name='generator' content='pythonOCC, https://github.com/tpaviot/pythonocc-core'/>";
     X3Dfile << "</Head>";
     X3Dfile << "<Scene><Transform scale='1 1 1'><Shape><Appearance><Material DEF='Shape_Mat' diffuseColor='0.65 0.65 0.7' ";
     X3Dfile << "specularColor='0.2 0.2 0.2'></Material></Appearance>";

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <stdexcept>
 //---------------------------------------------------------------------------
 #include <TopExp_Explorer.hxx>
 #include <Bnd_Box.hxx>
@@ -92,14 +93,16 @@ void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool par
     // clean shape to remove any previous tringulation
     BRepTools::Clean(myShape);
 
-    if (myDeviation == 0){
-       printf("There is no shape to tesselate\n");
-       return;
+    if (myDeviation <= 0){
+       throw std::invalid_argument("The deviation must be greater than 0");
+    };
+
+    if (mesh_quality <= 0){
+        throw std::invalid_argument("The mesh quality must be greater than 0");
     };
 
     //Triangulate
     BRepMesh_IncrementalMesh(myShape, myDeviation*mesh_quality, false, 0.5*mesh_quality, parallel);
-
 
     for (ExpFace.Init(myShape, TopAbs_FACE); ExpFace.More(); ExpFace.Next()) {
         Standard_Integer validFaceTriCount = 0;

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -424,10 +424,10 @@ void ShapeTesselator::ExportShapeToX3D(char * filename, int diffR, int diffG, in
     X3Dfile.open (filename);
     // write header
     X3Dfile << "<?xml version='1.0' encoding='UTF-8'?>" ;
-    X3Dfile << "<!DOCTYPE X3D PUBLIC 'ISO//Web3D//DTD X3D 3.1//EN' 'http://www.web3d.org/specifications/x3d-3.1.dtd'>";
+    X3Dfile << "<!DOCTYPE X3D PUBLIC 'ISO//Web3D//DTD X3D 3.1//EN' 'https://www.web3d.org/specifications/x3d-3.1.dtd'>";
     X3Dfile << "<X3D>";
     X3Dfile << "<Head>";
-    X3Dfile << "<meta name='generator' content='pythonOCC, http://www.pythonocc.org'/>";
+    X3Dfile << "<meta name='generator' content='pythonOCC, https://www.pythonocc.org'/>";
     X3Dfile << "</Head>";
     X3Dfile << "<Scene><Transform scale='1 1 1'><Shape><Appearance><Material DEF='Shape_Mat' diffuseColor='0.65 0.65 0.7' ";
     X3Dfile << "specularColor='0.2 0.2 0.2'></Material></Appearance>";

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -279,18 +279,18 @@ void ShapeTesselator::ComputeEdges()
         Handle(Poly_Triangulation) aPolyTria = BRep_Tool::Triangulation(aFace, aLoc);
         if (!aLoc.IsIdentity()) myTransf = aLoc.Transformation();
         // this holds the indices of the edge's triangulation to the actual points
-        Handle(Poly_PolygonOnTriangulation) aPoly = BRep_Tool::PolygonOnTriangulation(anEdge, aPolyTria, aLoc);
-        if (aPoly.IsNull()) continue; // polygon does not exist
+        Handle(Poly_PolygonOnTriangulation) aPoly2 = BRep_Tool::PolygonOnTriangulation(anEdge, aPolyTria, aLoc);
+        if (aPoly2.IsNull()) continue; // polygon does not exist
 
         // getting size and create the array
-        nbNodesInFace = aPoly->NbNodes();
+        nbNodesInFace = aPoly2->NbNodes();
         theEdge->number_of_coords = nbNodesInFace;
         theEdge->vertex_coord = new Standard_Real[nbNodesInFace * 3 * sizeof(Standard_Real)];
 
-        const TColStd_Array1OfInteger& indices = aPoly->Nodes();
+        const TColStd_Array1OfInteger& indices = aPoly2->Nodes();
 
         // go through the index array
-        for (Standard_Integer i=1;i <= aPoly->NbNodes();i++) {
+        for (Standard_Integer i=1;i <= aPoly2->NbNodes();i++) {
             gp_Pnt V = aPolyTria->Node(indices(i)).Transformed(myTransf).XYZ();
             int idx = (i - 1) * 3;
             theEdge->vertex_coord[idx] = V.X();

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -85,6 +85,10 @@ void ShapeTesselator::SetDeviation(Standard_Real aDeviation)
     myDeviation = aDeviation;   
 }
 
+Standard_Real ShapeTesselator::GetDeviation() const
+{
+  return myDeviation;
+}
 
 //---------------------------------------------------------------------------
 void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool parallel)

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -104,7 +104,6 @@ void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool par
         Handle(Poly_Triangulation) myT = BRep_Tool::Triangulation(myFace, aLocation);
 
         if (myT.IsNull()) {
-            invalidFaceTriCount++;
             continue;
         }
 
@@ -703,7 +702,6 @@ void ShapeTesselator::JoinPrimitives()
     myface->tri_indexes = nullptr;
 
     delete myface;
-    myface = nullptr;
 
     ++anIterator;
   }

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -205,11 +205,9 @@ void ShapeTesselator::ComputeDefaultDeviation()
     }
 
     //calculate the bounding box
-    Standard_Real aXmin,aYmin ,aZmin ,aXmax ,aYmax ,aZmax;
     aBox.Get(aXmin, aYmin, aZmin, aXmax, aYmax, aZmax);
 
-    Standard_Real adeviation = std::max(aXmax-aXmin, std::max(aYmax-aYmin, aZmax-aZmin)) * 2e-2 ;
-    myDeviation = adeviation;
+    myDeviation = std::max(aXmax-aXmin, std::max(aYmax-aYmin, aZmax-aZmin)) * 2e-2;
 }
 
 void ShapeTesselator::ComputeEdges()

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -417,7 +417,7 @@ std::string ShapeTesselator::ExportShapeToX3DTriangleSet()
   return str_ifs.str();
 }
 
-void ShapeTesselator::ExportShapeToX3D(char * filename, int diffR, int diffG, int diffB)
+void ShapeTesselator::ExportShapeToX3D(const char * filename, int diffR, int diffG, int diffB)
 {
   EnsureMeshIsComputed();
     std::ofstream X3Dfile;

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -91,6 +91,12 @@ void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool par
     TopExp_Explorer ExpFace;
     // clean shape to remove any previous tringulation
     BRepTools::Clean(myShape);
+
+    if (myDeviation == 0){
+       printf("There is no shape to tesselate\n");
+       return;
+    };
+
     //Triangulate
     BRepMesh_IncrementalMesh(myShape, myDeviation*mesh_quality, false, 0.5*mesh_quality, parallel);
 
@@ -184,10 +190,15 @@ void ShapeTesselator::ComputeDefaultDeviation()
 {
     // This method automatically computes precision from the bounding box of the shape
     Bnd_Box aBox;
-    Standard_Real aXmin,aYmin ,aZmin ,aXmax ,aYmax ,aZmax;
+    BRepBndLib::Add(myShape, aBox);
+
+    if (aBox.IsVoid()) { // there is no shape
+        myDeviation = 0;
+        return;
+    }
 
     //calculate the bounding box
-    BRepBndLib::Add(myShape, aBox);
+    Standard_Real aXmin,aYmin ,aZmin ,aXmax ,aYmax ,aZmax;
     aBox.Get(aXmin, aYmin, aZmin, aXmax, aYmax, aZmax);
 
     Standard_Real adeviation = std::max(aXmax-aXmin, std::max(aYmax-aYmin, aZmax-aZmin)) * 2e-2 ;

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -61,21 +61,15 @@ void ShapeTesselator::Compute(bool compute_edges, float mesh_quality, bool paral
 
 ShapeTesselator::~ShapeTesselator()
 {
-    if (locVertexcoord)
-      delete [] locVertexcoord;
 
-    if (locNormalcoord)
-      delete [] locNormalcoord;
-
-    if (locTriIndices)
-      delete [] locTriIndices;
+    delete [] locVertexcoord;
+    delete [] locNormalcoord;
+    delete [] locTriIndices;
 
     for (std::vector<aedge*>::iterator edgeit = edgelist.begin(); edgeit != edgelist.end(); ++edgeit) {
       aedge* edge = *edgeit;
       if (edge) {
-        if (edge->vertex_coord)
-          delete[] edge->vertex_coord;
-
+        delete[] edge->vertex_coord;
         delete edge;
         *edgeit = NULL;
       }
@@ -208,9 +202,7 @@ void ShapeTesselator::ComputeEdges()
   std::vector<aedge*>::iterator it;
   for (it = edgelist.begin(); it != edgelist.end(); ++it) {
     if (*it) {
-      if ((*it)->vertex_coord)
-        delete[] (*it)->vertex_coord;
-
+      delete[] (*it)->vertex_coord;
       delete *it;
       *it = NULL;
     }

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -43,11 +43,11 @@
 
 //---------------------------------------------------------------------------
 ShapeTesselator::ShapeTesselator(TopoDS_Shape  aShape):
-  myShape(std::move(aShape)),
+  computed(false),
   locVertexcoord(nullptr),
   locNormalcoord(nullptr),
   locTriIndices(nullptr),
-  computed(false)
+  myShape(std::move(aShape))
 {
     ComputeDefaultDeviation();
 }

--- a/src/Tesselator/ShapeTesselator.cpp
+++ b/src/Tesselator/ShapeTesselator.cpp
@@ -94,7 +94,7 @@ Standard_Real ShapeTesselator::GetDeviation() const
 void ShapeTesselator::Tesselate(bool compute_edges, float mesh_quality, bool parallel)
 {
     TopExp_Explorer ExpFace;
-    // clean shape to remove any previous tringulation
+    // clean shape to remove any previous triangulation
     BRepTools::Clean(myShape);
 
     if (myDeviation <= 0){
@@ -257,7 +257,7 @@ void ShapeTesselator::ComputeEdges()
     aedge* theEdge = new aedge;
     Standard_Integer nbNodesInFace;
 
-    // edge triangulation successfull
+    // edge triangulation successful
     if (!aPoly.IsNull ()) {
         if (!aLoc.IsIdentity()) myTransf = aLoc.Transformation();
         nbNodesInFace = aPoly->NbNodes();
@@ -312,7 +312,7 @@ void ShapeTesselator::EnsureMeshIsComputed()
     printf("The mesh is not computed. Currently computing with default parameters ...");
     Compute(true, 1.0, false);
     printf("done\n");
-    printf("Call explicitely the Compute method to set the parameters value.\n");
+    printf("Call explicitly the Compute method to set the parameters value.\n");
   }
 }
 

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -80,7 +80,7 @@ class ShapeTesselator
       Standard_Real* NormalsList();
       std::string ExportShapeToThreejsJSONString(char *shape_function_name);
       std::string ExportShapeToX3DTriangleSet();
-      void ExportShapeToX3D(char *filename, int diffR=1, int diffG=0, int diffB=0);
+      void ExportShapeToX3D(const char *filename, int diffR=1, int diffG=0, int diffB=0);
       Standard_Integer ObjGetTriangleCount();
       Standard_Integer ObjGetInvalidTriangleCount();
       Standard_Integer ObjGetVertexCount();

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -56,10 +56,10 @@ class ShapeTesselator
       Standard_Integer tot_invalid_triangle_count=0;
       std::vector<aface*> facelist;
       std::vector<aedge*> edgelist;
-      Standard_Real myDeviation;
+      Standard_Real myDeviation=0;
       TopoDS_Shape myShape;
-      Standard_Real aXmin, aYmin ,aZmin ,aXmax ,aYmax ,aZmax;
-      Standard_Real aBndBoxSz;
+      Standard_Real aXmin=0, aYmin=0 ,aZmin=0 ,aXmax=0,aYmax=0,aZmax=0;
+      Standard_Real aBndBoxSz=0;
 
       void ComputeDefaultDeviation();
       void ComputeEdges();

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -66,7 +66,7 @@ class ShapeTesselator
       void EnsureMeshIsComputed();
 
   public:
-      ShapeTesselator(TopoDS_Shape aShape);
+      ShapeTesselator(TopoDS_Shape  aShape);
       ~ShapeTesselator();
       void Compute(bool compute_edges=false, float mesh_quality=1.0, bool parallel=false);
       void Tesselate(bool compute_edges, float mesh_quality, bool parallel);

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -76,6 +76,7 @@ class ShapeTesselator
       void GetNormal(int inorm, float& x, float& y, float& z);
       void GetTriangleIndex(int triangleIdx, int& v1, int& v2, int& v3);
       void GetEdgeVertex(int iEdge, int ivert, float& x, float& y, float& z);
+      Standard_Real GetDeviation() const;
       Standard_Real* VerticesList();
       Standard_Real* NormalsList();
       std::string ExportShapeToThreejsJSONString(char *shape_function_name);

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -66,7 +66,7 @@ class ShapeTesselator
       void EnsureMeshIsComputed();
 
   public:
-      ShapeTesselator(TopoDS_Shape  aShape);
+      explicit ShapeTesselator(TopoDS_Shape  aShape);
       ~ShapeTesselator();
       void Compute(bool compute_edges=false, float mesh_quality=1.0, bool parallel=false);
       void Tesselate(bool compute_edges, float mesh_quality, bool parallel);

--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -66,7 +66,7 @@ class ShapeTesselator
       void EnsureMeshIsComputed();
 
   public:
-      explicit ShapeTesselator(TopoDS_Shape  aShape);
+      explicit ShapeTesselator(TopoDS_Shape& aShape);
       ~ShapeTesselator();
       void Compute(bool compute_edges=false, float mesh_quality=1.0, bool parallel=false);
       void Tesselate(bool compute_edges, float mesh_quality, bool parallel);

--- a/src/Tesselator/Tesselator.i
+++ b/src/Tesselator/Tesselator.i
@@ -55,6 +55,7 @@ class ShapeTesselator {
         void GetNormal(int inorm, float& x, float& y, float& z);
         void GetTriangleIndex(int triangleIdx, int& v1, int& v2, int& v3);
         void GetEdgeVertex(int iEdge, int ivert, float& x, float& y, float& z);
+        float GetDeviation();
         float* VerticesList();
         int ObjGetTriangleCount();
         int ObjGetInvalidTriangleCount();


### PR DESCRIPTION
+ Clang fixes
+ Performance fix by not duplicating the shape (&shape)
+ Fix when a shape has no geometry

## Summary by Sourcery

Addresses minor coding issues, enhances performance, and fixes a calculation error in the Tesselator module. It also adds exception handling for invalid deviation and mesh quality values.

Bug Fixes:
- Fixes a calculation error that occurs when a shape has no geometry, preventing potential crashes or incorrect tessellation results.
- Fixes memory leaks by ensuring that allocated memory for vertices, normals, and triangle indices is properly deallocated in the destructor and in edge computation.
- Fixes clang warnings.
- Fixes the shape duplication, improving performance by avoiding unnecessary copying of shape data during tessellation.

Enhancements:
- Improves code readability and maintainability by using nullptr instead of NULL for null pointers.
- Updates the ShapeTesselator constructor to take a reference to a TopoDS_Shape object, avoiding unnecessary copying of the shape.

Tests:
- Adds exception handling to ensure that deviation and mesh quality are greater than 0.