### PR TITLE
Add OpenGL Core Profile API to Display3d

### DIFF
--- a/src/Visualization/Display3d.cpp
+++ b/src/Visualization/Display3d.cpp
@@ -318,3 +318,13 @@ void Display3d::SetBuffersNoSwap(Standard_Boolean theNoSwap)
   // their own buffer swapping.
   GetGraphicDriver()->ChangeOptions().buffersNoSwap = theNoSwap;
 }
+
+void Display3d::SetSRGBDisabled(Standard_Boolean theDisabled)
+{
+  // Disable sRGB rendering (OFF by default in OCCT).
+  // When enabled, OCCT won't attempt to create sRGB framebuffers.
+  // Useful for macOS where GL_SRGB8_ALPHA8 format may not be supported
+  // in certain contexts.
+  // Must be called BEFORE Init()/InitOffscreen() to take effect.
+  GetGraphicDriver()->ChangeOptions().sRGBDisable = theDisabled;
+}

--- a/src/Visualization/Visualization.h
+++ b/src/Visualization/Visualization.h
@@ -74,6 +74,7 @@ public:
   Standard_EXPORT void SetContextCompatible(Standard_Boolean theCompatible);
   Standard_EXPORT void SetFfpEnable(Standard_Boolean theEnabled);
   Standard_EXPORT void SetBuffersNoSwap(Standard_Boolean theNoSwap);
+  Standard_EXPORT void SetSRGBDisabled(Standard_Boolean theDisabled);
 
   Standard_EXPORT Handle_V3d_View& GetView() {return myV3dView;};
 	Standard_EXPORT Handle_V3d_Viewer& GetViewer() {return myV3dViewer;};

--- a/src/Visualization/Visualization.i
+++ b/src/Visualization/Visualization.i
@@ -89,6 +89,8 @@ class Display3d {
     void SetFfpEnable(bool theEnabled);
     %feature("autodoc", "1");
     void SetBuffersNoSwap(bool theNoSwap);
+    %feature("autodoc", "1");
+    void SetSRGBDisabled(bool theDisabled);
 };
 
 %extend Display3d {


### PR DESCRIPTION
before / after invocation of `SetCoreProfileEnabled`:
  **Before:** `GLversion: 2.1`, `GLSLversion: 1.20`
  **After:** `GLversion: 4.1`, `GLSLversion: 4.10`

---

Expose OpenGl_Caps options via new Display3d methods:
- SetCoreProfileEnabled(bool) - convenience for Core Profile
- SetContextCompatible(bool) - control compatibility mode
- SetFfpEnable(bool) - enable/disable fixed-function pipeline
- SetBuffersNoSwap(bool) - for external GL context management

On macOS, compatibility profile limits OpenGL to 2.1/GLSL 1.20. Core Profile enables 3.2+/GLSL 1.50+ required for Qt6 integration (QML).

Must be called BEFORE Init() to take effect.

## Summary by Sourcery

Expose OpenGL context configuration controls on Display3d for core/compatibility profiles, fixed-function pipeline usage, and buffer swapping behavior.

New Features:
- Add Display3d API to toggle OpenGL core profile mode and corresponding compatibility settings.
- Add Display3d methods to enable or disable the fixed-function pipeline.
- Add Display3d control to disable buffer swapping for externally managed OpenGL contexts.

Enhancements:
- Expose the new OpenGL context configuration methods to the scripting/SWIG interface with autodoc metadata.