### PR TITLE
Review/cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ if (POLICY CMP0086)
     cmake_policy(SET CMP0086 NEW)
 endif(POLICY CMP0086)
 
-# Force C++ 14
-set(CMAKE_CXX_STANDARD 14)
+# Force C++ 17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(BUILD_SHARED_LIBS ON)
@@ -71,7 +71,7 @@ endmacro(option_with_default OPTION_NAME OPTION_STRING OPTION_DEFAULT)
 # OpenGL. If available, enable compilation for Visualization module #
 #####################################################################
 find_package(OpenGL)
-include_directories(OPENGL_INCLUDE_DIR)
+include_directories(${OPENGL_INCLUDE_DIR})
 
 #################
 # Build options #
@@ -196,7 +196,10 @@ if(NOT DEFINED PYTHONOCC_INSTALL_DIRECTORY)
       message(STATUS "conda-build running, using $ENV{SP_DIR} as install dir")
       set(PYTHONOCC_INSTALL_DIRECTORY $ENV{SP_DIR}/OCC CACHE PATH "pythonocc install directory")
     else(DEFINED ENV{SP_DIR} AND WIN32)
-      execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; from os.path import relpath; print(relpath(get_python_lib(1,prefix='${CMAKE_INSTALL_PREFIX}'),'${CMAKE_INSTALL_PREFIX}'))" OUTPUT_VARIABLE python_lib OUTPUT_STRIP_TRAILING_WHITESPACE)
+      execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import sysconfig, os, sys; print(os.path.relpath(sysconfig.get_path('platlib'), sys.prefix))"
+    OUTPUT_VARIABLE python_lib
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
       set(PYTHONOCC_INSTALL_DIRECTORY ${python_lib}/OCC CACHE PATH "pythonocc install directory")
     endif(DEFINED ENV{SP_DIR} AND WIN32)
 endif(NOT DEFINED PYTHONOCC_INSTALL_DIRECTORY)
@@ -292,7 +295,7 @@ foreach(OCCT_MODULE ${OCCT_TOOLKIT_MODEL})
     set(FILE ${SWIG_FILES_PATH}/${OCCT_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library (${OCCT_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} Python3::Module)
+    target_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} Python3::Module)
 endforeach(OCCT_MODULE)
 
 ###############
@@ -306,7 +309,7 @@ set(TESSELATOR_SOURCE_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Tesselator/ShapeTesselator.cpp)
 
 swig_add_library(Tesselator LANGUAGE python SOURCES ${TESSELATOR_SOURCE_FILES} TYPE MODULE)
-swig_link_libraries(Tesselator ${OCCT_MODEL_LIBRARIES} Python3::Module)
+target_link_libraries(Tesselator ${OCCT_MODEL_LIBRARIES} Python3::Module)
 
 #################
 # Visualisation #
@@ -316,13 +319,13 @@ if(PYTHONOCC_WRAP_VISU)
     if(OPENGL_FOUND)
       message(STATUS "OpenGL found; Visualization support enabled")
     endif()
