### PR TITLE
fix: correctly set default PYTHONOCC_WRAP_VISU build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,20 +70,22 @@ endmacro(option_with_default OPTION_NAME OPTION_STRING OPTION_DEFAULT)
 #####################################################################
 # OpenGL. If available, enable compilation for Visualization module #
 #####################################################################
-find_package(OpenGL)
-include_directories(${OPENGL_INCLUDE_DIR})
+set(OPENGL_FOUND FALSE)
+if(NOT DEFINED PYTHONOCC_WRAP_VISU)
+  find_package(OpenGL)
+  include_directories(${OPENGL_INCLUDE_DIR})
+  if(NOT OPENGL_FOUND)
+    message(WARNING "OpenGL library not found, Visualization compilation is turned OFF")
+  endif(NOT OPENGL_FOUND)
+endif(NOT DEFINED PYTHONOCC_WRAP_VISU)
 
 #################
 # Build options #
 #################
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/OCCT_Modules.cmake)
 # add an option to choose toolkits to compile
-if(OPENGL_FOUND)
-  option_with_default(PYTHONOCC_WRAP_VISU "Compile Visualisation" ON)
-else(OPENGL_FOUND)
-  message(WARNING "OpenGL library not found, Visualization compilation is turned OFF")
-  set(PYTHONOCC_WRAP_VISU "Compile Visualisation" OFF)
-endif(OPENGL_FOUND)
+option_with_default(PYTHONOCC_WRAP_VISU "Compile Visualisation" ${OPENGL_FOUND})
+option_with_default(PYTHONOCC_WRAP_DATAEXCHANGE "Compile DataExchange wrapper" ON)
 option_with_default(PYTHONOCC_WRAP_DATAEXCHANGE "Compile DataExchange wrapper" ON)
 option_with_default(PYTHONOCC_WRAP_OCAF "Compile OCCT Application Framework wrapper" ON)
 option_with_default(SWIG_HIDE_WARNINGS "Check this option if you want a less verbose swig output." ON)


### PR DESCRIPTION
Previously, the `PYTHONOCC_WRAP_VISU` build setting was incorrectly set to a non-empty string instead of the value `OFF` [here](https://github.com/tpaviot/pythonocc-core/blob/master/CMakeLists.txt#L85). This caused all subsequent `if(PYTHONOCC_WRAP_VISU)` checks to evaluate the variable as set.

Furthermore, a user couldn't set `PYTHONOCC_WRAP_VISU` on the command line, as it was always overwritten within `CMakeLists.txt`.

## Summary by Sourcery

Fix configuration of the visualization wrapper build option to respect user overrides and correctly depend on OpenGL availability.

Bug Fixes:
- Ensure PYTHONOCC_WRAP_VISU defaults to OFF when OpenGL is not found instead of being set to a non-empty string that always evaluates as enabled.
- Allow PYTHONOCC_WRAP_VISU to be set from the CMake command line without being overridden in CMakeLists.

Build:
- Tie the default value of PYTHONOCC_WRAP_VISU directly to OPENGL_FOUND while centralizing OpenGL detection and warnings in the CMake configuration.