### PR TITLE
Fixed incorrect reported package version

### DIFF
--- a/src/PkgBase/__init__.py
+++ b/src/PkgBase/__init__.py
@@ -5,7 +5,7 @@ import platform
 # Version number
 PYTHONOCC_VERSION_MAJOR = 7
 PYTHONOCC_VERSION_MINOR = 9
-PYTHONOCC_VERSION_PATCH = 0
+PYTHONOCC_VERSION_PATCH = 3
 
 # Empty for official releases, set to -dev, -rc1, etc for development releases
 PYTHONOCC_VERSION_DEVEL = ""


### PR DESCRIPTION
Fixes #1488

## Summary by Sourcery

Bug Fixes:
- Correct the package patch version constant from 0 to 3 so the reported version matches the released build.