### PR TITLE
Fix return type when as_compound = False and there is a single shape

### DIFF
--- a/src/Extend/DataExchange.py
+++ b/src/Extend/DataExchange.py
@@ -122,7 +122,10 @@ def read_step_file(
         raise AssertionError("No shape to transfer.")
 
     if nb_shapes == 1:
-        return step_reader.Shape(1)
+        if as_compound:
+            return step_reader.Shape(1)
+
+        return [step_reader.Shape(1)]
 
     shapes = []
     for i in range(1, nb_shapes + 1):


### PR DESCRIPTION
Fix return type when as_compound: bool = False and there is a single  shape.

## Summary by Sourcery

Bug Fixes:
- Ensure correct return type for single shape when as_compound is set to False, returning a list with a single shape instead of a single shape