### PR TITLE
Review/memory management

### DIFF
--- a/src/SWIG_files/common/ExceptionCatcher.i
+++ b/src/SWIG_files/common/ExceptionCatcher.i
@@ -22,28 +22,225 @@ along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 %{
 #include <Standard_Failure.hxx>
 #include <Standard_ErrorHandler.hxx>
+#include <Standard_TypeMismatch.hxx>
+#include <Standard_DimensionError.hxx>
+#include <Standard_DomainError.hxx>
+#include <Standard_MultiplyDefined.hxx>
+#include <Standard_NoSuchObject.hxx>
+#include <Standard_NotImplemented.hxx>
+#include <Standard_NullObject.hxx>
+#include <Standard_NullValue.hxx>
+#include <Standard_NumericError.hxx>
+#include <Standard_OutOfMemory.hxx>
+#include <Standard_OutOfRange.hxx>
+#include <Standard_Overflow.hxx>
+#include <Standard_RangeError.hxx>
+#include <Standard_Underflow.hxx>
 #include <sstream>
+#include <iostream>
+#include <typeinfo>
 %}
 
 %inline %{
-void process_exception(const Standard_Failure& error, const std::string& method_name, const std::string& class_name) {
+
+// Configuration for debugging (can be enabled/disabled)
+#ifndef PYTHONOCC_DEBUG_EXCEPTIONS
+#define PYTHONOCC_DEBUG_EXCEPTIONS 0
+#endif
+
+// Utility function to get a readable class name
+std::string get_readable_class_name(const std::string& class_name) {
+    if (class_name.empty() || class_name == "$parentclassname") {
+        return "Unknown";
+    }
+    return class_name;
+}
+
+// Utility function to get a readable method name
+std::string get_readable_method_name(const std::string& method_name) {
+    if (method_name.empty() || method_name == "$name") {
+        return "Unknown";
+    }
+    return method_name;
+}
+
+// Mapping OpenCASCADE exceptions to appropriate Python exceptions
+PyObject* get_exception_type(const Standard_Failure& error) {
+    const Handle(Standard_Type)& error_type = error.DynamicType();
+    const std::string type_name = error_type->Name();
+    
+    // Specific error type mapping
+    if (type_name.find("OutOfRange") != std::string::npos || 
+        type_name.find("RangeError") != std::string::npos) {
+        return PyExc_IndexError;
+    }
+    else if (type_name.find("OutOfMemory") != std::string::npos) {
+        return PyExc_MemoryError;
+    }
+    else if (type_name.find("NullObject") != std::string::npos || 
+             type_name.find("NullValue") != std::string::npos) {
+        return PyExc_ValueError;
+    }
+    else if (type_name.find("TypeMismatch") != std::string::npos) {
+        return PyExc_TypeError;
+    }
+    else if (type_name.find("NotImplemented") != std::string::npos) {
+        return PyExc_NotImplementedError;
+    }
+    else if (type_name.find("NoSuchObject") != std::string::npos) {
+        return PyExc_KeyError;
+    }
+    else if (type_name.find("DimensionError") != std::string::npos || 
+             type_name.find("DomainError") != std::string::npos) {
+        return PyExc_ValueError;
+    }
+    else if (type_name.find("NumericError") != std::string::npos || 
+             type_name.find("Overflow") != std::string::npos || 
+             type_name.find("Underflow") != std::string::npos) {
+        return PyExc_ArithmeticError;
+    }
+    else if (type_name.find("TooManyUsers") != std::string::npos) {
+        return PyExc_ResourceWarning;
+    }
+    
+    // Default to RuntimeError
+    return PyExc_RuntimeError;
+}
+
+// Main function for processing OpenCASCADE exceptions
+void process_opencascade_exception(const Standard_Failure& error, 
+                                  const std::string& method_name, 
+                                  const std::string& class_name) {
     std::ostringstream oss;
-    oss << error.DynamicType()->Name() << ": " << error.GetMessageString()
-        << " raised from method " << method_name << " of class " << class_name;
+    
+    // Basic error information
+    const std::string error_type = error.DynamicType()->Name();
+    const std::string error_message = error.GetMessageString();
+    const std::string readable_class = get_readable_class_name(class_name);
+    const std::string readable_method = get_readable_method_name(method_name);
+    
+    // Error message construction
+    oss << "OpenCASCADE Error [" << error_type << "]";
+    
+    if (!error_message.empty()) {
+        oss << ": " << error_message;
+    }
+    
+    oss << " (in " << readable_class;
+    if (readable_method != "Unknown") {
+        oss << "::" << readable_method;
+    }
+    oss << ")";
+    
+    // Debug information if enabled
+    #if PYTHONOCC_DEBUG_EXCEPTIONS
+    std::cerr << "[pythonOCC Debug] " << oss.str() << std::endl;
+    #endif
+    
+    // Set Python exception with appropriate type
+    PyObject* exception_type = get_exception_type(error);
+    PyErr_SetString(exception_type, oss.str().c_str());
+}
+
+// Function to handle C++ standard exceptions
+void process_std_exception(const std::exception& e, 
+                          const std::string& method_name, 
+                          const std::string& class_name) {
+    std::ostringstream oss;
+    const std::string readable_class = get_readable_class_name(class_name);
+    const std::string readable_method = get_readable_method_name(method_name);
+    
+    oss << "C++ Standard Exception: " << e.what();
+    oss << " (in " << readable_class;
+    if (readable_method != "Unknown") {
+        oss << "::" << readable_method;
+    }
+    oss << ")";
+    
+    #if PYTHONOCC_DEBUG_EXCEPTIONS
+    std::cerr << "[pythonOCC Debug] " << oss.str() << std::endl;
+    #endif
+    
+    // Try to determine the appropriate exception type
+    PyObject* exception_type = PyExc_RuntimeError;
+    
+    // Use typeid to determine the exact type
+    const std::type_info& ti = typeid(e);
+    const std::string type_name = ti.name();
+    
+    if (type_name.find("bad_alloc") != std::string::npos) {
+        exception_type = PyExc_MemoryError;
+    }
+    else if (type_name.find("out_of_range") != std::string::npos) {
+        exception_type = PyExc_IndexError;
+    }
+    else if (type_name.find("invalid_argument") != std::string::npos) {
+        exception_type = PyExc_ValueError;
+    }
+    
+    PyErr_SetString(exception_type, oss.str().c_str());
+}
+
+// Function for unknown exceptions
+void process_unknown_exception(const std::string& method_name, 
+                              const std::string& class_name) {
+    std::ostringstream oss;
+    const std::string readable_class = get_readable_class_name(class_name);
+    const std::string readable_method = get_readable_method_name(method_name);
+    
+    oss << "Unknown C++ Exception";
+    oss << " (in " << readable_class;
+    if (readable_method != "Unknown") {
+        oss << "::" << readable_method;
+    }
+    oss << ")";
+    
+    #if PYTHONOCC_DEBUG_EXCEPTIONS
+    std::cerr << "[pythonOCC Debug] " << oss.str() << std::endl;
+    #endif
+    
     PyErr_SetString(PyExc_RuntimeError, oss.str().c_str());
 }
+
 %}
 
+// Enhanced exception macro with hierarchical exception handling
 %exception
 {
     try
     {
+        // Capture system signals if macro is defined
         OCC_CATCH_SIGNALS
         $action
-    } 
+    }
     catch(const Standard_Failure& error)
     {
-        process_exception(error, "$name", "$parentclassname");
+        process_opencascade_exception(error, "$name", "$parentclassname");
+        SWIG_fail;
+    }
+    catch(const std::bad_alloc& e)
+    {
+        PyErr_SetString(PyExc_MemoryError, "Memory allocation failed in OpenCASCADE operation");
+        SWIG_fail;
+    }
+    catch(const std::out_of_range& e)
+    {
+        process_std_exception(e, "$name", "$parentclassname");
+        SWIG_fail;
+    }
+    catch(const std::invalid_argument& e)
+    {
+        process_std_exception(e, "$name", "$parentclassname");
+        SWIG_fail;
+    }
+    catch(const std::exception& e)
+    {
+        process_std_exception(e, "$name", "$parentclassname");
+        SWIG_fail;
+    }
+    catch(...)
+    {
+        process_unknown_exception("$name", "$parentclassname");
         SWIG_fail;
     }
 }

