### PR TITLE
erformance and memory management of ShapeTesselator

### DIFF
--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -39,8 +39,8 @@
 class ShapeTesselator {
 public:
     struct Face {
-        std::vector<Standard_Real> vertex_coords;     //!< Vertex coordinates (x,y,z)*n
-        std::vector<Standard_Real> normal_coords;     //!< Normal vectors (nx,ny,nz)*n 
+        std::vector<float> vertex_coords;     //!< Vertex coordinates (x,y,z)*n
+        std::vector<float> normal_coords;     //!< Normal vectors (nx,ny,nz)*n
         std::vector<Standard_Integer> triangle_indices; //!< Triangle vertex indices
         Standard_Integer number_of_triangles = 0;     //!< Number of valid triangles
         Standard_Integer number_of_invalid_triangles = 0; //!< Number of invalid triangles
@@ -54,7 +54,7 @@ public:
     };
     
     struct Edge {
-        std::vector<Standard_Real> vertex_coords; //!< Edge vertex coordinates
+        std::vector<float> vertex_coords; //!< Edge vertex coordinates
         
         //! Reserve memory for vertices
         //! @param vertices Expected number of vertices
@@ -76,8 +76,8 @@ private:
     std::vector<std::unique_ptr<Edge>> edge_list;  //!< Collection of tessellated edges
     
     // Consolidated mesh data for efficient access
-    std::vector<Standard_Real> consolidated_vertices;        //!< All vertex coordinates
-    std::vector<Standard_Real> consolidated_normals;         //!< All normal vectors
+    std::vector<float> consolidated_vertices;        //!< All vertex coordinates
+    std::vector<float> consolidated_normals;         //!< All normal vectors
     std::vector<Standard_Integer> consolidated_triangle_indices; //!< All triangle indices
     
     // Statistics counters
@@ -137,8 +137,8 @@ public:
     Standard_Integer ObjEdgeGetVertexCount(Standard_Integer iEdge) const;
 
     // Direct data access
-    const Standard_Real* VerticesList() const;  //!< Get pointer to vertex data
-    const Standard_Real* NormalsList() const;   //!< Get pointer to normal data
+    const float* VerticesList() const;  //!< Get pointer to vertex data
+    const float* NormalsList() const;   //!< Get pointer to normal data
 
     //! Get vertices as a flat array suitable for rendering
     //! @return Vector of vertex positions for all triangles

--- a/src/Tesselator/Tesselator.i
+++ b/src/Tesselator/Tesselator.i
@@ -57,8 +57,8 @@ class ShapeTesselator {
         void GetEdgeVertex(int iEdge, int ivert, float& x, float& y, float& z);
         void SetDeviation(double aDeviation);
         double GetDeviation();
-        double* VerticesList();
-        double* NormalsList();
+        const float* VerticesList();
+        const float* NormalsList();
         int ObjGetTriangleCount();
         int ObjGetInvalidTriangleCount();
         int ObjGetVertexCount();


### PR DESCRIPTION
- Memory Reduction: Switched from double (Standard_Real) to float for storing mesh vertices and normals. This halves the memory requirement for geometry data, which is the primary memory consumer in this module. Since this module is used for visualization exports (Three.js, X3D), single precision is sufficient.

- Export Performance: Optimized ExportShapeToThreejsJSONString to write directly to the output stream from internal buffers. Previously, it constructed a temporary vector containing a copy of all vertex data, which doubled the memory spike during export.

- API Updates: Updated VerticesList and NormalsList to return float*. Updated the SWIG interface to reflect these changes.

Note: This introduces a change in precision for the stored mesh data (double -> float), which is intentional for the visualization use case.

## Summary by Sourcery

Switch mesh storage in ShapeTesselator to single-precision floats and streamline export paths to reduce memory usage during visualization exports.

Enhancements:
- Store face, edge, and consolidated vertex/normal coordinates as float instead of double to reduce geometry memory footprint.
- Adjust ShapeTesselator public APIs and SWIG interface so VerticesList and NormalsList expose const float* data pointers.
- Optimize Three.js JSON export to stream vertices and normals directly from consolidated buffers without allocating intermediate vectors.
- Simplify various vertex/normal accessors to work directly with the new float-backed buffers while preserving existing behavior.