### PR TITLE
Prepare bump-my-version support

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,67 @@
+[tool.bumpversion]
+current_version = "7.9.3"
+commit = true
+tag = false
+tag_name = "{new_major}.{new_minor}.{new_patch}"
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "pythonocc-binderhub/{current_version}"
+replace = "pythonocc-binderhub/{new_version}"
+
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+regex = true
+search = "Latest release: \\[pythonocc-core {current_version} \\(\\d{{4}}-\\d{{2}}-\\d{{2}}\\)\\]\\(https://github\\.com/tpaviot/pythonocc-core/releases/tag/{current_version}\\)"
+replace = "Latest release: [pythonocc-core {new_version} ({now:%Y-%m-%d})](https://github.com/tpaviot/pythonocc-core/releases/tag/{new_version})"
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "to open a jupyter notebook running the latest pythonocc-core {current_version}."
+replace = "to open a jupyter notebook running the latest pythonocc-core {new_version}."
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "conda install -c conda-forge pythonocc-core={current_version}"
+replace = "conda install -c conda-forge pythonocc-core={new_version}"
+
+[[tool.bumpversion.files]]
+filename = "CMakeLists.txt"
+search = "VERSION_MAJOR {current_major}"
+replace = "VERSION_MAJOR {new_major}"
+
+[[tool.bumpversion.files]]
+filename = "CMakeLists.txt"
+search = "VERSION_MINOR {current_minor}"
+replace = "VERSION_MINOR {new_minor}"
+
+[[tool.bumpversion.files]]
+filename = "CMakeLists.txt"
+search = "VERSION_PATCH {current_patch}"
+replace = "VERSION_PATCH {new_patch}"
+
+[[tool.bumpversion.files]]
+filename = "src/PkgBase/__init__.py"
+search = "PYTHONOCC_VERSION_MAJOR = {current_major}"
+replace = "PYTHONOCC_VERSION_MAJOR = {new_major}"
+
+[[tool.bumpversion.files]]
+filename = "src/PkgBase/__init__.py"
+search = "PYTHONOCC_VERSION_MINOR = {current_minor}"
+replace = "PYTHONOCC_VERSION_MINOR = {new_minor}"
+
+[[tool.bumpversion.files]]
+filename = "src/PkgBase/__init__.py"
+search = "PYTHONOCC_VERSION_PATCH = {current_patch}"
+replace = "PYTHONOCC_VERSION_PATCH = {new_patch}"
+
+[[tool.bumpversion.files]]
+filename = "ci/conda/meta.yaml"
+search = "set version = \"{current_version}\""
+replace = "set version = \"{new_version}\""
+
+[[tool.bumpversion.files]]
+filename = "ci/conda/meta.yaml"
+search = "- occt =={current_version}"
+replace = "- occt =={new_version}"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ About
 -----
 pythonocc provides 3D modeling and dataexchange features. It is intended for CAD/PDM/PLM/BIM development. It is based on the OpenCascade Technology modeling kernel.
 
-Latest release: [pythonocc-core 7.9.3 (February 2026)](https://github.com/tpaviot/pythonocc-core/releases/tag/7.9.3)
+Latest release: [pythonocc-core 7.9.3 (2026-02-12)](https://github.com/tpaviot/pythonocc-core/releases/tag/7.9.3)
 
 Features
 --------

--- a/src/PkgBase/__init__.py
+++ b/src/PkgBase/__init__.py
@@ -5,7 +5,7 @@ import platform
 # Version number
 PYTHONOCC_VERSION_MAJOR = 7
 PYTHONOCC_VERSION_MINOR = 9
-PYTHONOCC_VERSION_PATCH = 0
+PYTHONOCC_VERSION_PATCH = 3
 
 # Empty for official releases, set to -dev, -rc1, etc for development releases
 PYTHONOCC_VERSION_DEVEL = ""


### PR DESCRIPTION
This allows to automatically bump the version of most of the involved files. 

Rationale: Manual version bump is error prone, files can be missed.

To bump e.g. the patch version, just type

    bump-my-version bump patch

This will also automatically  create a bump commit message, e.g.

    Bump version: 7.9.3 → 7.9.4

## Summary by Sourcery

Configure automated version bumping and align version references across project files.

New Features:
- Add bump-my-version configuration to automatically update project version across multiple files.

Enhancements:
- Normalize README latest release date format and synchronize package patch version with the documented release.