--- a/src/SWIG_files/common/IOStream.i
+++ b/src/SWIG_files/common/IOStream.i
@@ -1,75 +1,172 @@
 /*
-
 Copyright 2020 Thomas Paviot (tpaviot@gmail.com)
-
 This file is part of pythonOCC.
-
 pythonOCC is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
 pythonOCC is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
 You should have received a copy of the GNU General Public License
 along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
+Refactored for Python 3 only - No Python 2 support
 */
 
 %include <python/std_iostream.i>
 %include <python/std_string.i>
 
-// Standard_IStream
+//=============================================================================
+// Input stream conversion: Python str/bytes -> std::istream&
+//=============================================================================
 %typemap(in) std::istream& {
-  PyObject* temp_bytes = PyUnicode_AsEncodedString($input, "UTF-8", "strict");
-  std::string data(PyBytes_AsString(temp_bytes));
-  std::stringstream* ss = new std::stringstream(data);
-  $1 = ss;
+    if (!PyUnicode_Check($input) && !PyBytes_Check($input)) {
+        PyErr_SetString(PyExc_TypeError, "Expected str or bytes object");
+        SWIG_fail;
+    }
+    
+    PyObject* encoded_bytes = nullptr;
+    const char* data_ptr = nullptr;
+    
+    if (PyUnicode_Check($input)) {
+        encoded_bytes = PyUnicode_AsEncodedString($input, "UTF-8", "strict");
+        if (!encoded_bytes) {
+            PyErr_SetString(PyExc_UnicodeError, "Failed to encode string as UTF-8");
+            SWIG_fail;
+        }
+        data_ptr = PyBytes_AsString(encoded_bytes);
+    } else {
+        // Input is already bytes
+        data_ptr = PyBytes_AsString($input);
+        encoded_bytes = $input;
+        Py_INCREF(encoded_bytes);
+    }
+    
+    if (!data_ptr) {
+        Py_XDECREF(encoded_bytes);
+        PyErr_SetString(PyExc_ValueError, "Failed to extract string data");
+        SWIG_fail;
+    }
+    
+    std::string cpp_data(data_ptr);
+    Py_DECREF(encoded_bytes);
+    
+    std::stringstream* stream = new std::stringstream(cpp_data);
+    $1 = stream;
 }
 
 %typemap(freearg) std::istream& {
-  delete $1;
+    delete static_cast<std::stringstream*>($1);
 }
 
