### PR TITLE
Fix conda package link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Click [![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/tpav
 
 Install with conda
 ------------------
-pythonocc provides precompiled [conda packages](https://anaconda.org/pythonocc/pythonocc-core) (they depend on third part libraries made available from the conda-forge channel) for python 3.10, 3.11, 3.12, 3.13 and 3.14. This will get you up and running in minutes whether you run win32/win64/linux64/osx64. Here is an example for python 3.12:
+pythonocc provides precompiled [conda packages](https://anaconda.org/conda-forge/pythonocc-core) (they depend on third part libraries made available from the conda-forge channel) for python 3.10, 3.11, 3.12, 3.13 and 3.14. This will get you up and running in minutes whether you run win32/win64/linux64/osx64. Here is an example for python 3.12:
 
 ```bash
 # first create an environment

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Click [![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/tpav
 
 Install with conda
 ------------------
-pythonocc provides precompiled [conda packages](https://anaconda.org/conda-forge/pythonocc-core) (they depend on third part libraries made available from the conda-forge channel) for python 3.10, 3.11, 3.12, 3.13 and 3.14. This will get you up and running in minutes whether you run win32/win64/linux64/osx64. Here is an example for python 3.12:
+pythonocc provides precompiled [conda packages](https://anaconda.org/conda-forge/pythonocc-core) (they depend on third-party libraries made available from the conda-forge channel) for Python 3.10, 3.11, 3.12, 3.13 and 3.14. This will get you up and running in minutes whether you run win32/win64/linux64/osx64. Here is an example for Python 3.12:
 
 ```bash
 # first create an environment


### PR DESCRIPTION
Updated conda package link to point to conda-forge.

## Summary by Sourcery

Documentation:
- Update README conda installation section to point to the pythonocc-core package on the conda-forge channel instead of the old location.