-    include_directories(OPENGL_INCLUDE_DIR)
+    include_directories(${OPENGL_INCLUDE_DIR})
 
     foreach(OCCT_MODULE ${OCCT_TOOLKIT_VISUALIZATION})
       set(FILE ${SWIG_FILES_PATH}/${OCCT_MODULE}.i)
       set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
       swig_add_library (${OCCT_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-      swig_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
+      target_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
     endforeach(OCCT_MODULE)
 
   # Build third part modules
@@ -335,12 +338,12 @@ if(PYTHONOCC_WRAP_VISU)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/Visualization/Display3d.cpp)
 
     swig_add_library(Visualization LANGUAGE python SOURCES ${VISUALIZATION_SOURCE_FILES} TYPE MODULE)
-    swig_link_libraries(Visualization ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
+    target_link_libraries(Visualization ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
 
   if(APPLE)
     # on OSX, always add /System/Library/Frameworks/Cocoa.framework, even
     # if GLX is enabled
-    swig_link_libraries(Visualization /System/Library/Frameworks/Cocoa.framework)
+    target_link_libraries(Visualization /System/Library/Frameworks/Cocoa.framework)
   endif(APPLE)
 
   ##########################
@@ -355,7 +358,7 @@ if(PYTHONOCC_WRAP_VISU)
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MeshDataSource/MeshDataSource.cpp)
 
   swig_add_library(MeshDS LANGUAGE python SOURCES ${MESHDATASOURCE_SOURCE_FILES} TYPE MODULE)
-  swig_link_libraries(MeshDS ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
+  target_link_libraries(MeshDS ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
 
 endif(PYTHONOCC_WRAP_VISU)
 
@@ -367,7 +370,7 @@ if(PYTHONOCC_WRAP_DATAEXCHANGE)
     set(FILE ${SWIG_FILES_PATH}/${OCCT_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library(${OCCT_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_DATAEXCHANGE_LIBRARIES} Python3::Module)
+    target_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_DATAEXCHANGE_LIBRARIES} Python3::Module)
   endforeach(OCCT_MODULE)
 endif(PYTHONOCC_WRAP_DATAEXCHANGE)
 
@@ -379,26 +382,28 @@ if(PYTHONOCC_WRAP_OCAF)
     set(FILE ${SWIG_FILES_PATH}/${OCCT_MODULE}.i)
     set_source_files_properties(${FILE} PROPERTIES CPLUSPLUS ON)
     swig_add_library(${OCCT_MODULE} LANGUAGE python SOURCES ${FILE} TYPE MODULE)
-    swig_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_OCAF_LIBRARIES} Python3::Module)
+    target_link_libraries(${OCCT_MODULE} ${OCCT_MODEL_LIBRARIES} ${OCCT_OCAF_LIBRARIES} Python3::Module)
   endforeach(OCCT_MODULE)
 endif(PYTHONOCC_WRAP_OCAF)
 
 ##########
 # Addons #
 ##########
-execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory src/Addons)
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Addons.i PROPERTIES CPLUSPLUS ON)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/Addons)
-set(ADDONS_SOURCE_FILES
-${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Addons.i
-${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Font3d.cpp
-#${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/TextItem.cpp
-#${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/LineItem.cpp
-#${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/TextureItem.cpp
-)
+if(PYTHONOCC_WRAP_VISU)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory src/Addons)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Addons.i PROPERTIES CPLUSPLUS ON)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/Addons)
+  set(ADDONS_SOURCE_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Addons.i
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/Font3d.cpp
+  #${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/TextItem.cpp
+  #${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/LineItem.cpp
+  #${CMAKE_CURRENT_SOURCE_DIR}/src/Addons/TextureItem.cpp
+  )
 
-swig_add_library(Addons LANGUAGE python SOURCES ${ADDONS_SOURCE_FILES} TYPE MODULE)
-swig_link_libraries(Addons ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
+  swig_add_library(Addons LANGUAGE python SOURCES ${ADDONS_SOURCE_FILES} TYPE MODULE)
+  target_link_libraries(Addons ${OCCT_MODEL_LIBRARIES} ${OCCT_VISUALIZATION_LIBRARIES} Python3::Module)
+endif(PYTHONOCC_WRAP_VISU)
 
 ################
 # Installation #
@@ -461,8 +466,10 @@ if(PYTHONOCC_WRAP_VISU)
 endif(PYTHONOCC_WRAP_VISU)
 
 # install addons
-install(FILES ${BUILD_DIR}/Addons.py DESTINATION ${PYTHONOCC_INSTALL_DIRECTORY}/Core )
-install(TARGETS Addons DESTINATION ${PYTHONOCC_INSTALL_DIRECTORY}/Core )
+if(PYTHONOCC_WRAP_VISU)
+    install(FILES ${BUILD_DIR}/Addons.py DESTINATION ${PYTHONOCC_INSTALL_DIRECTORY}/Core )
+    install(TARGETS Addons DESTINATION ${PYTHONOCC_INSTALL_DIRECTORY}/Core )
+endif(PYTHONOCC_WRAP_VISU)
 
 # install Display
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/Display DESTINATION ${PYTHONOCC_INSTALL_DIRECTORY})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,3 +75,45 @@ jobs:
     vmImage: 'windows-2022'
     py_maj: 3
     py_min: 12
+
+- template: conda-build.yml
+  parameters:
+    name: Ubuntu_24_04_python313
+    vmImage: 'ubuntu-24.04'
+    py_maj: 3
+    py_min: 13
+
+- template:  conda-build.yml
+  parameters:
+    name: macOS_12_python313
+    vmImage: 'macOS-latest'
+    py_maj: 3
+    py_min: 13
+
+- template:  conda-build.yml
+  parameters:
+    name: Windows_VS2022_python313
+    vmImage: 'windows-2022'
+    py_maj: 3
+    py_min: 13
+
+- template: conda-build.yml
+  parameters:
+    name: Ubuntu_24_04_python314
+    vmImage: 'ubuntu-24.04'
+    py_maj: 3
+    py_min: 14
+
+- template:  conda-build.yml
+  parameters:
+    name: macOS_12_python314
+    vmImage: 'macOS-latest'
+    py_maj: 3
+    py_min: 14
+
+- template:  conda-build.yml
+  parameters:
+    name: Windows_VS2022_python314
+    vmImage: 'windows-2022'
+    py_maj: 3
+    py_min: 14

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# make an in source build do to some problems with install
 
 # Configure step