-// Standard_SStream
-%typemap(in) std::stringstream & {
-  PyObject* temp_bytes = PyUnicode_AsEncodedString($input, "UTF-8", "strict");
-  std::string data(PyBytes_AsString(temp_bytes));
-  std::stringstream* ss = new std::stringstream(data);
-  $1 = ss;
-}
-
-%typemap(freearg) std::stringstream & {
-  delete $1;
-}
-
-%typemap(argout) std::ostream &OutValue {
-    PyObject *o, *o2, *o3;
+//=============================================================================
+// String stream conversion: Python str/bytes -> std::stringstream&
+//=============================================================================
+%typemap(in) std::stringstream& {
+    if (!PyUnicode_Check($input) && !PyBytes_Check($input)) {
+        PyErr_SetString(PyExc_TypeError, "Expected str or bytes object");
+        SWIG_fail;
+    }
     
-    std::string str = ((std::stringstream*)$1)->str();
-    o = PyUnicode_FromString(str.c_str());
+    PyObject* encoded_bytes = nullptr;
+    const char* data_ptr = nullptr;
     
-    if ((!$result) || ($result == Py_None)) {
-        $result = o;
-    } else {
-        if (!PyTuple_Check($result)) {
-            PyObject *o2 = $result;
-            $result = PyTuple_New(1);
-            PyTuple_SetItem($result,0,o2);
+    if (PyUnicode_Check($input)) {
+        encoded_bytes = PyUnicode_AsEncodedString($input, "UTF-8", "strict");
+        if (!encoded_bytes) {
+            PyErr_SetString(PyExc_UnicodeError, "Failed to encode string as UTF-8");
+            SWIG_fail;
         }
-        o3 = PyTuple_New(1);
-        PyTuple_SetItem(o3,0,o);
-        o2 = $result;
-        $result = PySequence_Concat(o2,o3);
-        Py_DECREF(o2);
-        Py_DECREF(o3);
+        data_ptr = PyBytes_AsString(encoded_bytes);
+    } else {
+        // Input is already bytes
+        data_ptr = PyBytes_AsString($input);
+        encoded_bytes = $input;
+        Py_INCREF(encoded_bytes);
+    }
+    
+    if (!data_ptr) {
+        Py_XDECREF(encoded_bytes);
+        PyErr_SetString(PyExc_ValueError, "Failed to extract string data");
+        SWIG_fail;
+    }
+    
+    std::string cpp_data(data_ptr);
+    Py_DECREF(encoded_bytes);
+    
+    std::stringstream* stream = new std::stringstream(cpp_data);
+    $1 = stream;
+}
+
+%typemap(freearg) std::stringstream& {
+    delete static_cast<std::stringstream*>($1);
+}
+
+//=============================================================================
+// Output stream conversion: std::ostream& -> Python str (as return value)
+//=============================================================================
+%typemap(argout) std::ostream& OutValue {
+    // Extract content from the stringstream
+    std::stringstream* ss = static_cast<std::stringstream*>($1);
+    std::string content = ss->str();
+    
+    // Convert to Python Unicode string
+    PyObject* py_str = PyUnicode_FromStringAndSize(content.c_str(), content.size());
+    if (!py_str) {
+        PyErr_SetString(PyExc_UnicodeError, "Failed to create Python string from stream content");
+        SWIG_fail;
+    }
+    
+    // Handle return value combination
+    if (!$result || $result == Py_None) {
+        // No existing return value or None - use our string as the result
+        Py_XDECREF($result);
+        $result = py_str;
+    } else {
+        // Existing return value - combine into tuple
+        PyObject* current_result = $result;
+        
+        if (!PyTuple_Check(current_result)) {
+            // Convert single value to tuple
+            $result = PyTuple_New(1);
+            if (!$result) {
+                Py_DECREF(py_str);
+                Py_DECREF(current_result);
+                SWIG_fail;
+            }
+            PyTuple_SET_ITEM($result, 0, current_result);
+            current_result = $result;
+        }
+        
+        // Create new tuple with additional string
+        Py_ssize_t old_size = PyTuple_GET_SIZE(current_result);
+        PyObject* new_tuple = PyTuple_New(old_size + 1);
+        if (!new_tuple) {
+            Py_DECREF(py_str);
+            Py_DECREF(current_result);
+            SWIG_fail;
+        }
+        
+        // Copy existing items
+        for (Py_ssize_t i = 0; i < old_size; ++i) {
+            PyObject* item = PyTuple_GET_ITEM(current_result, i);
+            Py_INCREF(item);
+            PyTuple_SET_ITEM(new_tuple, i, item);
+        }
+        
+        // Add our string
+        PyTuple_SET_ITEM(new_tuple, old_size, py_str);
+        
+        Py_DECREF(current_result);
+        $result = new_tuple;
     }
 }
 
-%typemap(in, numinputs=0) std::ostream &OutValue (std::stringstream temp) {
-    $1 = &temp;
+//=============================================================================
+// Output stream input parameter: Create temporary stringstream
+//=============================================================================
+%typemap(in, numinputs=0) std::ostream& OutValue (std::stringstream temp_stream) {
+    $1 = &temp_stream;
 }
-

--- a/test/test_core_exception.py
+++ b/test/test_core_exception.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+##Copyright 2009-2016 Thomas Paviot (tpaviot@gmail.com)
+##
+##This file is part of pythonOCC.
+##
+##pythonOCC is free software: you can redistribute it and/or modify
+##it under the terms of the GNU Lesser General Public License as published by
+##the Free Software Foundation, either version 3 of the License, or
+##(at your option) any later version.
+##
+##pythonOCC is distributed in the hope that it will be useful,
+##but WITHOUT ANY WARRANTY; without even the implied warranty of
+##MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##GNU Lesser General Public License for more details.
+##
+##You should have received a copy of the GNU Lesser General Public License
+##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
+
+from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.Core.BRepBuilderAPI import (
+    BRepBuilderAPI_MakeEdge,
+    BRepBuilderAPI_Sewing,
+)
+from OCC.Core.gp import gp_Dir, gp_Pnt
+
+import pytest
+
+
+def test_standard_out_of_range() -> None:
+    """asserts that handling of OCC exceptions is handled correctly caught
+    Standard_OutOfRange mapped to IndexError
+    """
+    with pytest.raises(IndexError):
+        gp_Dir(0, 0, 1).Coord(-1)
+
+    with pytest.raises(IndexError):
+        BRepBuilderAPI_Sewing().FreeEdge(-1)
+
+
+def test_standard_fail_not_done() -> None:
+    with pytest.raises(RuntimeError):
+        BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(0, 0, 0)).Edge()
+
+
+def test_standard_domain() -> None:
+    with pytest.raises(ValueError):
+        BRepPrimAPI_MakeBox(0, 0, 0).Shape()

--- a/test/test_core_wrapper_features.py
+++ b/test/test_core_wrapper_features.py
@@ -608,26 +608,6 @@ def test_default_constructor_DEFINE_STANDARD_ALLOC() -> None:
     assert isinstance(s, ShapeAnalysis_Curve)
 
 
-def test_handling_exceptions() -> None:
-    """asserts that handling of OCC exceptions is handled correctly caught
-    see issue #259 -- Standard errors like Standard_OutOfRange not caught
-    """
-    # Standard_OutOfRange
-    with pytest.raises(RuntimeError):
-        gp_Dir(0, 0, 1).Coord(-1)
-    # StdFail_NotDone
-    with pytest.raises(RuntimeError):
-        BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(0, 0, 0)).Edge()
-    # Standard_DomainError
-    with pytest.raises(RuntimeError):
-        BRepPrimAPI_MakeBox(0, 0, 0).Shape()
-    # Standard_OutOfRange, related to specific issue in #778
-    # Note: the exception is raised if and only if OCCT is compiled
-    # using -D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
-    with pytest.raises(RuntimeError):
-        BRepBuilderAPI_Sewing().FreeEdge(-1)
-
-
 def test_memory_handle_getobject() -> None:
     """
     See https://github.com/tpaviot/pythonocc-generator/pull/24


### PR DESCRIPTION
## Summary by Sourcery

Modernize SWIG interface by dropping Python 2 support, refactoring IO stream conversions, and improving memory and exception management: add debug counters for handle ref tracking, refine handle utilities, map OpenCASCADE exceptions to precise Python errors, and update tests accordingly.

New Features:
- Introduce DEBUG_MEMORY counters for SWIG handle creation and deletion
- Add SWIG helpers Handle_ForceRelease and Handle_GetRefCount for handle introspection

Enhancements:
- Refactor IOStream typemaps for Python 3 str/bytes handling and robust error checking
- Improve std::ostream to Python return mapping, combining outputs into tuples
- Enhance SWIG handle reference-count logic with null checks and detailed DownCast error messages
- Remove Python 2 support from SWIG interfaces

Tests:
- Remove outdated exception tests and add new tests mapping OpenCASCADE errors to specific Python exceptions