### PR TITLE
Fix memory leaks, performance issues

### DIFF
--- a/src/SWIG_files/common/FunctionTransformers.i
+++ b/src/SWIG_files/common/FunctionTransformers.i
@@ -144,30 +144,54 @@ Standard_Boolean & function transformation
 
     switch (sh->ShapeType())
     {
-      case TopAbs_COMPOUND:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Compound(TopoDS::Compound(*sh)), SWIGTYPE_p_TopoDS_Compound, SWIG_POINTER_OWN |  0);
+      case TopAbs_COMPOUND: {
+        TopoDS_Compound* ptr = new TopoDS_Compound(TopoDS::Compound(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Compound, SWIG_POINTER_OWN |  0);
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_COMPSOLID:
-        resultobj = SWIG_NewPointerObj(new TopoDS_CompSolid(TopoDS::CompSolid(*sh)), SWIGTYPE_p_TopoDS_CompSolid, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_COMPSOLID: {
+        TopoDS_CompSolid* ptr = new TopoDS_CompSolid(TopoDS::CompSolid(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_CompSolid, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_SOLID:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Solid(TopoDS::Solid(*sh)), SWIGTYPE_p_TopoDS_Solid, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_SOLID: {
+        TopoDS_Solid* ptr = new TopoDS_Solid(TopoDS::Solid(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Solid, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_SHELL:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Shell(TopoDS::Shell(*sh)), SWIGTYPE_p_TopoDS_Shell, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_SHELL: {
+        TopoDS_Shell* ptr = new TopoDS_Shell(TopoDS::Shell(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Shell, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_FACE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Face(TopoDS::Face(*sh)), SWIGTYPE_p_TopoDS_Face, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_FACE: {
+        TopoDS_Face* ptr = new TopoDS_Face(TopoDS::Face(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Face, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_WIRE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Wire(TopoDS::Wire(*sh)), SWIGTYPE_p_TopoDS_Wire, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_WIRE: {
+        TopoDS_Wire* ptr = new TopoDS_Wire(TopoDS::Wire(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Wire, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_EDGE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Edge(TopoDS::Edge(*sh)), SWIGTYPE_p_TopoDS_Edge, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_EDGE: {
+        TopoDS_Edge* ptr = new TopoDS_Edge(TopoDS::Edge(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Edge, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_VERTEX:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Vertex(TopoDS::Vertex(*sh)), SWIGTYPE_p_TopoDS_Vertex, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_VERTEX: {
+        TopoDS_Vertex* ptr = new TopoDS_Vertex(TopoDS::Vertex(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Vertex, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
+      }
       default:
         break;
     }
@@ -184,30 +208,54 @@ Standard_Boolean & function transformation
 
     switch (sh->ShapeType())
     {
-      case TopAbs_COMPOUND:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Compound(TopoDS::Compound(*sh)), SWIGTYPE_p_TopoDS_Compound, SWIG_POINTER_OWN |  0);
+      case TopAbs_COMPOUND: {
+        TopoDS_Compound* ptr = new TopoDS_Compound(TopoDS::Compound(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Compound, SWIG_POINTER_OWN |  0);
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_COMPSOLID:
-        resultobj = SWIG_NewPointerObj(new TopoDS_CompSolid(TopoDS::CompSolid(*sh)), SWIGTYPE_p_TopoDS_CompSolid, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_COMPSOLID: {
+        TopoDS_CompSolid* ptr = new TopoDS_CompSolid(TopoDS::CompSolid(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_CompSolid, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_SOLID:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Solid(TopoDS::Solid(*sh)), SWIGTYPE_p_TopoDS_Solid, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_SOLID: {
+        TopoDS_Solid* ptr = new TopoDS_Solid(TopoDS::Solid(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Solid, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_SHELL:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Shell(TopoDS::Shell(*sh)), SWIGTYPE_p_TopoDS_Shell, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_SHELL: {
+        TopoDS_Shell* ptr = new TopoDS_Shell(TopoDS::Shell(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Shell, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_FACE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Face(TopoDS::Face(*sh)), SWIGTYPE_p_TopoDS_Face, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_FACE: {
+        TopoDS_Face* ptr = new TopoDS_Face(TopoDS::Face(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Face, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_WIRE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Wire(TopoDS::Wire(*sh)), SWIGTYPE_p_TopoDS_Wire, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_WIRE: {
+        TopoDS_Wire* ptr = new TopoDS_Wire(TopoDS::Wire(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Wire, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_EDGE:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Edge(TopoDS::Edge(*sh)), SWIGTYPE_p_TopoDS_Edge, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_EDGE: {
+        TopoDS_Edge* ptr = new TopoDS_Edge(TopoDS::Edge(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Edge, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
-      case TopAbs_VERTEX:
-        resultobj = SWIG_NewPointerObj(new TopoDS_Vertex(TopoDS::Vertex(*sh)), SWIGTYPE_p_TopoDS_Vertex, SWIG_POINTER_OWN |  0 );
+      }
+      case TopAbs_VERTEX: {
+        TopoDS_Vertex* ptr = new TopoDS_Vertex(TopoDS::Vertex(*sh));
+        resultobj = SWIG_NewPointerObj(ptr, SWIGTYPE_p_TopoDS_Vertex, SWIG_POINTER_OWN |  0 );
+        if (!resultobj) delete ptr;
         break;
+      }
       default:
         break;
     }

--- a/src/SWIG_files/common/OccHandle.i
+++ b/src/SWIG_files/common/OccHandle.i
@@ -87,7 +87,12 @@ template <typename T> class handle{};
 #endif
     }
   }
-  %set_output(SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN));
+  PyObject * obj = SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN);
+  if (!obj && presult) {
+    presult->DecrementRefCounter();
+    SWIG_fail;
+  }
+  %set_output(obj);
 }
 
 %typemap(out) Handle_ ## TYPE {
@@ -101,7 +106,12 @@ template <typename T> class handle{};
 #endif
     }
   }
-  %set_output(SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN));
+  PyObject * obj = SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN);
+  if (!obj && presult) {
+    presult->DecrementRefCounter();
+    SWIG_fail;
+  }
+  %set_output(obj);
 }
 
 // avoid useless copy for const objects
@@ -113,7 +123,12 @@ template <typename T> class handle{};
       handle_creation_count++;
 #endif
     }
-    %set_output(SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN));
+    PyObject * obj = SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN);
+    if (!obj && presult) {
+      presult->DecrementRefCounter();
+      SWIG_fail;
+    }
+    %set_output(obj);
 }
 
 
@@ -128,7 +143,12 @@ template <typename T> class handle{};
 #endif
     }
   }
-  %set_output(SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN));
+  PyObject * obj = SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN);
+  if (!obj && presult) {
+    presult->DecrementRefCounter();
+    SWIG_fail;
+  }
+  %set_output(obj);
 }
 
 %typemap(out) CONST Handle_ ## TYPE& {
@@ -142,7 +162,12 @@ template <typename T> class handle{};
 #endif
     }
   }
-  %set_output(SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN));
+  PyObject * obj = SWIG_NewPointerObj(%as_voidptr(presult), $descriptor(TYPE *), SWIG_POINTER_OWN);
+  if (!obj && presult) {
+    presult->DecrementRefCounter();
+    SWIG_fail;
+  }
+  %set_output(obj);
 }
 
 %typemap(out) CONST TYPE&, CONST TYPE* {
@@ -153,7 +178,12 @@ template <typename T> class handle{};
     handle_creation_count++;
 #endif
   }
-  %set_output(SWIG_NewPointerObj(%as_voidptr($1), $descriptor(TYPE *), SWIG_POINTER_OWN));
+  PyObject * obj = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(TYPE *), SWIG_POINTER_OWN);
+  if (!obj && $1) {
+    $1->DecrementRefCounter();
+    SWIG_fail;
+  }
+  %set_output(obj);
 }
 
 %typemap(in) opencascade::handle<TYPE> (void *argp, int res = 0) {

--- a/src/SWIG_files/wrapper/TopoDS.i
+++ b/src/SWIG_files/wrapper/TopoDS.i
@@ -1334,10 +1334,9 @@ No available documentation.
 }
 %pythoncode {
 def __ne__(self, right):
-    try:
-        return self.__ne_wrapper__(right)
-    except:
+    if not isinstance(right, TopoDS_Shape):
         return True
+    return self.__ne_wrapper__(right)
 }
 
 %extend{
@@ -1348,10 +1347,9 @@ def __ne__(self, right):
 }
 %pythoncode {
 def __eq__(self, right):
-    try:
-        return self.__eq_wrapper__(right)
-    except:
+    if not isinstance(right, TopoDS_Shape):
         return False
+    return self.__eq_wrapper__(right)
 }
 };
 


### PR DESCRIPTION
This PR addresses memory leaks and performance issues in the SWIG wrappers.

- TopoDS.i: Replaced costly try...except blocks in __eq__ and __ne__ with isinstance checks.

- FunctionTransformers.i: Added checks for SWIG_NewPointerObj failures to delete allocated C++ objects if Python wrapper creation fails.

- OccHandle.i: Added checks for SWIG_NewPointerObj failures to decrement reference counters if Python wrapper creation fails.

## Summary by Sourcery

Improve robustness and performance of SWIG-generated Python bindings for OpenCascade shapes and handle types.

Bug Fixes:
- Prevent memory leaks in shape transformers by deleting allocated C++ TopoDS_* objects when SWIG_NewPointerObj fails.
- Avoid leaking OpenCascade handle references by decrementing the reference counter when Python wrapper creation fails in OccHandle typemaps.

Enhancements:
- Simplify and speed up TopoDS_Shape equality and inequality in Python by replacing broad exception-based logic with explicit type checks before delegating to wrapper methods.