### PR TITLE
Use Delete() method for occ handles

### DIFF
--- a/src/SWIG_files/common/OccHandle.i
+++ b/src/SWIG_files/common/OccHandle.i
@@ -347,7 +347,7 @@ WRAP_OCC_TRANSIENT(const, TYPE)
     handle_deletion_count++;
 #endif
     if($this->DecrementRefCounter() == 0) {
-      delete $this;
+      $this->Delete();
     }
   }
 %}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure OCC handle instances are destroyed via their Delete() method rather than direct operator delete when the reference count drops to zero.