### PR TITLE
Bump occt to 7.9.3 and swig to 4.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(PYTHONOCC)
 # set pythonOCC version
 set(PYTHONOCC_VERSION_MAJOR 7)
 set(PYTHONOCC_VERSION_MINOR 9)
-set(PYTHONOCC_VERSION_PATCH 1)
+set(PYTHONOCC_VERSION_PATCH 3)
 
 #  Empty for official releases, set to -dev, -rc1, etc for development releases
 set(PYTHONOCC_VERSION_DEVEL -dev)
@@ -30,7 +30,7 @@ set(PYTHONOCC_VERSION_DEVEL -dev)
 # set OCCT version
 set(OCCT_VERSION_MAJOR 7)
 set(OCCT_VERSION_MINOR 9)
-set(OCCT_VERSION_PATCH 1)
+set(OCCT_VERSION_PATCH 3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
@@ -110,7 +110,7 @@ message(STATUS "Python library release: ${Python3_LIBRARY_RELEASE}")
 ########
 # SWIG #
 ########
-find_package(SWIG 4.2.1...4.3.1 REQUIRED)
+find_package(SWIG 4.2.1...4.4.1 REQUIRED)
 message(STATUS "SWIG version found: ${SWIG_VERSION}")
 include(${SWIG_USE_FILE})
 set(SWIG_FILES_PATH src/SWIG_files/wrapper)

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.9.1" %}
+{% set version = "7.9.3" %}
 
 package:
   name: pythonocc-core
@@ -22,15 +22,15 @@ requirements:
     - {{ cdt('libxi-devel') }}          # [linux]
     - ninja
     - cmake
-    - swig ==4.3.1
+    - swig ==4.4.1
 
   host:
     - python {{ python }}
-    - occt ==7.9.1
+    - occt ==7.9.3
     - numpy >=1.17
 
   run:
-    - occt ==7.9.1
+    - occt ==7.9.3
     - numpy >=1.17
 
 test:


### PR DESCRIPTION
## Summary by Sourcery

Bump pythonOCC and OCCT versions to 7.9.3 and update SWIG dependency range to 4.4.1.

Enhancements:
- Align project CMake versioning with OCCT 7.9.3 and require SWIG up to 4.4.1.

Build:
- Update conda recipe to require occt 7.9.3 and swig 4.4.1.