### PR TITLE
Improve ShapeTesselator

### DIFF
--- a/src/Tesselator/ShapeTesselator.h
+++ b/src/Tesselator/ShapeTesselator.h
@@ -68,6 +68,7 @@ public:
 private:
     // Internal state
     bool computed;                    //!< Whether tessellation has been computed
+    bool use_parallel;               //!< Whether to use parallel processing
     TopoDS_Shape myShape;            //!< The shape to tessellate
     Standard_Real myDeviation;       //!< Tessellation deviation parameter
     
@@ -196,7 +197,8 @@ private:
     void Tessellate(bool compute_edges, float mesh_quality, bool parallel);
 
     //! Process all faces in the shape
-    void ProcessFaces();
+    //! @param faces Vector of faces to process
+    void ProcessFaces(const std::vector<TopoDS_Face>& faces);
 
     //! Process a single face
     //! @param face The face to process


### PR DESCRIPTION
## Summary by Sourcery

Optimize and extend ShapeTesselator by adding optional parallel face processing, leveraging precomputed normals when available, and reducing memory allocations and string formatting overhead across tessellation and export routines.

Enhancements:
- Introduce a parallel-processing path for face tessellation using OpenMP when enabled and requested, while preserving a sequential fallback.
- Reuse collected face lists instead of re-exploring the shape during tessellation to streamline face processing.
- Prefer precomputed normals from Poly_Triangulation with a UV-based fallback, improving normal computation performance and robustness.
- Preallocate exact container sizes and switch from push/insert patterns to indexed writes for triangles, edges, and flattened vertex/normal tuples to reduce reallocations and improve performance.
- Simplify X3D export by writing coordinates and normals directly from consolidated buffers with more efficient float formatting into streams.