+EXTRA_CMAKE_ARGS=""
+if [ "$(uname)" == "Darwin" ]; then
+  EXTRA_CMAKE_ARGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
+fi
+
 cmake -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH=$PREFIX \
@@ -12,17 +16,11 @@ cmake -G Ninja \
  -DPython3_FIND_STRATEGY=LOCATION \
  -DPython3_FIND_FRAMEWORK=NEVER \
  -DSWIG_HIDE_WARNINGS=ON \
- -DPYTHONOCC_MESHDS_NUMPY=ON
+ -DPYTHONOCC_MESHDS_NUMPY=ON \
+ $EXTRA_CMAKE_ARGS
 
 # Build step
 ninja
 
 # Install step
 ninja install
-
-# fix rpaths
-#if [ $(uname) == Darwin ]; then
-#    for lib in $(ls $SP_DIR/OCC/_*.so); do
-#      install_name_tool -rpath $PREFIX/lib @loader_path/../../../ $lib
-#    done
-#fi

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -23,15 +23,20 @@ requirements:
     - ninja
     - cmake
     - swig ==4.4.1
+    - sysroot_linux-64 >=2.28  # [linux]
 
   host:
     - python {{ python }}
+    - python_abi * *_cp313  [py==313]
+    - python_abi * *_cp314  [py==314]
     - occt ==7.9.3
     - numpy >=1.17
 
   run:
     - occt ==7.9.3
     - numpy >=1.17
+    - python_abi * *_cp313  [py==313]
+    - python_abi * *_cp314  [py==314]
 
 test:
   imports:
@@ -39,12 +44,12 @@ test:
     - OCC.Core.BRepPrimAPI
     - OCC.Core.Tesselator
   requires:
-    - pyqt >=5
+    - pyqt5-sip       # [win]
+    - pyside6 >=6.10  # [win]
+    - wxpython >=4.2  # [win]
+    - svgwrite >=1.4
     - mypy
     - pytest
-    - svgwrite
-    - wxpython >=4
-    - pyside6
 
 about:
   home: https://github.com/tpaviot/pythonocc-core

--- a/conda-build.yml
+++ b/conda-build.yml
@@ -44,7 +44,7 @@ jobs:
         conda info -a && \
         conda config --add channels https://conda.anaconda.org/conda-forge
     displayName: 'Conda config and info'
-  - bash: conda create --yes --quiet --name build_env conda-build conda-verify libarchive python=${{ parameters.py_maj }}.${{ parameters.py_min }} anaconda-client
+  - bash: conda create --yes --quiet --name build_env conda-build conda-verify libarchive python=3.12 anaconda-client
     displayName: 'Create Anaconda environment'
   - ${{ if eq(parameters.vmImage, 'windows-2022') }}:
     - script: |
@@ -54,7 +54,7 @@ jobs:
         set CC=cl.exe
         set CXX=cl.exe
         call activate build_env
-        conda-build --no-remove-work-dir --dirty ci/conda
+        conda-build --python ${{ parameters.py_maj }}.${{ parameters.py_min }} --no-remove-work-dir --dirty ci/conda
       displayName: 'Set Windows environment and build'
       env:
         CXX: "cl.exe"
@@ -66,7 +66,7 @@ jobs:
   - ${{ if not(contains(parameters.vmImage, 'win')) }}:
     - bash: |
         source activate build_env && \
-        conda-build --no-remove-work-dir --dirty ci/conda
+        conda-build --python ${{ parameters.py_maj }}.${{ parameters.py_min }} --no-remove-work-dir --dirty ci/conda
       displayName: 'Run conda build'
       failOnStderr: false
       env:


### PR DESCRIPTION
## Summary by Sourcery

Update CMake configuration, conda packaging, and CI pipelines to support newer C++ and Python versions and align build/linking practices.

Build:
- Raise required C++ standard from C++14 to C++17 in the CMake configuration.
- Correct OpenGL include directory usage and switch SWIG-generated targets to use target_link_libraries instead of swig_link_libraries in CMake.
- Guard Addons SWIG module build and installation behind the PYTHONOCC_WRAP_VISU option in CMake.
- Adjust Python install path detection to use sysconfig platlib resolution in CMake.
- Add macOS deployment target configuration for conda builds and cleanup unused rpath fix-up logic in the build script.
- Update conda recipe to add linux sysroot, declare python_abi constraints for Python 3.13/3.14, and refine test GUI dependencies per platform.

CI:
- Extend Azure Pipelines matrix to build conda packages for Python 3.13 and 3.14 on Linux, macOS, and Windows.
- Change conda-build CI job to always create an environment with Python 3.12 but pass the target Python version explicitly to conda-build on all platforms.